### PR TITLE
ci: add gitleaks secret scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,22 @@ jobs:
           fi
           echo "OK: no real-identity leakage detected."
 
+  secret-scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          # Full history so a secret committed in any past commit is caught,
+          # not just the latest diff.
+          fetch-depth: 0
+
+      - name: Scan for committed secrets (gitleaks)
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   backend:
     runs-on: ubuntu-latest
     timeout-minutes: 25


### PR DESCRIPTION
Adds a `secret-scan` CI job using [gitleaks](https://github.com/gitleaks/gitleaks-action) that scans the full git history for committed secrets (API keys, private keys, tokens) on every push and PR.

This complements the existing `hygiene` job (which catches real-identity strings) with generic credential detection — the main safety net for a public-first workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)