### PR TITLE
feat(scheduler): enter and read job schedules in plain minutes

### DIFF
--- a/frontend/src/lib/components/settings/sections/SettingsAgents.svelte
+++ b/frontend/src/lib/components/settings/sections/SettingsAgents.svelte
@@ -25,6 +25,7 @@
 		type ForvenAuthProviderOAuthStartResponse,
 	} from '$lib/api';
 	import { openExternal } from '$lib/external-open';
+	import { msToMinutes, minutesToMs, formatIntervalMs } from '$lib/utils/schedule';
 
 	export let settings: Record<string, unknown> = {};
 	export let variant: 'default' | 'wizard' = 'default';
@@ -1151,21 +1152,38 @@
 								Type
 								<select
 									bind:value={job.schedule_type}
+									on:change={() => (job.schedule_expr = '')}
 									class="mt-1 w-full bg-gray-950 border border-gray-700 text-white px-2 py-1.5 rounded text-sm"
 								>
 									<option value="cron">Cron</option>
-									<option value="interval">Interval (ms)</option>
+									<option value="interval">Interval (minutes)</option>
 								</select>
 							</label>
-							<label class="block text-xs text-gray-400">
-								Expression
-								<input
-									type="text"
-									bind:value={job.schedule_expr}
-									placeholder="e.g. 0 9 * * * or 3600000"
-									class="mt-1 w-full bg-gray-950 border border-gray-700 text-white px-2 py-1.5 rounded text-sm font-mono"
-								/>
-							</label>
+							{#if job.schedule_type === 'interval'}
+								<label class="block text-xs text-gray-400">
+									Run every (minutes)
+									<input
+										type="number"
+										min="1"
+										step="1"
+										value={msToMinutes(job.schedule_expr)}
+										on:input={(e) =>
+											(job.schedule_expr = minutesToMs(e.currentTarget.value))}
+										placeholder="e.g. 60"
+										class="mt-1 w-full bg-gray-950 border border-gray-700 text-white px-2 py-1.5 rounded text-sm font-mono"
+									/>
+								</label>
+							{:else}
+								<label class="block text-xs text-gray-400">
+									Expression (cron)
+									<input
+										type="text"
+										bind:value={job.schedule_expr}
+										placeholder="e.g. 0 9 * * *"
+										class="mt-1 w-full bg-gray-950 border border-gray-700 text-white px-2 py-1.5 rounded text-sm font-mono"
+									/>
+								</label>
+							{/if}
 							<button
 								type="button"
 								on:click={() => saveSchedulerJob(job)}
@@ -1177,6 +1195,9 @@
 						</div>
 
 						<div class="flex gap-4 text-xs text-gray-400">
+							{#if job.schedule_type === 'interval' && job.schedule_expr}
+								<span>Schedule: <span class="text-gray-300">{formatIntervalMs(job.schedule_expr)}</span></span>
+							{/if}
 							{#if job.next_run_at}
 								<span>Next run: <span class="text-gray-300">{formatDate(job.next_run_at)}</span></span>
 							{/if}

--- a/frontend/src/lib/utils/schedule.ts
+++ b/frontend/src/lib/utils/schedule.ts
@@ -1,0 +1,95 @@
+// Helpers for displaying and entering scheduler timing in plain minutes.
+//
+// The backend is unchanged: interval scheduler jobs are still stored as an
+// integer-millisecond string, and routine schedules are still 5-field cron
+// expressions. These helpers convert only at the UI boundary so the operator
+// can think in minutes instead of milliseconds (interval jobs) or cron-step
+// syntax (routines).
+
+/** Convert a millisecond-interval string to whole minutes for display. Returns '' when not a positive interval. */
+export function msToMinutes(ms: string | number | null | undefined): string {
+	const raw = Number(ms);
+	if (!Number.isFinite(raw) || raw <= 0) return '';
+	return String(Math.max(1, Math.round(raw / 60000)));
+}
+
+/** Convert a minutes value entered in the UI to a millisecond-interval string for the backend. Returns '' when invalid. */
+export function minutesToMs(minutes: string | number | null | undefined): string {
+	const m = Number(minutes);
+	if (!Number.isFinite(m) || m <= 0) return '';
+	return String(Math.round(m) * 60000);
+}
+
+/** Human-readable interval label from a millisecond value, e.g. "every 30m" / "every 2h" / "every 1d". */
+export function formatIntervalMs(ms: string | number | null | undefined): string {
+	const raw = Number(ms);
+	if (!Number.isFinite(raw) || raw <= 0) return String(ms ?? '').trim() || '--';
+	const minutes = Math.max(1, Math.round(raw / 60000));
+	if (minutes >= 60 * 24) return `every ${Math.round(minutes / (60 * 24))}d`;
+	if (minutes >= 60) return `every ${Math.round(minutes / 60)}h`;
+	return `every ${minutes}m`;
+}
+
+/**
+ * Build a cron expression that fires every `minutes` minutes. Handles the
+ * cleanly-expressible cases (sub-hour steps, whole hours, whole days). The
+ * routines page renders a live "next fire times" preview, so any approximation
+ * of an awkward value stays visible to the operator. Returns '' when invalid.
+ */
+export function minutesToCron(minutes: string | number | null | undefined): string {
+	const n = Math.round(Number(minutes));
+	if (!Number.isFinite(n) || n < 1) return '';
+	if (n < 60) return `*/${n} * * * *`;
+	if (n === 60) return '0 * * * *';
+	if (n % 1440 === 0) {
+		const days = n / 1440;
+		return days === 1 ? '0 0 * * *' : `0 0 */${days} * *`;
+	}
+	if (n % 60 === 0) {
+		const hours = n / 60;
+		if (hours < 24) return `0 */${hours} * * *`;
+		return '0 0 * * *';
+	}
+	// Not cleanly expressible in cron — approximate to the nearest whole hour.
+	const hours = Math.max(1, Math.round(n / 60));
+	return hours < 24 ? `0 */${hours} * * *` : '0 0 * * *';
+}
+
+/**
+ * Inverse of minutesToCron for the patterns it produces, so an existing routine
+ * can be re-opened in "every N minutes" mode. Returns null when the expression
+ * isn't a simple interval (e.g. "0 14 * * MON"), signalling the caller to fall
+ * back to cron mode.
+ */
+export function cronToMinutes(expr: string | null | undefined): number | null {
+	const parts = (expr || '').trim().split(/\s+/);
+	if (parts.length !== 5) return null;
+	const [min, hour, dom, mon, dow] = parts;
+	if (mon !== '*' || dow !== '*') return null;
+
+	const stepMin = /^\*\/(\d+)$/.exec(min);
+	// */N * * * *  -> every N minutes (sub-hour)
+	if (stepMin && hour === '*' && dom === '*') {
+		const n = Number(stepMin[1]);
+		return n >= 1 && n < 60 ? n : null;
+	}
+	// 0 * * * *  -> hourly
+	if (min === '0' && hour === '*' && dom === '*') return 60;
+
+	const stepHour = /^\*\/(\d+)$/.exec(hour);
+	// 0 */H * * *  -> every H hours
+	if (min === '0' && stepHour && dom === '*') {
+		const h = Number(stepHour[1]);
+		return h >= 1 && h < 24 ? h * 60 : null;
+	}
+	// 0 0 * * *  -> daily
+	if (min === '0' && hour === '0' && dom === '*') return 1440;
+
+	const stepDom = /^\*\/(\d+)$/.exec(dom);
+	// 0 0 */D * *  -> every D days
+	if (min === '0' && hour === '0' && stepDom) {
+		const d = Number(stepDom[1]);
+		return d >= 1 ? d * 1440 : null;
+	}
+	return null;
+}

--- a/frontend/src/routes/agents/components/SchedulerJobRow.svelte
+++ b/frontend/src/routes/agents/components/SchedulerJobRow.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { ForvenSchedulerJob } from '$lib/api';
+	import { msToMinutes, minutesToMs, formatIntervalMs } from '$lib/utils/schedule';
 
 	export let job: ForvenSchedulerJob;
 	export let onSave: (jobId: string | number, scheduleType: string, scheduleExpr: string, enabled: boolean) => Promise<void>;
@@ -15,14 +16,24 @@
 
 	const scheduleTypeOptions = [
 		{ value: 'cron', label: 'cron' },
-		{ value: 'interval', label: 'interval' }
+		{ value: 'interval', label: 'interval (min)' }
 	] as const;
 
 	$: normalizedType = job.schedule_type === 'interval' || job.schedule_type === 'cron' ? job.schedule_type : 'cron';
 	$: normalizedExpr = (job.schedule_expr ?? '').trim();
 	$: if (!isEditing) {
 		draftType = normalizedType === 'interval' ? 'interval' : 'cron';
-		draftExpr = normalizedExpr;
+		draftExpr = toDisplayExpr(normalizedExpr, draftType);
+	}
+
+	// Interval schedules are stored as a millisecond string but shown/edited in
+	// minutes; cron schedules pass through unchanged.
+	function toDisplayExpr(expr: string, type: 'cron' | 'interval'): string {
+		return type === 'interval' ? msToMinutes(expr) : expr;
+	}
+
+	function toStoredExpr(expr: string, type: 'cron' | 'interval'): string {
+		return type === 'interval' ? minutesToMs(expr) : expr.trim();
 	}
 
 	function canSave(): boolean {
@@ -46,24 +57,9 @@
 		return `${Math.floor(minutes / (24 * 60))}d`;
 	}
 
-	function formatInterval(expr: string): string {
-		const raw = Number(expr);
-		if (!Number.isFinite(raw) || raw <= 0) return expr || '--';
-		const minutes = Math.floor(raw / 60000);
-		if (minutes >= 60 * 24) {
-			const days = Math.round(minutes / (60 * 24));
-			return `every ${days}d`;
-		}
-		if (minutes >= 60) {
-			const hours = Math.round(minutes / 60);
-			return `every ${hours}h`;
-		}
-		return `every ${minutes}m`;
-	}
-
 	function displaySchedule(): string {
 		if (!normalizedExpr) return '--';
-		if (normalizedType === 'interval') return formatInterval(normalizedExpr);
+		if (normalizedType === 'interval') return formatIntervalMs(normalizedExpr);
 		return normalizedExpr;
 	}
 
@@ -79,25 +75,12 @@
 		return 'border-gray-700 text-gray-500';
 	}
 
-	function normalizeExprForSave(expr: string, scheduleType: 'cron' | 'interval'): string {
-		const trimmed = expr.trim();
-		if (scheduleType === 'interval') {
-			const parsed = Number(trimmed);
-			if (!Number.isFinite(parsed) || parsed <= 0) return '';
-			return String(parsed);
-		}
-		return trimmed;
-	}
-
-	function resolveExpr(value: string): string {
-		return normalizeExprForSave(value, draftType) || value.trim();
-	}
-
 	async function handleSave() {
 		errorMessage = '';
-		const payload = normalizeExprForSave(draftExpr, draftType);
+		const payload = toStoredExpr(draftExpr, draftType);
 		if (!payload) {
-			errorMessage = 'Schedule expression is required';
+			errorMessage =
+				draftType === 'interval' ? 'Enter a positive number of minutes' : 'Schedule expression is required';
 			return;
 		}
 		if (!hasJobId(job.id)) {
@@ -107,7 +90,7 @@
 		saving = true;
 		try {
 			await onSave(job.id, draftType, payload, Boolean(job.enabled));
-			draftExpr = payload;
+			draftExpr = toDisplayExpr(payload, draftType);
 			isEditing = false;
 		} catch (err) {
 			errorMessage = err instanceof Error ? err.message : 'Failed to save job';
@@ -118,14 +101,14 @@
 
 	function handleCancel() {
 		draftType = normalizedType === 'interval' ? 'interval' : 'cron';
-		draftExpr = normalizedExpr;
+		draftExpr = toDisplayExpr(normalizedExpr, draftType);
 		errorMessage = '';
 		isEditing = false;
 	}
 
 	function startEdit() {
 		draftType = normalizedType === 'interval' ? 'interval' : 'cron';
-		draftExpr = normalizedExpr;
+		draftExpr = toDisplayExpr(normalizedExpr, draftType);
 		errorMessage = '';
 		isEditing = true;
 	}
@@ -138,7 +121,9 @@
 		const checked = (event.currentTarget as HTMLInputElement).checked;
 		errorMessage = '';
 		try {
-			await onSave(job.id, draftType, resolveExpr(draftExpr), checked);
+			// Toggling enabled must not reinterpret the schedule, so send the
+			// job's existing stored value as-is.
+			await onSave(job.id, normalizedType, normalizedExpr, checked);
 		} catch (err) {
 			errorMessage = err instanceof Error ? err.message : 'Failed to toggle job';
 		}
@@ -178,12 +163,33 @@
 	<td class="px-4 py-2 text-gray-500">
 		{#if isEditing}
 			<div class="flex items-center gap-2">
-				<select class="terminal-select !w-28 py-1" bind:value={draftType}>
+				<select
+					class="terminal-select !w-28 py-1"
+					bind:value={draftType}
+					on:change={() => (draftExpr = '')}
+				>
 					{#each scheduleTypeOptions as option}
 						<option value={option.value}>{option.label}</option>
 					{/each}
 				</select>
-				<input class="terminal-input py-1" type="text" placeholder="Schedule" bind:value={draftExpr} />
+				{#if draftType === 'interval'}
+					<input
+						class="terminal-input py-1 !w-24"
+						type="number"
+						min="1"
+						step="1"
+						placeholder="minutes"
+						value={draftExpr}
+						on:input={(e) => (draftExpr = e.currentTarget.value)}
+					/>
+				{:else}
+					<input
+						class="terminal-input py-1"
+						type="text"
+						placeholder="cron e.g. 0 9 * * *"
+						bind:value={draftExpr}
+					/>
+				{/if}
 				<div class="flex items-center gap-1">
 					<button
 						type="button"
@@ -205,9 +211,6 @@
 			</div>
 		{:else}
 			<div>{displaySchedule()}</div>
-			{#if normalizedType === 'interval'}
-				<div class="text-[10px] text-gray-600 uppercase tracking-wider">{formatInterval(normalizedExpr)}</div>
-			{/if}
 		{/if}
 	</td>
 	<td class="px-4 py-2 text-gray-400">{parseNextRun(job.next_run_at ?? null)}</td>

--- a/frontend/src/routes/pipeline/+page.svelte
+++ b/frontend/src/routes/pipeline/+page.svelte
@@ -11,6 +11,7 @@
 	} from '$lib/api';
 	import { activeProcesses, type TrackedProcess } from '$lib/stores/processTracker';
 	import { createRealtimeRefresh } from '$lib/utils/realtime';
+	import { formatIntervalMs } from '$lib/utils/schedule';
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
 	import { fetchApi } from '$lib/api/core';
@@ -451,7 +452,7 @@
 										<span class="w-2 h-2 rounded-full inline-block {job.enabled ? 'bg-green-400' : 'bg-gray-600'}"></span>
 									</td>
 									<td class="px-4 py-2 text-gray-300 whitespace-nowrap">{job.name || '-'}</td>
-									<td class="px-4 py-2 text-gray-500 font-mono text-[11px]">{job.schedule_expr || '-'}</td>
+									<td class="px-4 py-2 text-gray-500 font-mono text-[11px]">{job.schedule_type === 'interval' ? formatIntervalMs(job.schedule_expr) : job.schedule_expr || '-'}</td>
 									<td class="px-4 py-2 text-right text-gray-400 tabular-nums">{timeAgo(job.next_run_at)}</td>
 									<td class="px-4 py-2 text-right text-gray-400 tabular-nums">{timeAgo(job.last_run_at)}</td>
 									<td class="px-4 py-2 text-right font-bold uppercase {schedulerStatusColor(job.last_status)}">{job.last_status || '-'}</td>

--- a/frontend/src/routes/routines/+page.svelte
+++ b/frontend/src/routes/routines/+page.svelte
@@ -13,6 +13,9 @@
 		type Routine,
 		type RoutineCreatePayload,
 	} from '$lib/api/routines';
+	import { minutesToCron, cronToMinutes } from '$lib/utils/schedule';
+
+	type ScheduleMode = 'cron' | 'minutes';
 
 	let routines: Routine[] = [];
 	let loading = true;
@@ -32,12 +35,16 @@
 	let cronPreview: string[] = [];
 	let cronPreviewError: string | null = null;
 	let skillsInput = '';
+	let createMode: ScheduleMode = 'cron';
+	let createMinutes = 30;
 
 	let editingId: number | null = null;
 	let editDraft: RoutineCreatePayload = { name: '', prompt: '', cron_expr: '' };
 	let editSkillsInput = '';
 	let editError: string | null = null;
 	let editPreview: string[] = [];
+	let editMode: ScheduleMode = 'cron';
+	let editMinutes = 30;
 
 	const VALID_CONTEXTS = ['scheduled', 'interactive', 'recovery', 'research'];
 
@@ -148,6 +155,8 @@
 			createForm = { name: '', prompt: '', cron_expr: '0 14 * * *', tools_context: 'scheduled', skills: [], enabled: true };
 			skillsInput = '';
 			cronPreview = [];
+			createMode = 'cron';
+			createMinutes = 30;
 			await load();
 		} catch (err) {
 			error = err instanceof Error ? err.message : String(err);
@@ -168,6 +177,15 @@
 		};
 		editSkillsInput = (routine.skills || []).join(', ');
 		editError = null;
+		// Re-open in "every N minutes" mode when the stored cron is a simple
+		// interval; otherwise keep the raw cron editor.
+		const asMinutes = cronToMinutes(routine.cron_expr);
+		if (asMinutes !== null) {
+			editMode = 'minutes';
+			editMinutes = asMinutes;
+		} else {
+			editMode = 'cron';
+		}
 		try {
 			editPreview = await previewRoutineSchedule(routine.id, 5);
 		} catch (err) {
@@ -240,6 +258,11 @@
 		cronPreviewTimer = setTimeout(() => void refreshCronPreview(expr), 300);
 	}
 
+	// In "every N minutes" mode the cron field is derived from the minutes value;
+	// the backend still stores (and the preview still reads) a cron expression.
+	$: if (createMode === 'minutes') createForm.cron_expr = minutesToCron(createMinutes);
+	$: if (editMode === 'minutes') editDraft.cron_expr = minutesToCron(editMinutes);
+
 	$: scheduleCronPreview(createForm.cron_expr || '');
 
 	onMount(load);
@@ -270,17 +293,33 @@
 			<label class="text-xs"><span class="text-gray-500 uppercase tracking-wider">Name</span>
 				<input type="text" bind:value={createForm.name} placeholder="weekly-postmortem" class="mt-1 w-full bg-black border border-[#222] px-2 py-1.5 text-gray-200" />
 			</label>
-			<label class="text-xs"><span class="text-gray-500 uppercase tracking-wider">Cron expression (UTC)</span>
-				<input type="text" bind:value={createForm.cron_expr} placeholder="0 14 * * MON" class="mt-1 w-full bg-black border border-[#222] px-2 py-1.5 text-gray-200 font-mono" />
-				<div class="mt-1 flex flex-wrap gap-1">
-					{#each CRON_PRESETS as preset}
-						<button type="button" class="border border-[#333] text-gray-400 hover:text-gray-100 hover:border-[#555] px-1.5 py-0.5 rounded text-[10px]" on:click={() => (createForm.cron_expr = preset.expr)}>{preset.label}</button>
-					{/each}
+			<div class="text-xs">
+				<div class="flex items-center justify-between gap-2">
+					<span class="text-gray-500 uppercase tracking-wider">Schedule (UTC)</span>
+					<div class="inline-flex rounded overflow-hidden border border-[#222] text-[10px]">
+						<button type="button" class="px-2 py-0.5 {createMode === 'minutes' ? 'bg-[#1a1a1a] text-gray-100' : 'text-gray-500 hover:text-gray-300'}" on:click={() => (createMode = 'minutes')}>Every N min</button>
+						<button type="button" class="px-2 py-0.5 {createMode === 'cron' ? 'bg-[#1a1a1a] text-gray-100' : 'text-gray-500 hover:text-gray-300'}" on:click={() => (createMode = 'cron')}>Cron</button>
+					</div>
 				</div>
-				{#if describeCron(createForm.cron_expr || '')}
-					<div class="mt-1 text-[11px] text-gray-400">{describeCron(createForm.cron_expr || '')}</div>
+				{#if createMode === 'minutes'}
+					<div class="mt-1 flex items-center gap-2">
+						<span class="text-gray-400">Run every</span>
+						<input type="number" min="1" step="1" bind:value={createMinutes} class="w-20 bg-black border border-[#222] px-2 py-1.5 text-gray-200" />
+						<span class="text-gray-400">minutes</span>
+					</div>
+					<div class="mt-1 text-[11px] text-gray-500 font-mono">cron: {createForm.cron_expr || '--'}</div>
+				{:else}
+					<input type="text" bind:value={createForm.cron_expr} placeholder="0 14 * * MON" class="mt-1 w-full bg-black border border-[#222] px-2 py-1.5 text-gray-200 font-mono" />
+					<div class="mt-1 flex flex-wrap gap-1">
+						{#each CRON_PRESETS as preset}
+							<button type="button" class="border border-[#333] text-gray-400 hover:text-gray-100 hover:border-[#555] px-1.5 py-0.5 rounded text-[10px]" on:click={() => (createForm.cron_expr = preset.expr)}>{preset.label}</button>
+						{/each}
+					</div>
+					{#if describeCron(createForm.cron_expr || '')}
+						<div class="mt-1 text-[11px] text-gray-400">{describeCron(createForm.cron_expr || '')}</div>
+					{/if}
 				{/if}
-			</label>
+			</div>
 		</div>
 		<label class="text-xs block"><span class="text-gray-500 uppercase tracking-wider">Prompt</span>
 			<textarea rows="3" bind:value={createForm.prompt} class="mt-1 w-full bg-black border border-[#222] px-2 py-1.5 text-gray-200" placeholder="What should the Brain do when this fires?"></textarea>
@@ -310,7 +349,7 @@
 			{/if}
 		</div>
 		<div>
-			<button type="button" disabled={creating || !createForm.name.trim() || !createForm.prompt.trim()} class="border border-emerald-700 bg-emerald-900/20 hover:bg-emerald-900/40 text-emerald-300 px-4 py-2 rounded text-xs disabled:opacity-40" on:click={() => void handleCreate()}>{creating ? 'Creating...' : 'Create routine'}</button>
+			<button type="button" disabled={creating || !createForm.name.trim() || !createForm.prompt.trim() || !createForm.cron_expr.trim()} class="border border-emerald-700 bg-emerald-900/20 hover:bg-emerald-900/40 text-emerald-300 px-4 py-2 rounded text-xs disabled:opacity-40" on:click={() => void handleCreate()}>{creating ? 'Creating...' : 'Create routine'}</button>
 		</div>
 	</section>
 
@@ -368,9 +407,25 @@
 									<label class="text-xs"><span class="text-gray-500 uppercase tracking-wider">Name</span>
 										<input type="text" bind:value={editDraft.name} class="mt-1 w-full bg-black border border-[#222] px-2 py-1.5 text-gray-200" />
 									</label>
-									<label class="text-xs"><span class="text-gray-500 uppercase tracking-wider">Cron</span>
-										<input type="text" bind:value={editDraft.cron_expr} class="mt-1 w-full bg-black border border-[#222] px-2 py-1.5 text-gray-200 font-mono" />
-									</label>
+									<div class="text-xs">
+										<div class="flex items-center justify-between gap-2">
+											<span class="text-gray-500 uppercase tracking-wider">Schedule (UTC)</span>
+											<div class="inline-flex rounded overflow-hidden border border-[#222] text-[10px]">
+												<button type="button" class="px-2 py-0.5 {editMode === 'minutes' ? 'bg-[#1a1a1a] text-gray-100' : 'text-gray-500 hover:text-gray-300'}" on:click={() => (editMode = 'minutes')}>Every N min</button>
+												<button type="button" class="px-2 py-0.5 {editMode === 'cron' ? 'bg-[#1a1a1a] text-gray-100' : 'text-gray-500 hover:text-gray-300'}" on:click={() => (editMode = 'cron')}>Cron</button>
+											</div>
+										</div>
+										{#if editMode === 'minutes'}
+											<div class="mt-1 flex items-center gap-2">
+												<span class="text-gray-400">Run every</span>
+												<input type="number" min="1" step="1" bind:value={editMinutes} class="w-20 bg-black border border-[#222] px-2 py-1.5 text-gray-200" />
+												<span class="text-gray-400">minutes</span>
+											</div>
+											<div class="mt-1 text-[11px] text-gray-500 font-mono">cron: {editDraft.cron_expr || '--'}</div>
+										{:else}
+											<input type="text" bind:value={editDraft.cron_expr} placeholder="0 14 * * MON" class="mt-1 w-full bg-black border border-[#222] px-2 py-1.5 text-gray-200 font-mono" />
+										{/if}
+									</div>
 								</div>
 								<label class="text-xs block"><span class="text-gray-500 uppercase tracking-wider">Prompt</span>
 									<textarea rows="3" bind:value={editDraft.prompt} class="mt-1 w-full bg-black border border-[#222] px-2 py-1.5 text-gray-200"></textarea>


### PR DESCRIPTION
## What
Operator UX: schedule agent jobs and routines in **plain minutes** instead of raw milliseconds (interval jobs) or cron strings (routines).

## Changes
- New `frontend/src/lib/utils/schedule.ts` — shared `ms<->minutes` + `minutes<->cron` conversions with input validation.
- `SchedulerJobRow.svelte` / `SettingsAgents.svelte` — interval jobs use a minutes number input with a human-readable "every 30m" label; cron jobs keep the text field.
- `routines/+page.svelte` — "Every N min" ↔ "Cron" mode toggle for create + edit; a simple interval cron (`*/30 * * * *`) auto-detects back to minutes on edit.
- `pipeline/+page.svelte` — schedule column renders "every 30m"/"every 2h" instead of milliseconds.

Backend unchanged — all conversion happens at the UI boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)