### PR TITLE
feat: free-tier LLM providers (Groq & Gemini) + provider hardening

### DIFF
--- a/forven/agents/providers.py
+++ b/forven/agents/providers.py
@@ -950,6 +950,56 @@ class DeepSeekProvider(OpenAIProvider):
 
 
 # ---------------------------------------------------------------------------
+# Groq + Gemini (free-tier) — OpenAI-compatible
+# ---------------------------------------------------------------------------
+
+class GroqProvider(OpenAIProvider):
+    """Groq Chat API — OpenAI Chat Completions compatible.
+
+    Default base: ``https://api.groq.com/openai/v1``. Free tier with low
+    rate limits; tool-calling is supported on the larger models (e.g.
+    ``llama-3.3-70b-versatile``).
+    """
+
+    DEFAULT_BASE_URL = "https://api.groq.com/openai/v1"
+
+    @staticmethod
+    def _get_base_url() -> str:
+        profile = get_profile("groq") or {}
+        base_url = str(profile.get("base_url") or "").strip()
+        if not base_url:
+            base_url = GroqProvider.DEFAULT_BASE_URL
+        return base_url.rstrip("/")
+
+    @property
+    def ENDPOINT(self) -> str:  # type: ignore[override]
+        return f"{self._get_base_url()}/chat/completions"
+
+
+class GeminiProvider(OpenAIProvider):
+    """Google Gemini — via its OpenAI Chat Completions compatible endpoint.
+
+    Default base: ``https://generativelanguage.googleapis.com/v1beta/openai``.
+    Free tier with daily/per-minute limits; tool-calling is supported on the
+    Gemini 2.x models.
+    """
+
+    DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
+
+    @staticmethod
+    def _get_base_url() -> str:
+        profile = get_profile("gemini") or {}
+        base_url = str(profile.get("base_url") or "").strip()
+        if not base_url:
+            base_url = GeminiProvider.DEFAULT_BASE_URL
+        return base_url.rstrip("/")
+
+    @property
+    def ENDPOINT(self) -> str:  # type: ignore[override]
+        return f"{self._get_base_url()}/chat/completions"
+
+
+# ---------------------------------------------------------------------------
 # Factory
 # ---------------------------------------------------------------------------
 
@@ -967,5 +1017,9 @@ def get_provider(name: str) -> ToolCallProvider:
         return AnthropicProvider()
     if name == "deepseek":
         return DeepSeekProvider()
+    if name == "groq":
+        return GroqProvider()
+    if name == "gemini":
+        return GeminiProvider()
     # Default to OpenAI for all other providers (openai, codex, etc.)
     return OpenAIProvider()

--- a/forven/agents/runner.py
+++ b/forven/agents/runner.py
@@ -14,6 +14,7 @@ from contextvars import Token
 from datetime import datetime, timedelta, timezone
 
 from forven.ai import (
+    _is_quota_exhausted,
     _is_rate_limit_exception,
     call_ai,
     is_transient_provider_exception,
@@ -22,7 +23,7 @@ from forven.ai import (
 from forven.async_utils import spawn
 from forven.context import build_agent_context
 from forven.cost_pricing import estimate_cost_usd
-from forven.db import claim_pending_agent_tasks, create_pending_task, format_prefixed_id, get_db, get_task_tool_calls, init_db, is_user_active, kv_get, log_activity
+from forven.db import claim_pending_agent_tasks, create_pending_task, format_prefixed_id, get_db, get_task_tool_calls, init_db, is_user_active, kv_get, kv_set, log_activity
 from forven.model_routing import get_fallback_chain
 from forven.research_context import build_research_context, coerce_research_contract
 from forven.task_timeouts import DEFAULT_AGENT_TASK_TIMEOUT_SECONDS, resolve_agent_task_timeout_seconds
@@ -61,6 +62,12 @@ log = logging.getLogger("forven.agents.runner")
 
 _MAX_RATE_LIMIT_RETRIES = 3
 _RATE_LIMIT_BACKOFF_MINUTES = (1, 2, 5)
+# Persistent quota/billing exhaustion (spend cap, out of credits): retrying
+# within minutes can't help, so back off on the scale of tens of minutes and
+# raise ONE deduped actionable alert per provider rather than per task.
+_MAX_QUOTA_EXHAUSTED_RETRIES = 3
+_QUOTA_EXHAUSTED_BACKOFF_MINUTES = (30, 60, 120)
+_PROVIDER_QUOTA_ALERT_COOLDOWN_MINUTES = 30
 _MAX_TRANSIENT_PROVIDER_RETRIES = 3
 _TRANSIENT_PROVIDER_BACKOFF_MINUTES = (2, 5, 10)
 # Missing/expired provider credentials are an OPERATOR-fixable condition, not a
@@ -475,8 +482,14 @@ def _requeue_agent_task(
     backoff_minutes: tuple[int, ...] | None = None,
     max_retries: int | None = None,
     exhausted_label: str = "retries exhausted",
+    quiet: bool = False,
 ) -> bool:
-    """Requeue a task for retry.  Returns False if the task has exceeded max retries."""
+    """Requeue a task for retry.  Returns False if the task has exceeded max retries.
+
+    ``quiet`` suppresses the per-requeue activity warning — used when the caller
+    raises its own (deduplicated) alert instead, to avoid flooding the alerts
+    panel when many tasks fail for the same persistent reason.
+    """
     with get_db() as conn:
         row = conn.execute("SELECT retry_count FROM agent_tasks WHERE id = ?", (task_id,)).fetchone()
         retry_count = int(row["retry_count"] or 0) if row else 0
@@ -512,12 +525,39 @@ def _requeue_agent_task(
                 task_id,
             ),
         )
+    if not quiet:
+        log_activity(
+            "warning",
+            f"agent:{agent_id}",
+            f"Task requeued (retry {retry_count + 1}, wait {delay_minutes}m): {title}",
+        )
+    return True
+
+
+def _emit_provider_quota_alert(provider: str, detail: str) -> None:
+    """Raise an actionable provider-exhaustion alert, deduped per provider.
+
+    A persistent quota/spend-cap failure affects every agent on that provider,
+    so without dedup the alerts panel floods. Emit at most one per provider per
+    cooldown window (tracked in the KV store so it survives across tasks).
+    """
+    provider_key = (provider or "unknown").strip().lower() or "unknown"
+    cooldown_key = f"forven:provider-quota-alert:{provider_key}"
+    now = datetime.now(timezone.utc).timestamp()
+    try:
+        last_ts = float(kv_get(cooldown_key, 0) or 0)
+    except (TypeError, ValueError):
+        last_ts = 0.0
+    if now - last_ts < _PROVIDER_QUOTA_ALERT_COOLDOWN_MINUTES * 60:
+        return
+    kv_set(cooldown_key, now)
     log_activity(
         "warning",
-        f"agent:{agent_id}",
-        f"Task requeued (retry {retry_count + 1}, wait {delay_minutes}m): {title}",
+        f"provider:{provider_key}",
+        f"{provider_key} quota/spend cap exhausted — tasks are retrying on a long "
+        f"backoff. Raise the cap / add credits, or switch the agents to another "
+        f"provider. Detail: {detail[:280]}",
     )
-    return True
 
 
 def _resolve_task_timeout_seconds(task_type: str) -> int:
@@ -1335,6 +1375,24 @@ async def _run_agent_task_inner(
         # errors: re-running the task can re-submit the order and open a duplicate
         # position. Fail safe instead (fall through to status='failed' + early
         # return below); the Brain/operator can re-evaluate explicitly.
+        # Persistent quota/billing exhaustion (spend cap, out of credits) is
+        # checked BEFORE the generic rate-limit branch: it won't clear on a
+        # minute-scale retry, so back off long and raise ONE deduped actionable
+        # alert per provider instead of flooding the alerts panel per task.
+        if _is_quota_exhausted(e) and not is_trade_execution_task:
+            _requeue_agent_task(
+                task_id,
+                agent_id,
+                task.get("title", ""),
+                f"Provider quota/spend cap exhausted: {error_summary[:350]}",
+                backoff_minutes=_QUOTA_EXHAUSTED_BACKOFF_MINUTES,
+                max_retries=_MAX_QUOTA_EXHAUSTED_RETRIES,
+                exhausted_label="Quota-exhaustion retries exhausted",
+                quiet=True,
+            )
+            _emit_provider_quota_alert(str(agent.get("model") or ""), error_summary)
+            return {"error": error_summary}
+
         if _is_rate_limit_exception(e) and not is_trade_execution_task:
             _requeue_agent_task(
                 task_id,

--- a/forven/ai.py
+++ b/forven/ai.py
@@ -44,6 +44,20 @@ _REQUEST_TOO_LARGE_HINTS = (
     "too large for model",
     "request_too_large",
 )
+# PERSISTENT quota/billing exhaustion (spend cap, out of credits, monthly quota)
+# — distinct from a transient per-minute throttle. Retrying within minutes can
+# never help; the operator must raise the cap / add credits / switch provider.
+# These phrases are billing-specific so they won't match an ordinary 429.
+_QUOTA_EXHAUSTED_HINTS = (
+    "spend cap",
+    "spending cap",
+    "insufficient_quota",
+    "out of credits",
+    "credit balance",
+    "billing hard limit",
+    "exceeded your current quota",
+    "monthly spending",
+)
 _TRANSIENT_PROVIDER_STATUS_CODES = {408, 425, 429, 500, 502, 503, 504}
 _TRANSIENT_PROVIDER_HINTS = (
     "connecttimeout",
@@ -578,6 +592,24 @@ def _is_request_too_large(error: Exception) -> bool:
         except Exception:
             message = ""
         if any(hint in message for hint in _REQUEST_TOO_LARGE_HINTS):
+            return True
+    return False
+
+
+def _is_quota_exhausted(error: Exception) -> bool:
+    """True for PERSISTENT quota/billing exhaustion (spend cap, out of credits).
+
+    Distinct from a transient per-minute rate-limit: retrying within minutes
+    won't help — the operator must raise the cap / add credits / switch
+    provider. Callers use this to apply a long backoff and a single actionable
+    alert instead of fast per-task retries.
+    """
+    for node in _walk_exception_chain(error):
+        try:
+            message = str(node).lower()
+        except Exception:
+            message = ""
+        if any(hint in message for hint in _QUOTA_EXHAUSTED_HINTS):
             return True
     return False
 

--- a/forven/ai.py
+++ b/forven/ai.py
@@ -33,6 +33,17 @@ _RATE_LIMIT_HINTS = (
     "quota exceeded",
     "insufficient_quota",
 )
+# A single request that exceeds the provider's per-minute token budget (HTTP
+# 413). This is NOT a transient rate-limit — waiting and retrying the same
+# request can never succeed because the request itself is too big. Providers
+# (e.g. Groq) often phrase it with "rate limit" wording, so it must be detected
+# and excluded from the retryable rate-limit class.
+_REQUEST_TOO_LARGE_HINTS = (
+    "request too large",
+    "reduce your message size",
+    "too large for model",
+    "request_too_large",
+)
 _TRANSIENT_PROVIDER_STATUS_CODES = {408, 425, 429, 500, 502, 503, 504}
 _TRANSIENT_PROVIDER_HINTS = (
     "connecttimeout",
@@ -480,6 +491,13 @@ def _message_mentions_rate_limit(text: str) -> bool:
 
 
 def _is_rate_limit_exception(error: Exception) -> bool:
+    # A 413 "request too large" is a capacity mismatch, not a transient
+    # throttle — retrying the identical request never succeeds. Exclude it so
+    # callers fall back to a higher-capacity provider / fail fast instead of
+    # requeuing with minute-scale backoffs.
+    if _is_request_too_large(error):
+        return False
+
     seen: set[int] = set()
     current: object | None = error
 
@@ -540,6 +558,28 @@ def _walk_exception_chain(error: Exception):
         seen.add(current_id)
         yield current
         current = getattr(current, "__cause__", None) or getattr(current, "__context__", None)
+
+
+def _is_request_too_large(error: Exception) -> bool:
+    """True when a single request exceeds the provider's token/size budget (413).
+
+    Distinct from a retryable rate-limit: the request must be made smaller or
+    sent to a higher-capacity provider — retrying as-is can never succeed.
+    """
+    for node in _walk_exception_chain(error):
+        status = getattr(node, "status_code", None)
+        if status == 413:
+            return True
+        response = getattr(node, "response", None)
+        if response is not None and getattr(response, "status_code", None) == 413:
+            return True
+        try:
+            message = str(node).lower()
+        except Exception:
+            message = ""
+        if any(hint in message for hint in _REQUEST_TOO_LARGE_HINTS):
+            return True
+    return False
 
 
 def is_transient_provider_exception(error: Exception) -> bool:

--- a/forven/ai.py
+++ b/forven/ai.py
@@ -135,6 +135,8 @@ ENDPOINTS = {
     "minimax": "https://api.minimax.io/anthropic/v1/messages",
     "zai": "https://api.z.ai/api/paas/v4/chat/completions",
     "openrouter": "https://openrouter.ai/api/v1/chat/completions",
+    "groq": "https://api.groq.com/openai/v1/chat/completions",
+    "gemini": "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
 }
 
 _PROVIDER_ALIAS = {
@@ -149,7 +151,7 @@ _PROVIDER_ALIAS = {
 }
 
 _KNOWN_PROVIDER_PREFIXES: frozenset[str] = frozenset({
-    "openai", "minimax", "lmstudio", "zai", "openrouter",
+    "openai", "minimax", "lmstudio", "zai", "openrouter", "groq", "gemini",
     "codex", "openai-codex", "local", "lm-studio", "z.ai", "z-ai",
     "open-router", "open_router",
 })
@@ -811,6 +813,21 @@ async def _call_single(
             response_schema_name=response_schema_name,
             endpoint=ENDPOINTS["openrouter"],
             provider_label="openrouter",
+        )
+    elif provider in ("groq", "gemini"):
+        # Groq and Gemini both expose OpenAI-compatible Chat Completions
+        # endpoints, so route through the shared OpenAI caller.
+        return await _call_openai(
+            token,
+            model,
+            messages,
+            max_tokens,
+            temperature,
+            system,
+            response_schema=response_schema,
+            response_schema_name=response_schema_name,
+            endpoint=ENDPOINTS[provider],
+            provider_label=provider,
         )
     else:
         raise ValueError(f"Unknown provider: {provider}")

--- a/forven/api_core.py
+++ b/forven/api_core.py
@@ -323,6 +323,17 @@ _MODEL_DISCOVERY_HEADERS = {
         "Authorization": "Bearer {token}",
     },
 }
+
+# Endpoints used by the connection "Test" to verify a key is actually valid
+# (not just present). Defaults to the model-discovery endpoints/headers above;
+# overrides here cover providers whose /models route is unauthenticated and so
+# can't distinguish a good key from a bad one (e.g. OpenRouter).
+_AUTH_TEST_ENDPOINT_OVERRIDES = {
+    "openrouter": ["https://openrouter.ai/api/v1/key"],
+}
+_AUTH_TEST_HEADER_OVERRIDES = {
+    "openrouter": {"Authorization": "Bearer {token}"},
+}
 _MODEL_PROVIDER_DISPLAY_NAMES = {
     "openai": "OpenAI",
     "minimax": "MiniMax",
@@ -7018,12 +7029,69 @@ def test_auth_provider(provider: str):
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not token:
         raise HTTPException(status_code=400, detail=f"{normalized_provider} token missing after load")
-    return {
-        "ok": True,
-        "provider": normalized_provider,
-        "status": _build_auth_provider_payload(normalized_provider)["status"],
-        "message": "Token loaded successfully",
-    }
+
+    # Verify the key against the provider — a present-but-invalid key must fail.
+    endpoints = (
+        _AUTH_TEST_ENDPOINT_OVERRIDES.get(normalized_provider)
+        or _MODEL_DISCOVERY_ALT_ENDPOINTS.get(normalized_provider, [])
+    )
+    headers_template = (
+        _AUTH_TEST_HEADER_OVERRIDES.get(normalized_provider)
+        or _MODEL_DISCOVERY_HEADERS.get(normalized_provider, {})
+    )
+    if not (endpoints and headers_template):
+        # No way to verify this provider remotely — surface that honestly rather
+        # than implying the key was checked.
+        return {
+            "ok": True,
+            "provider": normalized_provider,
+            "status": _build_auth_provider_payload(normalized_provider)["status"],
+            "message": "Token saved (not verified against provider)",
+        }
+
+    header = {key: value.format(token=token) for key, value in headers_template.items()}
+    last_error: str | None = None
+    for endpoint in endpoints:
+        try:
+            with httpx.Client(timeout=15) as client:
+                response = client.get(endpoint, headers=header)
+        except Exception as exc:
+            last_error = str(exc)
+            continue
+        code = response.status_code
+        if code == 200:
+            try:
+                models = _extract_discovery_models(response.json(), normalized_provider)
+                count_note = f" ({len(models)} models available)" if models else ""
+            except Exception:
+                count_note = ""
+            return {
+                "ok": True,
+                "provider": normalized_provider,
+                "status": _build_auth_provider_payload(normalized_provider)["status"],
+                "message": f"Connected{count_note}",
+            }
+        if code == 429:
+            # Authenticated but rate-limited — the key itself is valid.
+            return {
+                "ok": True,
+                "provider": normalized_provider,
+                "status": _build_auth_provider_payload(normalized_provider)["status"],
+                "message": "Key valid (rate-limited at test time)",
+            }
+        if code in (400, 401, 403):
+            raise HTTPException(
+                status_code=400,
+                detail=f"{normalized_provider}: invalid API key (HTTP {code})",
+            )
+        # 404 (wrong path — try the next endpoint) / 5xx / other transient.
+        last_error = f"HTTP {code}"
+        continue
+
+    raise HTTPException(
+        status_code=400,
+        detail=f"{normalized_provider}: could not verify key ({last_error or 'no endpoint responded'})",
+    )
 
 
 def get_auth_providers():

--- a/forven/api_core.py
+++ b/forven/api_core.py
@@ -289,6 +289,9 @@ _MODEL_DISCOVERY_ALT_ENDPOINTS = {
     ],
     "groq": ["https://api.groq.com/openai/v1/models"],
     "gemini": ["https://generativelanguage.googleapis.com/v1beta/openai/models"],
+    # Anthropic paginates /v1/models (default 20); ask for the full list so new
+    # releases (e.g. newer Opus/Sonnet) surface without a catalog edit.
+    "anthropic": ["https://api.anthropic.com/v1/models?limit=1000"],
 }
 _MODEL_DISCOVERY_HEADERS = {
     "openai": {
@@ -306,6 +309,10 @@ _MODEL_DISCOVERY_HEADERS = {
     },
     "gemini": {
         "Authorization": "Bearer {token}",
+    },
+    "anthropic": {
+        "x-api-key": "{token}",
+        "anthropic-version": "2023-06-01",
     },
 }
 _MODEL_PROVIDER_DISPLAY_NAMES = {
@@ -390,6 +397,10 @@ _AGENT_MODEL_CATALOG = [
 
 def _normalize_model_id(value: object) -> str:
     normalized = str(value or "").strip()
+    # Gemini's OpenAI-compatible /models endpoint returns ids like
+    # "models/gemini-2.5-flash"; the chat endpoint wants the bare id.
+    if normalized.startswith("models/"):
+        normalized = normalized[len("models/"):]
     return normalized
 
 
@@ -452,6 +463,42 @@ def _looks_like_zai_discovery_model(model: str) -> bool:
     return lowered.startswith("glm-")
 
 
+def _looks_like_anthropic_discovery_model(model: str) -> bool:
+    lowered = model.lower().strip()
+    return lowered.startswith("claude-") or "claude" in lowered
+
+
+def _looks_like_groq_discovery_model(model: str) -> bool:
+    raw = str(model or "").strip()
+    if not raw:
+        return False
+    # Groq's /models payload carries both a callable id (lowercase slug, e.g.
+    # "llama-3.3-70b-versatile") and a human display name ("Llama 3.3 70B").
+    # Only the id is callable, so reject anything with spaces or uppercase.
+    if any(ch.isspace() or ch.isupper() for ch in raw):
+        return False
+    # Exclude non-chat models (speech-to-text, text-to-speech, moderation).
+    if any(tag in raw for tag in ("whisper", "tts", "guard", "orpheus", "safety")):
+        return False
+    return True
+
+
+def _looks_like_gemini_discovery_model(model: str) -> bool:
+    lowered = model.lower().strip()  # "models/" prefix already stripped upstream
+    if not lowered.startswith("gemini-"):
+        return False
+    # Gemini's compat /models also lists non-text modalities; keep chat models.
+    if any(
+        tag in lowered
+        for tag in (
+            "embedding", "image", "tts", "aqa", "computer-use",
+            "native-audio", "live", "robotics",
+        )
+    ):
+        return False
+    return True
+
+
 def _discovery_model_should_belong(provider: str, model_id: str) -> bool:
     if not model_id:
         return False
@@ -463,6 +510,12 @@ def _discovery_model_should_belong(provider: str, model_id: str) -> bool:
         return _looks_like_lmstudio_discovery_model(model_id)
     if provider == "zai":
         return _looks_like_zai_discovery_model(model_id)
+    if provider == "anthropic":
+        return _looks_like_anthropic_discovery_model(model_id)
+    if provider == "groq":
+        return _looks_like_groq_discovery_model(model_id)
+    if provider == "gemini":
+        return _looks_like_gemini_discovery_model(model_id)
     return False
 
 

--- a/forven/api_core.py
+++ b/forven/api_core.py
@@ -292,6 +292,11 @@ _MODEL_DISCOVERY_ALT_ENDPOINTS = {
     # Anthropic paginates /v1/models (default 20); ask for the full list so new
     # releases (e.g. newer Opus/Sonnet) surface without a catalog edit.
     "anthropic": ["https://api.anthropic.com/v1/models?limit=1000"],
+    # DeepSeek is OpenAI-compatible; try the /v1 path first, then the bare path.
+    "deepseek": [
+        "https://api.deepseek.com/v1/models",
+        "https://api.deepseek.com/models",
+    ],
 }
 _MODEL_DISCOVERY_HEADERS = {
     "openai": {
@@ -313,6 +318,9 @@ _MODEL_DISCOVERY_HEADERS = {
     "anthropic": {
         "x-api-key": "{token}",
         "anthropic-version": "2023-06-01",
+    },
+    "deepseek": {
+        "Authorization": "Bearer {token}",
     },
 }
 _MODEL_PROVIDER_DISPLAY_NAMES = {
@@ -468,6 +476,11 @@ def _looks_like_anthropic_discovery_model(model: str) -> bool:
     return lowered.startswith("claude-") or "claude" in lowered
 
 
+def _looks_like_deepseek_discovery_model(model: str) -> bool:
+    lowered = model.lower().strip()
+    return lowered.startswith("deepseek")
+
+
 def _looks_like_groq_discovery_model(model: str) -> bool:
     raw = str(model or "").strip()
     if not raw:
@@ -512,6 +525,8 @@ def _discovery_model_should_belong(provider: str, model_id: str) -> bool:
         return _looks_like_zai_discovery_model(model_id)
     if provider == "anthropic":
         return _looks_like_anthropic_discovery_model(model_id)
+    if provider == "deepseek":
+        return _looks_like_deepseek_discovery_model(model_id)
     if provider == "groq":
         return _looks_like_groq_discovery_model(model_id)
     if provider == "gemini":

--- a/forven/api_core.py
+++ b/forven/api_core.py
@@ -6982,6 +6982,14 @@ def upsert_auth_provider(provider: str, body: AuthProviderProfileBody):
     if not profile:
         raise HTTPException(status_code=400, detail=f"invalid credentials payload for {normalized_provider}")
 
+    # Reject a definitively-invalid key at entry time. Only when a new token is
+    # being set (not a base_url-only update) and never for lmstudio (local, no
+    # key to verify). _verify_provider_key raises HTTPException(400) on a hard
+    # rejection (400/401/403); transient/unverifiable outcomes are tolerated so
+    # a network blip can't block a legitimate save.
+    if access_token and normalized_provider != "lmstudio":
+        _verify_provider_key(normalized_provider, access_token)
+
     upsert_profile(normalized_provider, profile)
     return {"ok": True, "provider": normalized_provider}
 
@@ -6992,6 +7000,59 @@ def delete_auth_provider(provider: str):
     if not removed:
         return {"ok": False, "provider": normalized_provider, "removed": False}
     return {"ok": True, "provider": normalized_provider, "removed": True}
+
+
+def _verify_provider_key(provider: str, token: str) -> tuple[str, str]:
+    """Probe *provider* to check *token* is actually valid.
+
+    Returns ``(state, message)`` where state is:
+      - ``"ok"``           — provider accepted the key (HTTP 200/429)
+      - ``"no_endpoint"``  — no way to verify this provider remotely
+      - ``"unreachable"``  — had an endpoint but it didn't answer (404/5xx/network)
+
+    Raises ``HTTPException(400)`` when the provider *definitively* rejects the
+    key (HTTP 400/401/403) — that is a real "bad key" signal, distinct from a
+    transient failure callers may choose to tolerate.
+    """
+    endpoints = (
+        _AUTH_TEST_ENDPOINT_OVERRIDES.get(provider)
+        or _MODEL_DISCOVERY_ALT_ENDPOINTS.get(provider, [])
+    )
+    headers_template = (
+        _AUTH_TEST_HEADER_OVERRIDES.get(provider)
+        or _MODEL_DISCOVERY_HEADERS.get(provider, {})
+    )
+    if not (endpoints and headers_template):
+        return "no_endpoint", "not verifiable for this provider"
+
+    header = {key: value.format(token=token) for key, value in headers_template.items()}
+    last_error: str | None = None
+    for endpoint in endpoints:
+        try:
+            with httpx.Client(timeout=15) as client:
+                response = client.get(endpoint, headers=header)
+        except Exception as exc:
+            last_error = str(exc)
+            continue
+        code = response.status_code
+        if code == 200:
+            try:
+                models = _extract_discovery_models(response.json(), provider)
+                note = f" ({len(models)} models available)" if models else ""
+            except Exception:
+                note = ""
+            return "ok", f"Connected{note}"
+        if code == 429:
+            return "ok", "Key valid (rate-limited at test time)"
+        if code in (400, 401, 403):
+            raise HTTPException(
+                status_code=400,
+                detail=f"{provider}: invalid API key (HTTP {code})",
+            )
+        last_error = f"HTTP {code}"
+        continue
+
+    return "unreachable", last_error or "no endpoint responded"
 
 
 def test_auth_provider(provider: str):
@@ -7031,67 +7092,20 @@ def test_auth_provider(provider: str):
         raise HTTPException(status_code=400, detail=f"{normalized_provider} token missing after load")
 
     # Verify the key against the provider — a present-but-invalid key must fail.
-    endpoints = (
-        _AUTH_TEST_ENDPOINT_OVERRIDES.get(normalized_provider)
-        or _MODEL_DISCOVERY_ALT_ENDPOINTS.get(normalized_provider, [])
-    )
-    headers_template = (
-        _AUTH_TEST_HEADER_OVERRIDES.get(normalized_provider)
-        or _MODEL_DISCOVERY_HEADERS.get(normalized_provider, {})
-    )
-    if not (endpoints and headers_template):
-        # No way to verify this provider remotely — surface that honestly rather
-        # than implying the key was checked.
-        return {
-            "ok": True,
-            "provider": normalized_provider,
-            "status": _build_auth_provider_payload(normalized_provider)["status"],
-            "message": "Token saved (not verified against provider)",
-        }
-
-    header = {key: value.format(token=token) for key, value in headers_template.items()}
-    last_error: str | None = None
-    for endpoint in endpoints:
-        try:
-            with httpx.Client(timeout=15) as client:
-                response = client.get(endpoint, headers=header)
-        except Exception as exc:
-            last_error = str(exc)
-            continue
-        code = response.status_code
-        if code == 200:
-            try:
-                models = _extract_discovery_models(response.json(), normalized_provider)
-                count_note = f" ({len(models)} models available)" if models else ""
-            except Exception:
-                count_note = ""
-            return {
-                "ok": True,
-                "provider": normalized_provider,
-                "status": _build_auth_provider_payload(normalized_provider)["status"],
-                "message": f"Connected{count_note}",
-            }
-        if code == 429:
-            # Authenticated but rate-limited — the key itself is valid.
-            return {
-                "ok": True,
-                "provider": normalized_provider,
-                "status": _build_auth_provider_payload(normalized_provider)["status"],
-                "message": "Key valid (rate-limited at test time)",
-            }
-        if code in (400, 401, 403):
-            raise HTTPException(
-                status_code=400,
-                detail=f"{normalized_provider}: invalid API key (HTTP {code})",
-            )
-        # 404 (wrong path — try the next endpoint) / 5xx / other transient.
-        last_error = f"HTTP {code}"
-        continue
-
-    raise HTTPException(
-        status_code=400,
-        detail=f"{normalized_provider}: could not verify key ({last_error or 'no endpoint responded'})",
-    )
+    # _verify_provider_key raises on a definitive rejection (400/401/403).
+    state, message = _verify_provider_key(normalized_provider, token)
+    if state == "unreachable":
+        # Test is strict: an endpoint exists but we couldn't confirm the key.
+        raise HTTPException(
+            status_code=400,
+            detail=f"{normalized_provider}: could not verify key ({message})",
+        )
+    return {
+        "ok": True,
+        "provider": normalized_provider,
+        "status": _build_auth_provider_payload(normalized_provider)["status"],
+        "message": message if state == "ok" else "Token saved (not verified against provider)",
+    }
 
 
 def get_auth_providers():

--- a/forven/api_core.py
+++ b/forven/api_core.py
@@ -252,7 +252,7 @@ def _parse_int_query(value: str | None, default: int = 0) -> int:
         return default
 
 
-_SUPPORTED_AUTH_PROVIDERS: list[str] = ["openai", "minimax", "lmstudio", "zai", "openrouter", "anthropic", "deepseek"]
+_SUPPORTED_AUTH_PROVIDERS: list[str] = ["openai", "minimax", "lmstudio", "zai", "openrouter", "anthropic", "deepseek", "groq", "gemini"]
 _AUTH_PROVIDER_ENV_VARS = {
     "openai": "OPENAI_API_KEY",
     "minimax": "MINIMAX_API_KEY",
@@ -261,6 +261,8 @@ _AUTH_PROVIDER_ENV_VARS = {
     "openrouter": "OPENROUTER_API_KEY",
     "anthropic": "ANTHROPIC_API_KEY",
     "deepseek": "DEEPSEEK_API_KEY",
+    "groq": "GROQ_API_KEY",
+    "gemini": "GEMINI_API_KEY",
 }
 _AUTH_OAUTH_SESSIONS: dict[str, dict[str, dict[str, object]]] = {}
 _AUTH_OAUTH_CALLBACKS: dict[str, dict[str, str]] = {}
@@ -285,6 +287,8 @@ _MODEL_DISCOVERY_ALT_ENDPOINTS = {
         "https://api.z.ai/api/paas/v4/models",
         "https://open.bigmodel.cn/api/paas/v4/models",
     ],
+    "groq": ["https://api.groq.com/openai/v1/models"],
+    "gemini": ["https://generativelanguage.googleapis.com/v1beta/openai/models"],
 }
 _MODEL_DISCOVERY_HEADERS = {
     "openai": {
@@ -297,6 +301,12 @@ _MODEL_DISCOVERY_HEADERS = {
     "zai": {
         "Authorization": "Bearer {token}",
     },
+    "groq": {
+        "Authorization": "Bearer {token}",
+    },
+    "gemini": {
+        "Authorization": "Bearer {token}",
+    },
 }
 _MODEL_PROVIDER_DISPLAY_NAMES = {
     "openai": "OpenAI",
@@ -306,6 +316,8 @@ _MODEL_PROVIDER_DISPLAY_NAMES = {
     "openrouter": "OpenRouter",
     "anthropic": "Anthropic",
     "deepseek": "DeepSeek",
+    "groq": "Groq",
+    "gemini": "Google Gemini",
 }
 _LOCAL_PROVIDER_DEFAULT_BASE_URLS = {
     "lmstudio": "http://127.0.0.1:1234",
@@ -362,6 +374,17 @@ _AGENT_MODEL_CATALOG = [
     {"provider": "anthropic", "model_id": "claude-3-5-haiku-20241022", "label": "Anthropic Claude 3.5 Haiku"},
     {"provider": "deepseek", "model_id": "deepseek-chat", "label": "DeepSeek Chat"},
     {"provider": "deepseek", "model_id": "deepseek-reasoner", "label": "DeepSeek Reasoner"},
+    {"provider": "groq", "model_id": "llama-3.3-70b-versatile", "label": "Groq Llama 3.3 70B Versatile"},
+    {"provider": "groq", "model_id": "llama-3.1-8b-instant", "label": "Groq Llama 3.1 8B Instant"},
+    {"provider": "groq", "model_id": "openai/gpt-oss-120b", "label": "Groq GPT-OSS 120B"},
+    {"provider": "groq", "model_id": "openai/gpt-oss-20b", "label": "Groq GPT-OSS 20B"},
+    {"provider": "groq", "model_id": "moonshotai/kimi-k2-instruct", "label": "Groq Kimi K2 Instruct"},
+    {"provider": "groq", "model_id": "qwen/qwen3-32b", "label": "Groq Qwen3 32B"},
+    {"provider": "gemini", "model_id": "gemini-2.5-pro", "label": "Google Gemini 2.5 Pro"},
+    {"provider": "gemini", "model_id": "gemini-2.5-flash", "label": "Google Gemini 2.5 Flash"},
+    {"provider": "gemini", "model_id": "gemini-2.5-flash-lite", "label": "Google Gemini 2.5 Flash Lite"},
+    {"provider": "gemini", "model_id": "gemini-2.0-flash", "label": "Google Gemini 2.0 Flash"},
+    {"provider": "gemini", "model_id": "gemini-1.5-flash", "label": "Google Gemini 1.5 Flash"},
 ]
 
 

--- a/forven/auth/store.py
+++ b/forven/auth/store.py
@@ -20,7 +20,7 @@ log = logging.getLogger("forven.auth.store")
 
 LOCK_PATH = AUTH_FILE.with_suffix(".lock")
 REFRESH_BUFFER_MS = 5 * 60 * 1000  # 5 minutes before expiry
-_SUPPORTED_AUTH_PROVIDERS = {"openai", "minimax", "lmstudio", "zai", "openrouter", "anthropic", "deepseek"}
+_SUPPORTED_AUTH_PROVIDERS = {"openai", "minimax", "lmstudio", "zai", "openrouter", "anthropic", "deepseek", "groq", "gemini"}
 _AUTH_SECRET_FIELDS = {"access", "refresh", "token", "id_token", "api_key", "api_secret"}
 
 # Runtime-only marker attached to a profile whose ciphertext could not be
@@ -42,12 +42,16 @@ _ENV_ACCESS_TOKEN_KEYS = {
     "openrouter": ("OPENROUTER_API_KEY",),
     "anthropic": ("ANTHROPIC_API_KEY",),
     "deepseek": ("DEEPSEEK_API_KEY",),
+    "groq": ("GROQ_API_KEY",),
+    "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
 }
 _ENV_BASE_URL_KEYS = {
     "lmstudio": ("LMSTUDIO_BASE_URL",),
     "zai": ("ZAI_BASE_URL", "ANTHROPIC_BASE_URL"),
     "anthropic": ("ANTHROPIC_BASE_URL",),
     "deepseek": ("DEEPSEEK_BASE_URL",),
+    "groq": ("GROQ_BASE_URL",),
+    "gemini": ("GEMINI_BASE_URL",),
 }
 
 

--- a/forven/model_routing.py
+++ b/forven/model_routing.py
@@ -135,6 +135,10 @@ _DEFAULT_MODEL_ROUTING = {
         ],
         "groq": [
             {"provider": "groq", "model_id": "llama-3.3-70b-versatile"},
+            # Groq's free tier has a tight per-minute token budget; fall back to
+            # Gemini (free, large context) before any paid provider so a request
+            # too large for Groq still completes for free.
+            {"provider": "gemini", "model_id": "gemini-2.5-flash"},
             {"provider": "openai", "model_id": "gpt-5.2"},
         ],
         "gemini": [

--- a/forven/model_routing.py
+++ b/forven/model_routing.py
@@ -19,6 +19,8 @@ _SUPPORTED_PROVIDERS: tuple[str, ...] = (
     "openrouter",
     "anthropic",
     "deepseek",
+    "groq",
+    "gemini",
 )
 _MODEL_ROUTING_STORAGE_KEY = "forven:model-routing"
 _LEGACY_MODEL_ALIASES: dict[str, dict[str, str]] = {}
@@ -31,6 +33,11 @@ _ZAI_PRIMARY_PROVIDER_PRIORITY = [
     "openrouter",
     "anthropic",
     "deepseek",
+    # Free-tier providers default to the bottom of the priority order: their
+    # rate limits are aggressive, so they shouldn't outrank paid providers on
+    # the hot path unless the operator reorders them.
+    "groq",
+    "gemini",
 ]
 
 # Auxiliary task kinds — small/cheap helper models that run *outside* the
@@ -92,6 +99,8 @@ _DEFAULT_MODEL_ROUTING = {
         "openrouter": "openai/gpt-4o-mini",
         "anthropic": "claude-sonnet-4-6",
         "deepseek": "deepseek-chat",
+        "groq": "llama-3.3-70b-versatile",
+        "gemini": "gemini-2.5-flash",
     },
     "fallback_chains": {
         "openai": [
@@ -122,6 +131,14 @@ _DEFAULT_MODEL_ROUTING = {
         ],
         "deepseek": [
             {"provider": "deepseek", "model_id": "deepseek-chat"},
+            {"provider": "openai", "model_id": "gpt-5.2"},
+        ],
+        "groq": [
+            {"provider": "groq", "model_id": "llama-3.3-70b-versatile"},
+            {"provider": "openai", "model_id": "gpt-5.2"},
+        ],
+        "gemini": [
+            {"provider": "gemini", "model_id": "gemini-2.5-flash"},
             {"provider": "openai", "model_id": "gpt-5.2"},
         ],
     },

--- a/forven/model_routing.py
+++ b/forven/model_routing.py
@@ -100,7 +100,10 @@ _DEFAULT_MODEL_ROUTING = {
         "anthropic": "claude-sonnet-4-6",
         "deepseek": "deepseek-chat",
         "groq": "llama-3.3-70b-versatile",
-        "gemini": "gemini-2.5-flash",
+        # Cheapest Gemini model that still runs the agent tool-loop reliably
+        # (~$0.10/$0.40 per 1M tokens, free tier available). Step up to
+        # gemini-2.5-flash if strategy quality looks weak.
+        "gemini": "gemini-2.5-flash-lite",
     },
     "fallback_chains": {
         "openai": [
@@ -138,11 +141,11 @@ _DEFAULT_MODEL_ROUTING = {
             # Groq's free tier has a tight per-minute token budget; fall back to
             # Gemini (free, large context) before any paid provider so a request
             # too large for Groq still completes for free.
-            {"provider": "gemini", "model_id": "gemini-2.5-flash"},
+            {"provider": "gemini", "model_id": "gemini-2.5-flash-lite"},
             {"provider": "openai", "model_id": "gpt-5.2"},
         ],
         "gemini": [
-            {"provider": "gemini", "model_id": "gemini-2.5-flash"},
+            {"provider": "gemini", "model_id": "gemini-2.5-flash-lite"},
             {"provider": "openai", "model_id": "gpt-5.2"},
         ],
     },

--- a/frontend/src/lib/api/forven.ts
+++ b/frontend/src/lib/api/forven.ts
@@ -13,7 +13,9 @@ export type ForvenProvider =
 	| 'zai'
 	| 'openrouter'
 	| 'anthropic'
-	| 'deepseek';
+	| 'deepseek'
+	| 'groq'
+	| 'gemini';
 
 // ============== Forven Classic Compatibility ==============
 

--- a/frontend/src/lib/components/settings/sections/SettingsModels.svelte
+++ b/frontend/src/lib/components/settings/sections/SettingsModels.svelte
@@ -25,7 +25,7 @@
 	// Backup AI provider (wired setting). When an agent's primary provider's
 	// credentials become unusable, the call falls back to this provider instead of
 	// failing; 'none' disables fallback (the routine is then paused + an alert raised).
-	const BACKUP_PROVIDER_CHOICES = ['openai', 'minimax', 'zai', 'lmstudio'];
+	const BACKUP_PROVIDER_CHOICES = ['openai', 'minimax', 'zai', 'lmstudio', 'groq', 'gemini'];
 	// Seed from the parent prop for first paint; load() then refreshes it from the
 	// LIVE settings so a revisit reflects the persisted choice (the parent's prop is
 	// loaded once and our save doesn't update it).

--- a/frontend/src/lib/components/wizard/SetupWizardModal.svelte
+++ b/frontend/src/lib/components/wizard/SetupWizardModal.svelte
@@ -214,6 +214,15 @@
 							visibleSubsections={TRADING_SUBS_WIZARD}
 						/>
 					{:else if step.id === 'ai'}
+						<div class="mb-4 rounded border border-cyan-900 bg-cyan-950/30 px-4 py-3 text-sm text-cyan-100">
+							<p class="font-semibold text-cyan-200">💡 On a budget? Recommended: Google Gemini → <span class="font-mono">gemini-2.5-flash-lite</span></p>
+							<ul class="mt-2 space-y-1 text-xs text-cyan-100/90 list-disc pl-5">
+								<li>Cheapest model that reliably runs Forven's agents (~$0.10 / $0.40 per 1M input/output tokens) and has a <strong>free tier</strong> to try.</li>
+								<li>Supports the tool-calling and large context the agents need.</li>
+								<li><strong>Caveat:</strong> it trades some reasoning depth for cost. If strategy quality looks weak, step up to <span class="font-mono">gemini-2.5-flash</span> (still far cheaper than the pro/3.x models).</li>
+								<li><strong>Free tiers rate-limit hard</strong> (and can hit a project spend cap). For a continuous research loop, expect to add a small paid budget — see <a href="https://ai.studio/spend" target="_blank" rel="noopener" class="underline">ai.studio/spend</a>.</li>
+							</ul>
+						</div>
 						<SettingsAgents {settings} variant="wizard" />
 					{:else if step.id === 'notifications'}
 						<SettingsNotifications {settings} />

--- a/frontend/src/routes/agents/+page.svelte
+++ b/frontend/src/routes/agents/+page.svelte
@@ -255,7 +255,11 @@
 			value === 'openai' ||
 			value === 'lmstudio' ||
 			value === 'zai' ||
-			value === 'openrouter'
+			value === 'openrouter' ||
+			value === 'anthropic' ||
+			value === 'deepseek' ||
+			value === 'groq' ||
+			value === 'gemini'
 		);
 	}
 
@@ -264,6 +268,10 @@
 		if (provider === 'minimax') return 'MiniMax';
 		if (provider === 'zai') return 'Z.AI';
 		if (provider === 'openrouter') return 'OpenRouter';
+		if (provider === 'anthropic') return 'Anthropic';
+		if (provider === 'deepseek') return 'DeepSeek';
+		if (provider === 'groq') return 'Groq';
+		if (provider === 'gemini') return 'Google Gemini';
 		return 'LM Studio';
 	}
 
@@ -299,7 +307,7 @@
 
 	function buildDefaultModelPresets() {
 		const resolved = new Map<string, AgentModelPreset>();
-		for (const provider of ['openai', 'minimax', 'lmstudio', 'zai', 'openrouter'] as AgentProvider[]) {
+		for (const provider of ['openai', 'minimax', 'lmstudio', 'zai', 'openrouter', 'anthropic', 'deepseek', 'groq', 'gemini'] as AgentProvider[]) {
 			const defaultPreset = resolveDefaultModelPreset(provider);
 			if (defaultPreset) {
 				resolved.set(defaultPreset.key, defaultPreset);

--- a/tests/test_api_core_auth.py
+++ b/tests/test_api_core_auth.py
@@ -63,6 +63,73 @@ def test_lmstudio_test_provider_calls_local_models_endpoint(monkeypatch):
     assert "2 models discovered" in str(result["message"])
 
 
+def _make_fake_client(status: int, json_body: dict | None = None):
+    """Return an httpx.Client stand-in whose GET yields a fixed status/body."""
+
+    class _FakeClient:
+        def __init__(self, timeout: float | None = None):
+            self.timeout = timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, url: str, headers: dict | None = None):
+            return httpx.Response(
+                status,
+                json=json_body if json_body is not None else {},
+                request=httpx.Request("GET", url),
+            )
+
+    return _FakeClient
+
+
+def test_test_provider_accepts_valid_key(monkeypatch):
+    monkeypatch.setattr(api_core, "get_profile", lambda provider: {"api_key": "gsk-real"})
+    monkeypatch.setattr(api_core, "get_token", lambda provider: "gsk-real")
+    monkeypatch.setattr(
+        api_core.httpx,
+        "Client",
+        _make_fake_client(200, {"data": [{"id": "llama-3.3-70b-versatile"}]}),
+    )
+
+    result = api_core.test_auth_provider("groq")
+
+    assert result["ok"] is True
+    assert result["provider"] == "groq"
+    assert "Connected" in str(result["message"])
+
+
+def test_test_provider_rejects_invalid_key_401(monkeypatch):
+    import pytest
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(api_core, "get_profile", lambda provider: {"api_key": "garbage"})
+    monkeypatch.setattr(api_core, "get_token", lambda provider: "garbage")
+    monkeypatch.setattr(api_core.httpx, "Client", _make_fake_client(401))
+
+    with pytest.raises(HTTPException) as excinfo:
+        api_core.test_auth_provider("groq")
+    assert excinfo.value.status_code == 400
+    assert "invalid api key" in str(excinfo.value.detail).lower()
+
+
+def test_test_provider_rejects_invalid_key_400(monkeypatch):
+    """Gemini returns HTTP 400 for a bad key — must still fail the test."""
+    import pytest
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(api_core, "get_profile", lambda provider: {"api_key": "garbage"})
+    monkeypatch.setattr(api_core, "get_token", lambda provider: "garbage")
+    monkeypatch.setattr(api_core.httpx, "Client", _make_fake_client(400))
+
+    with pytest.raises(HTTPException) as excinfo:
+        api_core.test_auth_provider("gemini")
+    assert excinfo.value.status_code == 400
+
+
 def test_normalize_provider_and_model_preserves_lmstudio_provider():
     provider, model = ai.normalize_provider_and_model("lmstudio", "qwen-local")
 

--- a/tests/test_api_core_auth.py
+++ b/tests/test_api_core_auth.py
@@ -86,6 +86,56 @@ def _make_fake_client(status: int, json_body: dict | None = None):
     return _FakeClient
 
 
+def test_upsert_rejects_invalid_key_at_save(monkeypatch):
+    import pytest
+    from fastapi import HTTPException
+
+    saved_profiles: dict[str, dict] = {}
+    monkeypatch.setattr(api_core, "get_profile", lambda provider: saved_profiles.get(provider))
+    monkeypatch.setattr(
+        api_core, "upsert_profile", lambda p, prof: saved_profiles.__setitem__(p, dict(prof))
+    )
+    monkeypatch.setattr(api_core.httpx, "Client", _make_fake_client(401))
+
+    with pytest.raises(HTTPException) as excinfo:
+        api_core.upsert_auth_provider(
+            "groq", api_core.AuthProviderProfileBody(api_key="garbage")
+        )
+    assert excinfo.value.status_code == 400
+    assert "groq" not in saved_profiles  # nothing persisted on rejection
+
+
+def test_upsert_accepts_valid_key_at_save(monkeypatch):
+    saved_profiles: dict[str, dict] = {}
+    monkeypatch.setattr(api_core, "get_profile", lambda provider: saved_profiles.get(provider))
+    monkeypatch.setattr(
+        api_core, "upsert_profile", lambda p, prof: saved_profiles.__setitem__(p, dict(prof))
+    )
+    monkeypatch.setattr(api_core.httpx, "Client", _make_fake_client(200, {"data": [{"id": "gemini-2.5-flash"}]}))
+
+    result = api_core.upsert_auth_provider(
+        "gemini", api_core.AuthProviderProfileBody(api_key="AIza-real")
+    )
+    assert result == {"ok": True, "provider": "gemini"}
+    assert saved_profiles["gemini"]["access"] == "AIza-real"
+
+
+def test_upsert_tolerates_unreachable_at_save(monkeypatch):
+    """A network/transient failure must NOT block a legitimate save."""
+    saved_profiles: dict[str, dict] = {}
+    monkeypatch.setattr(api_core, "get_profile", lambda provider: saved_profiles.get(provider))
+    monkeypatch.setattr(
+        api_core, "upsert_profile", lambda p, prof: saved_profiles.__setitem__(p, dict(prof))
+    )
+    monkeypatch.setattr(api_core.httpx, "Client", _make_fake_client(503))  # transient
+
+    result = api_core.upsert_auth_provider(
+        "groq", api_core.AuthProviderProfileBody(api_key="gsk-maybe-fine")
+    )
+    assert result == {"ok": True, "provider": "groq"}
+    assert saved_profiles["groq"]["access"] == "gsk-maybe-fine"
+
+
 def test_test_provider_accepts_valid_key(monkeypatch):
     monkeypatch.setattr(api_core, "get_profile", lambda provider: {"api_key": "gsk-real"})
     monkeypatch.setattr(api_core, "get_token", lambda provider: "gsk-real")

--- a/tests/test_model_discovery_rules.py
+++ b/tests/test_model_discovery_rules.py
@@ -1,0 +1,82 @@
+"""Discovery belong-rules for auto-updating model lists.
+
+Covers the provider /models → catalog pipeline added for Anthropic, Groq, and
+Gemini so new releases (e.g. a newer Claude Opus) surface without a catalog
+edit. These are pure functions — no network — exercising the id extraction and
+the per-provider "belongs to this provider" filter.
+"""
+
+from __future__ import annotations
+
+from forven import api_core as ac
+
+
+def test_gemini_models_prefix_is_stripped() -> None:
+    # Gemini's compat /models returns "models/<id>"; the chat endpoint wants bare.
+    assert ac._normalize_model_id("models/gemini-2.5-flash") == "gemini-2.5-flash"
+    assert ac._normalize_model_id("gemini-2.5-flash") == "gemini-2.5-flash"
+    assert ac._normalize_model_id("  claude-opus-4-8  ") == "claude-opus-4-8"
+
+
+def test_anthropic_belong_rule() -> None:
+    assert ac._discovery_model_should_belong("anthropic", "claude-opus-4-8")
+    assert ac._discovery_model_should_belong("anthropic", "claude-sonnet-4-6")
+    assert not ac._discovery_model_should_belong("anthropic", "text-embedding-3")
+
+
+def test_groq_belong_rule_rejects_display_names_and_non_chat() -> None:
+    # Real callable ids (lowercase slugs, optional vendor/ prefix) are kept.
+    assert ac._discovery_model_should_belong("groq", "llama-3.3-70b-versatile")
+    assert ac._discovery_model_should_belong("groq", "openai/gpt-oss-120b")
+    assert ac._discovery_model_should_belong("groq", "moonshotai/kimi-k2-instruct")
+    # Display names (spaces / uppercase) that Groq also returns are rejected.
+    assert not ac._discovery_model_should_belong("groq", "Llama 3.3 70B")
+    assert not ac._discovery_model_should_belong("groq", "GPT OSS 120B")
+    # Non-chat modalities are rejected.
+    assert not ac._discovery_model_should_belong("groq", "whisper-large-v3")
+    assert not ac._discovery_model_should_belong("groq", "canopylabs/orpheus-v1-english")
+    assert not ac._discovery_model_should_belong("groq", "meta-llama/llama-guard-4-12b")
+
+
+def test_gemini_belong_rule_keeps_chat_drops_other_modalities() -> None:
+    assert ac._discovery_model_should_belong("gemini", "gemini-2.5-flash")
+    assert ac._discovery_model_should_belong("gemini", "gemini-3-pro-preview")
+    # Non-text modalities / different APIs are dropped.
+    assert not ac._discovery_model_should_belong("gemini", "gemini-embedding-001")
+    assert not ac._discovery_model_should_belong("gemini", "gemini-2.5-flash-image")
+    assert not ac._discovery_model_should_belong("gemini", "gemini-3.1-flash-live-preview")
+    assert not ac._discovery_model_should_belong("gemini", "gemini-robotics-er-1.5-preview")
+    assert not ac._discovery_model_should_belong("gemini", "text-embedding-004")
+
+
+def test_unwired_provider_still_returns_false() -> None:
+    # Providers without a belong-rule fall back to the static catalog.
+    assert not ac._discovery_model_should_belong("openrouter", "anthropic/claude-sonnet-4")
+
+
+def test_extract_anthropic_models_payload() -> None:
+    payload = {
+        "data": [
+            {"type": "model", "id": "claude-opus-4-8", "display_name": "Claude Opus 4.8"},
+            {"type": "model", "id": "claude-sonnet-4-6", "display_name": "Claude Sonnet 4.6"},
+        ],
+        "has_more": False,
+    }
+    assert ac._extract_discovery_models(payload, "anthropic") == [
+        "claude-opus-4-8",
+        "claude-sonnet-4-6",
+    ]
+
+
+def test_extract_groq_payload_drops_display_name_pollution() -> None:
+    # Groq returns both a callable id and a human display name; only the id stays.
+    payload = {
+        "data": [
+            {"id": "llama-3.3-70b-versatile", "name": "Llama 3.3 70B"},
+            {"id": "openai/gpt-oss-120b", "name": "GPT OSS 120B"},
+        ]
+    }
+    assert ac._extract_discovery_models(payload, "groq") == [
+        "llama-3.3-70b-versatile",
+        "openai/gpt-oss-120b",
+    ]

--- a/tests/test_model_discovery_rules.py
+++ b/tests/test_model_discovery_rules.py
@@ -49,6 +49,12 @@ def test_gemini_belong_rule_keeps_chat_drops_other_modalities() -> None:
     assert not ac._discovery_model_should_belong("gemini", "text-embedding-004")
 
 
+def test_deepseek_belong_rule() -> None:
+    assert ac._discovery_model_should_belong("deepseek", "deepseek-chat")
+    assert ac._discovery_model_should_belong("deepseek", "deepseek-reasoner")
+    assert not ac._discovery_model_should_belong("deepseek", "gpt-4o")
+
+
 def test_unwired_provider_still_returns_false() -> None:
     # Providers without a belong-rule fall back to the static catalog.
     assert not ac._discovery_model_should_belong("openrouter", "anthropic/claude-sonnet-4")

--- a/tests/test_provider_gemini.py
+++ b/tests/test_provider_gemini.py
@@ -1,0 +1,144 @@
+"""GeminiProvider unit tests.
+
+Confirms the Google Gemini round-trip via its OpenAI-compatible endpoint:
+- inherits OpenAI function-calling format,
+- ``ENDPOINT`` resolves through the profile-driven base URL,
+- ``base_url`` profile override redirects the request,
+- factory wiring resolves ``gemini`` to ``GeminiProvider``.
+
+Gemini's OpenAI-compatible base URL already includes ``/v1beta/openai``, so
+``ENDPOINT`` appends only ``/chat/completions``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from forven.agents.providers import (
+    GeminiProvider,
+    OpenAIProvider,
+    ProviderResponse,
+    ToolCall,
+    get_provider,
+)
+
+
+def _mock_chat_completion(
+    content: str = "",
+    tool_calls: list[dict] | None = None,
+) -> MagicMock:
+    message: dict = {"content": content}
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = MagicMock(return_value={
+        "choices": [{"message": message, "finish_reason": "tool_calls" if tool_calls else "stop"}],
+        "usage": {"prompt_tokens": 11, "completion_tokens": 22, "total_tokens": 33},
+    })
+    return resp
+
+
+def test_factory_resolves_gemini() -> None:
+    provider = get_provider("gemini")
+    assert isinstance(provider, GeminiProvider)
+    assert isinstance(provider, OpenAIProvider)
+
+
+def test_gemini_default_endpoint() -> None:
+    with patch("forven.agents.providers.get_profile", return_value=None):
+        provider = GeminiProvider()
+        assert provider.ENDPOINT == (
+            "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
+        )
+
+
+def test_gemini_endpoint_override() -> None:
+    with patch(
+        "forven.agents.providers.get_profile",
+        return_value={"base_url": "https://proxy.example.com/"},
+    ):
+        provider = GeminiProvider()
+        assert provider.ENDPOINT == "https://proxy.example.com/chat/completions"
+
+
+def test_gemini_call_returns_tool_calls() -> None:
+    provider = GeminiProvider()
+    raw_tc = [{
+        "id": "call_xyz",
+        "type": "function",
+        "function": {
+            "name": "list_strategies",
+            "arguments": json.dumps({"limit": 5}),
+        },
+    }]
+    fake_resp = _mock_chat_completion(content="Calling tool.", tool_calls=raw_tc)
+
+    mock_client = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(return_value=fake_resp)
+
+    with patch("forven.agents.providers.httpx.AsyncClient", return_value=mock_client), \
+         patch("forven.agents.providers.get_profile", return_value=None):
+        result = asyncio.run(provider.call(
+            model_id="gemini-2.5-flash",
+            messages=[{"role": "user", "content": "list strategies"}],
+            system="you are helpful",
+            tools=[{"name": "list_strategies", "description": "x", "input_schema": {}}],
+            token="gemini-test-key",
+        ))
+
+    assert isinstance(result, ProviderResponse)
+    assert "Calling tool." in result.text
+    assert len(result.tool_calls) == 1
+    call = result.tool_calls[0]
+    assert isinstance(call, ToolCall)
+    assert call.id == "call_xyz"
+    assert call.name == "list_strategies"
+    assert call.input == {"limit": 5}
+    assert result.stop is False  # tool calls present
+
+    # Verify request shape
+    call_args = mock_client.post.call_args
+    assert call_args[0][0] == (
+        "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
+    )
+    headers = call_args[1]["headers"]
+    assert headers["Authorization"] == "Bearer gemini-test-key"
+    body = call_args[1]["json"]
+    assert body["model"] == "gemini-2.5-flash"
+    # System prepended into messages array (OpenAI format)
+    assert body["messages"][0] == {"role": "system", "content": "you are helpful"}
+    assert body["tools"][0]["type"] == "function"
+    assert body["tools"][0]["function"]["name"] == "list_strategies"
+    assert body["tool_choice"] == "auto"
+
+
+def test_gemini_endpoint_override_routes_request() -> None:
+    """Profile base_url override must reach the actual HTTP call site."""
+    provider = GeminiProvider()
+    fake_resp = _mock_chat_completion(content="ok")
+
+    mock_client = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(return_value=fake_resp)
+
+    with patch("forven.agents.providers.httpx.AsyncClient", return_value=mock_client), \
+         patch(
+             "forven.agents.providers.get_profile",
+             return_value={"base_url": "https://proxy.example.com"},
+         ):
+        asyncio.run(provider.call(
+            model_id="gemini-2.0-flash",
+            messages=[{"role": "user", "content": "hi"}],
+            system="",
+            tools=[],
+            token="gemini",
+        ))
+
+    call_args = mock_client.post.call_args
+    assert call_args[0][0] == "https://proxy.example.com/chat/completions"

--- a/tests/test_provider_groq.py
+++ b/tests/test_provider_groq.py
@@ -1,0 +1,140 @@
+"""GroqProvider unit tests.
+
+Confirms the Groq Chat Completions round-trip:
+- inherits OpenAI function-calling format,
+- ``ENDPOINT`` resolves through the profile-driven base URL,
+- ``base_url`` profile override redirects the request,
+- factory wiring resolves ``groq`` to ``GroqProvider``.
+
+Groq exposes an OpenAI-compatible endpoint whose base URL already includes
+``/openai/v1``, so ``ENDPOINT`` appends only ``/chat/completions``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from forven.agents.providers import (
+    GroqProvider,
+    OpenAIProvider,
+    ProviderResponse,
+    ToolCall,
+    get_provider,
+)
+
+
+def _mock_chat_completion(
+    content: str = "",
+    tool_calls: list[dict] | None = None,
+) -> MagicMock:
+    message: dict = {"content": content}
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = MagicMock(return_value={
+        "choices": [{"message": message, "finish_reason": "tool_calls" if tool_calls else "stop"}],
+        "usage": {"prompt_tokens": 11, "completion_tokens": 22, "total_tokens": 33},
+    })
+    return resp
+
+
+def test_factory_resolves_groq() -> None:
+    provider = get_provider("groq")
+    assert isinstance(provider, GroqProvider)
+    assert isinstance(provider, OpenAIProvider)
+
+
+def test_groq_default_endpoint() -> None:
+    with patch("forven.agents.providers.get_profile", return_value=None):
+        provider = GroqProvider()
+        assert provider.ENDPOINT == "https://api.groq.com/openai/v1/chat/completions"
+
+
+def test_groq_endpoint_override() -> None:
+    with patch(
+        "forven.agents.providers.get_profile",
+        return_value={"base_url": "https://proxy.example.com/"},
+    ):
+        provider = GroqProvider()
+        assert provider.ENDPOINT == "https://proxy.example.com/chat/completions"
+
+
+def test_groq_call_returns_tool_calls() -> None:
+    provider = GroqProvider()
+    raw_tc = [{
+        "id": "call_xyz",
+        "type": "function",
+        "function": {
+            "name": "list_strategies",
+            "arguments": json.dumps({"limit": 5}),
+        },
+    }]
+    fake_resp = _mock_chat_completion(content="Calling tool.", tool_calls=raw_tc)
+
+    mock_client = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(return_value=fake_resp)
+
+    with patch("forven.agents.providers.httpx.AsyncClient", return_value=mock_client), \
+         patch("forven.agents.providers.get_profile", return_value=None):
+        result = asyncio.run(provider.call(
+            model_id="llama-3.3-70b-versatile",
+            messages=[{"role": "user", "content": "list strategies"}],
+            system="you are helpful",
+            tools=[{"name": "list_strategies", "description": "x", "input_schema": {}}],
+            token="gsk-groq-test",
+        ))
+
+    assert isinstance(result, ProviderResponse)
+    assert "Calling tool." in result.text
+    assert len(result.tool_calls) == 1
+    call = result.tool_calls[0]
+    assert isinstance(call, ToolCall)
+    assert call.id == "call_xyz"
+    assert call.name == "list_strategies"
+    assert call.input == {"limit": 5}
+    assert result.stop is False  # tool calls present
+
+    # Verify request shape
+    call_args = mock_client.post.call_args
+    assert call_args[0][0] == "https://api.groq.com/openai/v1/chat/completions"
+    headers = call_args[1]["headers"]
+    assert headers["Authorization"] == "Bearer gsk-groq-test"
+    body = call_args[1]["json"]
+    assert body["model"] == "llama-3.3-70b-versatile"
+    # System prepended into messages array (OpenAI format)
+    assert body["messages"][0] == {"role": "system", "content": "you are helpful"}
+    assert body["tools"][0]["type"] == "function"
+    assert body["tools"][0]["function"]["name"] == "list_strategies"
+    assert body["tool_choice"] == "auto"
+
+
+def test_groq_endpoint_override_routes_request() -> None:
+    """Profile base_url override must reach the actual HTTP call site."""
+    provider = GroqProvider()
+    fake_resp = _mock_chat_completion(content="ok")
+
+    mock_client = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(return_value=fake_resp)
+
+    with patch("forven.agents.providers.httpx.AsyncClient", return_value=mock_client), \
+         patch(
+             "forven.agents.providers.get_profile",
+             return_value={"base_url": "https://proxy.example.com"},
+         ):
+        asyncio.run(provider.call(
+            model_id="llama-3.1-8b-instant",
+            messages=[{"role": "user", "content": "hi"}],
+            system="",
+            tools=[],
+            token="gsk",
+        ))
+
+    call_args = mock_client.post.call_args
+    assert call_args[0][0] == "https://proxy.example.com/chat/completions"

--- a/tests/test_request_too_large.py
+++ b/tests/test_request_too_large.py
@@ -53,6 +53,38 @@ def test_genuine_rate_limit_still_classified():
     assert ai._is_rate_limit_exception(err) is True
 
 
+GEMINI_SPEND_CAP = (
+    "Error code: 429 - [{'error': {'code': 429, 'message': 'Your project has "
+    "exceeded its monthly spending cap. Please go to AI Studio at "
+    "https://ai.studio/spend to manage your project spend cap.', "
+    "'status': 'RESOURCE_EXHAUSTED'}}]"
+)
+
+
+def test_quota_exhausted_detects_spend_cap():
+    err = _http_error(429, GEMINI_SPEND_CAP)
+    assert ai._is_quota_exhausted(err) is True
+
+
+def test_quota_exhausted_detects_out_of_credits_and_insufficient_quota():
+    assert ai._is_quota_exhausted(RuntimeError("You're out of credits"))
+    assert ai._is_quota_exhausted(RuntimeError("error code: insufficient_quota"))
+
+
+def test_generic_rate_limit_is_not_quota_exhausted():
+    # A transient per-minute throttle must NOT be treated as persistent
+    # exhaustion (which would apply a 30+ minute backoff).
+    err = _http_error(429, "Rate limit reached for requests. Please try again in 1s.")
+    assert ai._is_quota_exhausted(err) is False
+    assert ai._is_rate_limit_exception(err) is True
+
+
+def test_spend_cap_is_not_request_too_large():
+    err = _http_error(429, GEMINI_SPEND_CAP)
+    assert ai._is_request_too_large(err) is False
+    assert ai._is_quota_exhausted(err) is True
+
+
 def test_groq_fallback_chain_routes_to_gemini():
     from forven.model_routing import get_fallback_chain
 
@@ -61,3 +93,26 @@ def test_groq_fallback_chain_routes_to_gemini():
     assert "gemini" in providers
     # Gemini (free, large context) must come before any paid provider.
     assert providers.index("gemini") < providers.index("openai")
+
+
+def test_provider_quota_alert_dedupes(forven_db):
+    """A persistent-exhaustion alert is raised once per provider per cooldown."""
+    from forven.agents.runner import _emit_provider_quota_alert
+    from forven.db import get_db
+
+    _emit_provider_quota_alert("gemini", "spend cap exceeded")
+    _emit_provider_quota_alert("gemini", "spend cap exceeded again")  # within cooldown
+
+    with get_db() as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) AS c FROM activity_log WHERE source = 'provider:gemini'"
+        ).fetchone()["c"]
+    assert count == 1  # second call deduped, not flooding
+
+    # A different provider is tracked independently.
+    _emit_provider_quota_alert("groq", "out of credits")
+    with get_db() as conn:
+        groq_count = conn.execute(
+            "SELECT COUNT(*) AS c FROM activity_log WHERE source = 'provider:groq'"
+        ).fetchone()["c"]
+    assert groq_count == 1

--- a/tests/test_request_too_large.py
+++ b/tests/test_request_too_large.py
@@ -1,0 +1,63 @@
+"""A 413 "request too large" must not be treated as a retryable rate-limit.
+
+Groq's free tier rejects a single request that exceeds its per-minute token
+budget with HTTP 413 and "rate limit" wording. Retrying the identical request
+can never succeed, so it must be excluded from the rate-limit class (which
+would otherwise requeue the task with minute-scale backoffs) and instead fall
+back to a higher-capacity provider.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from forven import ai
+
+
+def _http_error(status: int, message: str) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://api.groq.com/openai/v1/chat/completions")
+    response = httpx.Response(status, text=message, request=request)
+    return httpx.HTTPStatusError(message, request=request, response=response)
+
+
+GROQ_413 = (
+    "Request too large for model `llama-3.3-70b-versatile` in organization "
+    "org_x service tier `on_demand` on tokens per minute (TPM): Limit 12000, "
+    "Requested 13409, please reduce your message size and try again. "
+    "Code: rate_limit_exceeded"
+)
+
+
+def test_request_too_large_detected_by_status():
+    assert ai._is_request_too_large(_http_error(413, "anything"))
+
+
+def test_request_too_large_detected_by_message():
+    assert ai._is_request_too_large(_http_error(413, GROQ_413))
+    # Even without the 413 status, the wording alone is enough.
+    assert ai._is_request_too_large(RuntimeError(GROQ_413))
+
+
+def test_request_too_large_not_classified_as_rate_limit():
+    # The Groq 413 message contains "rate limit" / "rate_limit", but it must NOT
+    # be treated as a retryable rate-limit.
+    err = _http_error(413, GROQ_413)
+    assert ai._is_request_too_large(err) is True
+    assert ai._is_rate_limit_exception(err) is False
+
+
+def test_genuine_rate_limit_still_classified():
+    # A real 429 with no "too large" wording stays a retryable rate-limit.
+    err = _http_error(429, "Rate limit reached for requests. Please try again later.")
+    assert ai._is_request_too_large(err) is False
+    assert ai._is_rate_limit_exception(err) is True
+
+
+def test_groq_fallback_chain_routes_to_gemini():
+    from forven.model_routing import get_fallback_chain
+
+    chain = get_fallback_chain("groq")
+    providers = [entry[0] if isinstance(entry, tuple) else entry.get("provider") for entry in chain]
+    assert "gemini" in providers
+    # Gemini (free, large context) must come before any paid provider.
+    assert providers.index("gemini") < providers.index("openai")


### PR DESCRIPTION
## Summary

Adds **free / low-cost LLM provider support** (Groq + Google Gemini) and hardens provider handling along the way. Both providers expose OpenAI-compatible APIs, so they slot into the existing abstraction and work everywhere — Brain, agents, auxiliary tasks, deep-dive, and chat.

## What's included

**New providers**
- Groq and Google Gemini as first-class providers (tool-call path + simple-completion path). Credential UI auto-populates; keys via Settings → Agents or `GROQ_API_KEY` / `GEMINI_API_KEY`.

**Auto-updating model lists**
- Model lists are pulled live from each provider's `/models` API and merged with the curated catalog, so new releases appear without a code change.
- Wired for Anthropic, Groq, Gemini, and DeepSeek (previously only OpenAI/MiniMax/Z.AI). Non-chat models (audio/image/embeddings/moderation) and display-name noise are filtered out.

**Auth / validation**
- Connection **Test** now makes a real authenticated request and rejects invalid keys (401/403/400) instead of passing for any non-empty string.
- Invalid keys are rejected at **save time** too.

**Fixes**
- Agent Hub model picker now lists Anthropic/DeepSeek/Groq/Gemini (were dropped or mislabeled as "OpenAI").
- HTTP 413 "request too large" is treated as a capacity issue, not a rate-limit — fails fast and falls back (Groq → Gemini before any paid provider) instead of retrying for minutes.
- Persistent quota exhaustion (spend cap / out of credits) no longer floods alerts — long backoff + one deduped actionable alert per provider.

**Cheaper default**
- `gemini-2.5-flash-lite` is the default Gemini model (cheapest that still runs the agent tool-loop, ~17× cheaper than premium flash for this workload).
- Setup wizard recommends it with caveats (trades reasoning depth; free tiers rate-limit / can hit a spend cap).

## Testing
- New unit tests: provider adapters (Groq/Gemini), discovery filters, key validation (valid/401/400 + save path), 413 classification + fallback chain, quota-exhaustion classification + alert dedup.
- Verified live end-to-end: full tool loop on `gemini-2.5-flash-lite` through Forven's provider (tool call → result → final answer).
- Pre-existing `duckdb`-import test failure is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
