### PR TITLE
feat(exchange): ClawStreet adapter for public-leaderboard paper trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,25 @@ Forven uses **your** LLM provider and **your** exchange — configured locally a
 
 Add your Hyperliquid **testnet** credentials in the dashboard under `/settings`. No Forven account is required, and credentials never leave your machine.
 
+### ClawStreet adapter (optional, public-leaderboard paper trading)
+
+Forven also ships a [ClawStreet](https://clawstreet.io) exchange adapter at `forven/exchange/clawstreet.py` so promoted strategies can publish their trades and reasoning to a public paper-trading leaderboard. Register a bot via `register_bot()` (or the ClawStreet web UI), claim it once, then set:
+
+```bash
+export CLAWSTREET_API_KEY="<your-bot-key>"
+```
+
+The adapter mirrors the Hyperliquid module shape (`market_order`, `limit_order`, `cancel_order`, `get_positions`, `get_account_value`, `get_open_orders`), so existing call sites can target it by import. Crypto only by default (31 pairs mapped); stock tickers pass through if you want US equities.
+
+To run the live integration test against your bot:
+
+```bash
+export CLAWSTREET_TEST_API_KEY="<your-test-bot-key>"
+pytest tests/test_clawstreet_exchange_integration.py
+```
+
+The integration suite skips cleanly when the env var is unset, so CI for outside contributors does not require a ClawStreet account.
+
 ## Documentation
 
 - **Full docs:** **https://forven.app**

--- a/forven/exchange/clawstreet.py
+++ b/forven/exchange/clawstreet.py
@@ -1,0 +1,465 @@
+"""ClawStreet exchange connector — public paper-trading leaderboard.
+
+ClawStreet (https://clawstreet.io) is a public paper-trading leaderboard for AI
+agents. This adapter lets Forven-promoted strategies execute against a ClawStreet
+bot so their reasoning and trades are visible on the public feed in real time.
+
+Differences from the Hyperliquid adapter:
+
+* All money is paper; there is no testnet/mainnet distinction.
+* Universe: 31 crypto pairs (`X:BTCUSD` etc.) plus ~1,500 US stocks/ETFs. This
+  adapter exposes the crypto subset by default; stock symbols pass through
+  unchanged if requested explicitly.
+* Orders REQUIRE a public ``reasoning`` field. Forven strategies that don't
+  carry their reasoning into the execution call should set a static reason at
+  the strategy level before promotion.
+* No OCO / bracket orders. Native order types are ``market``, ``limit``,
+  ``stop``, ``trailing_stop``. Bracketed entries are synthesized by placing the
+  stop as a separate resting order after the entry fills.
+* Authentication: one API key per ClawStreet bot, presented as
+  ``Authorization: Bearer <key>``. Read ``CLAWSTREET_API_KEY`` from the
+  environment or pass ``api_key=`` explicitly.
+
+The adapter mirrors the Hyperliquid module shape (``market_order``,
+``limit_order``, ``cancel_order``, ``get_positions``, ``get_account_value``,
+``get_open_orders``) so callers in ``forven/scanner.py`` etc. can target it by
+swapping the import path.
+
+Follow-ups (intentionally out of scope for the first PR):
+
+* Wire the ClawStreet account into ``forven.circuit_breaker`` named breakers.
+* Add an MCP tool ``deploy_to_clawstreet(strategy_id, bot_id)`` once the
+  adapter lands.
+* Symbol mapping for the full US equity universe (currently crypto-only).
+* OCO synthesis for strategies that need bracketed stops/take-profit.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import httpx
+
+from forven.circuit_breaker import CircuitBreaker
+
+log = logging.getLogger("forven.exchange.clawstreet")
+
+
+# --------------------------------------------------------------------------- #
+# Endpoints
+# --------------------------------------------------------------------------- #
+
+# Legacy REST surface (sunsets 2026-09-13 per ClawStreet's docs). The new v1
+# surface at api.clawstreet.io requires an Idempotency-Key header on writes;
+# that's a follow-up once the adapter base ships.
+BASE_URL = "https://www.clawstreet.io/api"
+V1_BASE_URL = "https://api.clawstreet.io/v1"
+DEFAULT_TIMEOUT = 15.0
+
+# Breakers (mirroring the Hyperliquid naming convention).
+cs_trade_breaker = CircuitBreaker(name="clawstreet.trade", failure_threshold=5)
+cs_account_breaker = CircuitBreaker(name="clawstreet.account", failure_threshold=5)
+
+
+# --------------------------------------------------------------------------- #
+# Credential resolution
+# --------------------------------------------------------------------------- #
+
+
+def _get_api_key(api_key: str | None = None) -> str:
+    """Resolve the ClawStreet API key in order: explicit arg, env, raise."""
+    if api_key:
+        return api_key
+    env_key = os.environ.get("CLAWSTREET_API_KEY")
+    if env_key:
+        return env_key
+    raise RuntimeError(
+        "No ClawStreet API key available. Set CLAWSTREET_API_KEY in the "
+        "environment or pass api_key= to the adapter call."
+    )
+
+
+def _headers(api_key: str | None = None) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {_get_api_key(api_key)}",
+        "Content-Type": "application/json",
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Symbol normalization
+# --------------------------------------------------------------------------- #
+
+# Forven asset symbols → ClawStreet ticker form. ClawStreet uses the
+# "X:<base><quote>" convention for crypto and bare tickers for stocks. We treat
+# anything that already contains a colon as pre-formatted and pass it through.
+
+_CRYPTO_MAP = {
+    "BTC": "X:BTCUSD",
+    "ETH": "X:ETHUSD",
+    "SOL": "X:SOLUSD",
+    "AVAX": "X:AVAXUSD",
+    "MATIC": "X:MATICUSD",
+    "DOT": "X:DOTUSD",
+    "LINK": "X:LINKUSD",
+    "ADA": "X:ADAUSD",
+    "DOGE": "X:DOGEUSD",
+    "XRP": "X:XRPUSD",
+    "LTC": "X:LTCUSD",
+    "BCH": "X:BCHUSD",
+}
+
+
+def normalize_symbol(asset: str) -> str:
+    """Translate Forven's bare asset symbol to ClawStreet's ticker form.
+
+    Pre-formatted symbols (containing ``:``) and stock tickers are passed
+    through unchanged.
+    """
+    if ":" in asset:
+        return asset
+    upper = asset.upper()
+    return _CRYPTO_MAP.get(upper, upper)
+
+
+# --------------------------------------------------------------------------- #
+# Low-level HTTP
+# --------------------------------------------------------------------------- #
+
+
+def _request(
+    method: str,
+    path: str,
+    *,
+    api_key: str | None = None,
+    json_body: dict | None = None,
+    params: dict | None = None,
+    breaker: CircuitBreaker | None = None,
+    base: str = BASE_URL,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> dict:
+    """One-shot HTTP request against the ClawStreet API.
+
+    Uses the named circuit breaker when supplied. ClawStreet is paper-trading
+    and rate limits are generous (30/min for scan endpoints, 60/min default),
+    so this adapter does not implement bounded backoff in the first PR; a
+    breaker trip on persistent failure is sufficient.
+    """
+    url = f"{base.rstrip('/')}/{path.lstrip('/')}"
+    if breaker is not None and not breaker.can_execute():
+        raise RuntimeError(f"circuit breaker '{breaker.name}' is open")
+
+    # Connection-level errors (timeout, DNS, reset) are recorded by the outer
+    # except; response-level errors (status >= 400) are recorded inside the
+    # status check. Each request records at most ONE breaker failure.
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            resp = client.request(
+                method=method,
+                url=url,
+                headers=_headers(api_key),
+                json=json_body,
+                params=params,
+            )
+    except httpx.HTTPError as exc:
+        log.warning("ClawStreet %s %s connection error: %s", method, path, exc)
+        if breaker is not None:
+            breaker.record_failure()
+        raise
+
+    if resp.status_code >= 400:
+        log.warning(
+            "ClawStreet %s %s returned %s", method, path, resp.status_code
+        )
+        if breaker is not None:
+            breaker.record_failure()
+        raise httpx.HTTPStatusError(
+            f"ClawStreet {method} {path} returned {resp.status_code}: {resp.text[:200]}",
+            request=resp.request,
+            response=resp,
+        )
+
+    if breaker is not None:
+        breaker.record_success()
+    # 204 No Content has no body.
+    if resp.status_code == 204:
+        return {}
+    return resp.json()
+
+
+# --------------------------------------------------------------------------- #
+# Account state (mirrors HL get_account_value / get_positions / get_open_orders)
+# --------------------------------------------------------------------------- #
+
+
+def get_account_value(*, api_key: str | None = None) -> float:
+    """Return total equity (cash + market value of positions) in USD."""
+    payload = _request("GET", "v2/portfolio", api_key=api_key, breaker=cs_account_breaker)
+    return float(payload.get("equity", 0.0))
+
+
+def get_cash(*, api_key: str | None = None) -> float:
+    """Return cash balance only (without marked-to-market positions)."""
+    payload = _request("GET", "v2/portfolio", api_key=api_key, breaker=cs_account_breaker)
+    return float(payload.get("cash", 0.0))
+
+
+def get_positions(*, api_key: str | None = None) -> list[dict]:
+    """Return the list of open positions with mark-to-market values."""
+    payload = _request("GET", "v2/portfolio", api_key=api_key, breaker=cs_account_breaker)
+    return list(payload.get("positions") or [])
+
+
+def get_open_orders(*, api_key: str | None = None) -> list[dict]:
+    """Return the list of pending (unfilled) orders."""
+    payload = _request(
+        "GET",
+        "v2/orders",
+        api_key=api_key,
+        params={"status": "pending"},
+        breaker=cs_account_breaker,
+    )
+    orders = payload.get("orders") if isinstance(payload, dict) else payload
+    return list(orders or [])
+
+
+def get_me(*, api_key: str | None = None) -> dict:
+    """Return the bot identity payload (``/api/me``).
+
+    Use to verify the key resolves to the expected bot before placing orders.
+    """
+    return _request("GET", "me", api_key=api_key, breaker=cs_account_breaker)
+
+
+# --------------------------------------------------------------------------- #
+# Order placement (mirrors HL market_order / limit_order)
+# --------------------------------------------------------------------------- #
+
+
+def market_order(
+    asset: str,
+    side: str,
+    qty: float,
+    reasoning: str,
+    *,
+    api_key: str | None = None,
+) -> dict:
+    """Place a market order.
+
+    ``reasoning`` is a public field shown on the leaderboard feed and is
+    required by ClawStreet's API. ``side`` is one of ``buy``, ``sell``,
+    ``short``, ``cover``.
+    """
+    body = {
+        "symbol": normalize_symbol(asset),
+        "side": side,
+        "qty": qty,
+        "order_type": "market",
+        "reasoning": reasoning,
+    }
+    return _request(
+        "POST", "v2/orders", api_key=api_key, json_body=body, breaker=cs_trade_breaker
+    )
+
+
+def limit_order(
+    asset: str,
+    side: str,
+    qty: float,
+    limit_price: float,
+    reasoning: str,
+    *,
+    time_in_force: str = "GTC",
+    api_key: str | None = None,
+) -> dict:
+    """Place a limit order with the given limit price and TIF (GTC/DAY/IOC)."""
+    body = {
+        "symbol": normalize_symbol(asset),
+        "side": side,
+        "qty": qty,
+        "order_type": "limit",
+        "limit_price": limit_price,
+        "time_in_force": time_in_force,
+        "reasoning": reasoning,
+    }
+    return _request(
+        "POST", "v2/orders", api_key=api_key, json_body=body, breaker=cs_trade_breaker
+    )
+
+
+def stop_order(
+    asset: str,
+    side: str,
+    qty: float,
+    stop_price: float,
+    reasoning: str,
+    *,
+    time_in_force: str = "GTC",
+    api_key: str | None = None,
+) -> dict:
+    """Place a protective stop order (executes at market when ``stop_price`` hits)."""
+    body = {
+        "symbol": normalize_symbol(asset),
+        "side": side,
+        "qty": qty,
+        "order_type": "stop",
+        "stop_price": stop_price,
+        "time_in_force": time_in_force,
+        "reasoning": reasoning,
+    }
+    return _request(
+        "POST", "v2/orders", api_key=api_key, json_body=body, breaker=cs_trade_breaker
+    )
+
+
+def trailing_stop(
+    asset: str,
+    side: str,
+    qty: float,
+    trail_pct: float,
+    reasoning: str,
+    *,
+    time_in_force: str = "GTC",
+    api_key: str | None = None,
+) -> dict:
+    """Place a trailing-stop order (ratchets the trigger by ``trail_pct``)."""
+    body = {
+        "symbol": normalize_symbol(asset),
+        "side": side,
+        "qty": qty,
+        "order_type": "trailing_stop",
+        "trail_pct": trail_pct,
+        "time_in_force": time_in_force,
+        "reasoning": reasoning,
+    }
+    return _request(
+        "POST", "v2/orders", api_key=api_key, json_body=body, breaker=cs_trade_breaker
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Order management (mirrors HL cancel_order / cancel_all_orders / close_position)
+# --------------------------------------------------------------------------- #
+
+
+def cancel_order(order_id: str, *, api_key: str | None = None) -> dict:
+    """Cancel a single pending order by ID."""
+    return _request(
+        "DELETE", f"v2/orders/{order_id}", api_key=api_key, breaker=cs_trade_breaker
+    )
+
+
+def cancel_all_orders(*, api_key: str | None = None) -> list[dict]:
+    """Cancel every pending order on the bot. Returns the list of results."""
+    pending = get_open_orders(api_key=api_key)
+    results = []
+    for order in pending:
+        order_id = order.get("id")
+        if not order_id:
+            continue
+        try:
+            results.append(cancel_order(order_id, api_key=api_key))
+        except Exception as exc:  # noqa: BLE001
+            log.warning("cancel_order(%s) failed: %s", order_id, exc)
+            results.append({"order_id": order_id, "error": str(exc)})
+    return results
+
+
+def close_position(
+    asset: str,
+    reasoning: str,
+    *,
+    qty: float | None = None,
+    api_key: str | None = None,
+) -> dict:
+    """Close (or trim) an open position.
+
+    Omitting ``qty`` flattens the position; passing a positive number trims by
+    that quantity. ClawStreet picks ``sell`` vs ``cover`` automatically based on
+    the current sign of the position, so callers don't need to know whether
+    they're long or short.
+    """
+    symbol = normalize_symbol(asset)
+    body: dict[str, Any] = {"reasoning": reasoning}
+    if qty is not None:
+        body["qty"] = qty
+    return _request(
+        "POST",
+        f"v2/positions/{symbol}/close",
+        api_key=api_key,
+        json_body=body,
+        breaker=cs_trade_breaker,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Feed bridging (ClawStreet-specific; no Hyperliquid equivalent)
+# --------------------------------------------------------------------------- #
+
+
+def post_thought(
+    bot_id: str, thought: str, *, api_key: str | None = None
+) -> dict:
+    """Post a substantive narrative to the public ClawStreet feed.
+
+    The 500-character cap is enforced server-side (``THOUGHT_TOO_LONG``); long
+    inputs are sent verbatim and the caller catches the rejection.
+    """
+    return _request(
+        "POST",
+        f"bots/{bot_id}/thoughts",
+        api_key=api_key,
+        json_body={"thought": thought},
+        breaker=cs_account_breaker,
+    )
+
+
+def delete_thought(thought_id: str, *, api_key: str | None = None) -> dict:
+    """Delete a previously-posted thought (1.32.0+; author-only; cascades comments)."""
+    return _request(
+        "DELETE",
+        f"thoughts/{thought_id}",
+        api_key=api_key,
+        breaker=cs_account_breaker,
+        base=V1_BASE_URL,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Bot lifecycle (run once per Forven-promoted strategy)
+# --------------------------------------------------------------------------- #
+
+
+def register_bot(
+    name: str,
+    ticker: str,
+    strategy: str,
+    personality: str,
+    bio: str,
+    model: str,
+    framework: str = "Forven",
+    tags: list[str] | None = None,
+) -> dict:
+    """Register a new ClawStreet bot for a Forven-promoted strategy.
+
+    The response includes ``api_key`` exactly once — store it in the operator's
+    secret store immediately. The operator then claims the bot at
+    ``claim_url`` via X or email, after which the bot can place orders.
+    """
+    body = {
+        "name": name,
+        "ticker": ticker,
+        "strategy": strategy,
+        "personality": personality,
+        "bio": bio,
+        "model": model,
+        "framework": framework,
+        "tags": tags or [],
+    }
+    url = f"{BASE_URL.rstrip('/')}/bots/register"
+    with httpx.Client(timeout=DEFAULT_TIMEOUT) as client:
+        resp = client.post(url, json=body)
+    resp.raise_for_status()
+    return resp.json()

--- a/forven/exchange/clawstreet_paper.py
+++ b/forven/exchange/clawstreet_paper.py
@@ -1,0 +1,400 @@
+"""Forven-compatible wrapper around the ClawStreet adapter.
+
+This module exposes the same public API as ``forven/exchange/hyperliquid.py``
+so Forven's scanner can call it as a drop-in for the ``paper`` execution mode.
+The maintainer still has to wire it into ``forven.config.get_execution_mode``
+or the import path (see PR #10 thread for the architecture decision), but with
+this shim in place, the routing change becomes a one-line config switch rather
+than a code rewrite.
+
+Why a separate module instead of changing the pure adapter:
+
+* ``forven/exchange/clawstreet.py`` mirrors ClawStreet's actual REST API
+  shape (CCXT-flavored). It is reusable outside Forven.
+* This module maps Forven's internal call convention (``size``,
+  ``stop_loss_price``, ``take_profit_price``, ``idempotency_key``,
+  ``testnet``, ``vault_address``) onto that adapter. ClawStreet has no native
+  OCO, so the bracketed entry + stop + TP are synthesized as three separate
+  orders.
+
+Differences from Hyperliquid worth flagging:
+
+* ``testnet`` is accepted and ignored (ClawStreet is paper-only).
+* ``vault_address`` is accepted and ignored (no sub-account routing on
+  ClawStreet).
+* ``idempotency_key`` is logged but not yet used (the v1 surface honors it;
+  this module currently targets the legacy ``/api/*``).
+* ``stop_loss_price`` and ``take_profit_price`` become separate resting
+  orders. If the entry partial-fills, the stop/TP sizes are NOT auto-resized;
+  the caller's reconciliation loop has to handle that (same as Hyperliquid's
+  partial-fill semantics).
+* ``slippage_bps`` on ``close_position`` is accepted and ignored (paper fills
+  use the platform's slippage model already).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from forven.exchange import clawstreet
+
+log = logging.getLogger("forven.exchange.clawstreet_paper")
+
+
+# --------------------------------------------------------------------------- #
+# Side translation: Forven uses "long"/"short"/"buy"/"sell"; ClawStreet uses
+# "buy"/"sell"/"short"/"cover".
+# --------------------------------------------------------------------------- #
+
+
+def _entry_side(forven_side: str) -> str:
+    """Translate a Forven entry direction to a ClawStreet ``side``."""
+    s = (forven_side or "").strip().lower()
+    if s in {"b", "buy", "long"}:
+        return "buy"
+    if s in {"s", "sell", "short"}:
+        return "short"
+    raise ValueError(f"unknown Forven side: {forven_side!r}")
+
+
+def _exit_side(entry_side: str) -> str:
+    """The side used to flatten/protect a position opened with ``entry_side``."""
+    return "sell" if entry_side == "buy" else "cover"
+
+
+# --------------------------------------------------------------------------- #
+# Default reasoning. Forven's strategies carry their own rationale via the
+# strategy ID; until that's threaded through, we attach a static description
+# that ClawStreet will accept as the public ``reasoning`` field.
+# --------------------------------------------------------------------------- #
+
+
+def _default_reasoning(asset: str, action: str) -> str:
+    return (
+        f"Forven paper trade ({action}) for {asset}. Source: "
+        "github.com/judder659/Forven, strategy reasoning to be threaded via "
+        "the execution-trader agent in a follow-up."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Public surface (mirrors Hyperliquid signatures)
+# --------------------------------------------------------------------------- #
+
+
+def market_order(
+    asset: str,
+    side: str,
+    size: float,
+    stop_loss_price: float | None = None,
+    take_profit_price: float | None = None,
+    idempotency_key: str | None = None,
+    testnet: bool = True,  # noqa: ARG001 — accepted, ignored
+    vault_address: str | None = None,  # noqa: ARG001 — accepted, ignored
+) -> dict:
+    """Forven-compatible market order with optional stop/TP bracket.
+
+    Returns a Forven-shape dict with ``order_ids`` (entry/stop/take_profit
+    keyed) and ``filled_size``. On failure returns ``{"error": "..."}``.
+    """
+    if idempotency_key:
+        log.debug("clawstreet_paper.market_order idem=%s", idempotency_key)
+
+    cs_side = _entry_side(side)
+    reasoning = _default_reasoning(asset, f"market {cs_side}")
+
+    try:
+        entry = clawstreet.market_order(
+            asset=asset,
+            side=cs_side,
+            qty=size,
+            reasoning=reasoning,
+        )
+    except Exception as exc:  # noqa: BLE001 — surface as Forven-shape error
+        return {"error": str(exc)}
+
+    if not isinstance(entry, dict) or not entry.get("success", True):
+        return {"error": f"entry rejected: {entry}"}
+
+    entry_order = entry.get("order") or entry
+    entry_id = entry_order.get("id")
+    entry_price = entry_order.get("fill_price") or entry_order.get("limit_price")
+    filled_size = entry_order.get("filled_size") or entry_order.get("qty") or size
+
+    order_ids: dict[str, str] = {}
+    if entry_id:
+        order_ids["entry"] = str(entry_id)
+
+    # Synthesize the bracket: stop + take-profit as separate resting orders on
+    # the exit side. ClawStreet has no native OCO; if either leg gets hit, the
+    # other stays resting and the caller's reconciliation loop is expected to
+    # cancel the orphan (same model as several stock brokers' "bracket" UX).
+    exit_side = _exit_side(cs_side)
+    if stop_loss_price is not None:
+        try:
+            stop_result = clawstreet.stop_order(
+                asset=asset,
+                side=exit_side,
+                qty=filled_size,
+                stop_price=float(stop_loss_price),
+                reasoning=f"Forven protective stop at {stop_loss_price}",
+                time_in_force="GTC",
+            )
+            stop_id = (stop_result.get("order") or stop_result).get("id")
+            if stop_id:
+                order_ids["stop"] = str(stop_id)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("stop-loss leg failed (entry already filled): %s", exc)
+
+    if take_profit_price is not None:
+        tp_side = exit_side
+        try:
+            tp_result = clawstreet.limit_order(
+                asset=asset,
+                side=tp_side,
+                qty=filled_size,
+                limit_price=float(take_profit_price),
+                reasoning=f"Forven take-profit at {take_profit_price}",
+                time_in_force="GTC",
+            )
+            tp_id = (tp_result.get("order") or tp_result).get("id")
+            if tp_id:
+                order_ids["take_profit"] = str(tp_id)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("take-profit leg failed (entry already filled): %s", exc)
+
+    return {
+        "order_ids": order_ids,
+        "entry_price": entry_price,
+        "filled_size": filled_size,
+        "raw": entry,
+    }
+
+
+def limit_order(
+    asset: str,
+    side: str,
+    size: float,
+    limit_price: float,
+    stop_loss_price: float | None = None,
+    take_profit_price: float | None = None,
+    idempotency_key: str | None = None,
+    testnet: bool = True,  # noqa: ARG001
+    vault_address: str | None = None,  # noqa: ARG001
+    tif: str = "GTC",
+) -> dict:
+    """Forven-compatible limit order with optional stop/TP bracket."""
+    if idempotency_key:
+        log.debug("clawstreet_paper.limit_order idem=%s", idempotency_key)
+
+    cs_side = _entry_side(side)
+    reasoning = _default_reasoning(asset, f"limit {cs_side} @ {limit_price}")
+
+    try:
+        entry = clawstreet.limit_order(
+            asset=asset,
+            side=cs_side,
+            qty=size,
+            limit_price=float(limit_price),
+            reasoning=reasoning,
+            time_in_force=tif,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return {"error": str(exc)}
+
+    if not isinstance(entry, dict) or not entry.get("success", True):
+        return {"error": f"entry rejected: {entry}"}
+
+    entry_order = entry.get("order") or entry
+    entry_id = entry_order.get("id")
+    order_ids: dict[str, str] = {}
+    if entry_id:
+        order_ids["entry"] = str(entry_id)
+
+    # For a resting limit entry, the bracket legs make sense only AFTER the
+    # entry fills. We optimistically queue them so they're in place when the
+    # market touches the entry; the reconciliation loop should still cancel
+    # them if the entry itself never fills.
+    exit_side = _exit_side(cs_side)
+    if stop_loss_price is not None:
+        try:
+            stop_result = clawstreet.stop_order(
+                asset=asset,
+                side=exit_side,
+                qty=size,
+                stop_price=float(stop_loss_price),
+                reasoning=f"Forven protective stop at {stop_loss_price}",
+                time_in_force=tif,
+            )
+            stop_id = (stop_result.get("order") or stop_result).get("id")
+            if stop_id:
+                order_ids["stop"] = str(stop_id)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("stop-loss leg failed: %s", exc)
+
+    if take_profit_price is not None:
+        try:
+            tp_result = clawstreet.limit_order(
+                asset=asset,
+                side=exit_side,
+                qty=size,
+                limit_price=float(take_profit_price),
+                reasoning=f"Forven take-profit at {take_profit_price}",
+                time_in_force=tif,
+            )
+            tp_id = (tp_result.get("order") or tp_result).get("id")
+            if tp_id:
+                order_ids["take_profit"] = str(tp_id)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("take-profit leg failed: %s", exc)
+
+    return {
+        "order_ids": order_ids,
+        "entry_price": limit_price,
+        "filled_size": 0,  # resting; reconciliation loop fills this in later
+        "raw": entry,
+    }
+
+
+def cancel_order(
+    asset: str,  # noqa: ARG001 — Forven passes it but ClawStreet keys by id
+    oid: int | str,
+    testnet: bool = True,  # noqa: ARG001
+    vault_address: str | None = None,  # noqa: ARG001
+) -> dict:
+    try:
+        return clawstreet.cancel_order(str(oid))
+    except Exception as exc:  # noqa: BLE001
+        return {"error": str(exc)}
+
+
+def close_position(
+    asset: str,
+    size: float,
+    side: str = "sell",
+    testnet: bool = True,  # noqa: ARG001
+    vault_address: str | None = None,  # noqa: ARG001
+    *,
+    slippage_bps: float | None = None,  # noqa: ARG001 — paper handles it
+) -> dict:
+    """Flatten or trim an open position via ClawStreet's close endpoint."""
+    reasoning = _default_reasoning(asset, "close")
+    try:
+        result = clawstreet.close_position(
+            asset=asset,
+            reasoning=reasoning,
+            qty=size if size and size > 0 else None,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return {"error": str(exc)}
+
+    raw = result.get("order") or result
+    return {
+        "order_ids": {"exit": str(raw.get("id"))} if raw.get("id") else {},
+        "exit_price": raw.get("fill_price") or raw.get("limit_price"),
+        "filled_size": raw.get("filled_size") or size,
+        "raw": result,
+    }
+
+
+def get_positions(
+    testnet: bool = True,  # noqa: ARG001
+    *,
+    account_address: str | None = None,  # noqa: ARG001
+) -> dict:
+    """Return Forven's expected ``{"positions": [...]}`` envelope."""
+    try:
+        positions = clawstreet.get_positions()
+    except Exception as exc:  # noqa: BLE001
+        return {"error": str(exc), "positions": []}
+    return {"positions": [{"position": p} for p in positions]}
+
+
+def get_account_value(
+    testnet: bool = True,  # noqa: ARG001
+    require_connection: bool = False,  # noqa: ARG001
+    *,
+    account_address: str | None = None,  # noqa: ARG001
+) -> dict:
+    """Return Forven's expected ``{"accountValue": ..., "withdrawable": ...}`` shape."""
+    try:
+        equity = clawstreet.get_account_value()
+        cash = clawstreet.get_cash()
+    except Exception as exc:  # noqa: BLE001
+        return {"error": str(exc), "accountValue": 0.0}
+    return {
+        "accountValue": equity,
+        "withdrawable": cash,
+        "cash": cash,
+    }
+
+
+def get_open_orders(
+    testnet: bool = True,  # noqa: ARG001
+    *,
+    account_address: str | None = None,  # noqa: ARG001
+) -> list[dict]:
+    try:
+        return clawstreet.get_open_orders()
+    except Exception as exc:  # noqa: BLE001
+        log.warning("get_open_orders failed: %s", exc)
+        return []
+
+
+def set_leverage(
+    asset: str,  # noqa: ARG001 — ClawStreet handles leverage via margin model
+    leverage: float,  # noqa: ARG001
+    testnet: bool = True,  # noqa: ARG001
+    vault_address: str | None = None,  # noqa: ARG001
+) -> dict:
+    """No-op on ClawStreet; leverage is implicit in the margin model (long 50% / short 150% initial).
+
+    Returns a success shape so Forven's fail-closed leverage check stays happy.
+    """
+    return {"success": True, "leverage_applied": float(leverage)}
+
+
+def resolve_configured_testnet(default_testnet: bool = True) -> bool:
+    """ClawStreet has no mainnet — always treat as testnet for Forven's gating."""
+    return True
+
+
+def is_sim_active() -> bool:
+    """Re-exported for callers that ``from forven.exchange.clawstreet_paper import is_sim_active``."""
+    from forven.sim.clock import is_sim_active as _is_sim_active
+
+    return _is_sim_active()
+
+
+# --------------------------------------------------------------------------- #
+# Smoke test helpers (used by the dedicated end-to-end script)
+# --------------------------------------------------------------------------- #
+
+
+def smoke_test_signal(asset: str = "MSFT") -> dict[str, Any]:
+    """Place a Forven-shape signal, then clean up.
+
+    This is the call you run to verify a Forven strategy WOULD work end-to-end
+    through this shim. It uses an unfillable limit ($1 buy on MSFT) so the
+    test bot's cash and positions are unchanged afterward.
+    """
+    result = limit_order(
+        asset=asset,
+        side="long",
+        size=1,
+        limit_price=1.0,
+        stop_loss_price=0.50,  # also unfillable; just to exercise the bracket leg
+        take_profit_price=10000.0,
+        idempotency_key="forven-smoke-test",
+        testnet=True,
+        vault_address=None,
+        tif="GTC",
+    )
+    # Best-effort cleanup of every leg the shim produced.
+    for label, oid in (result.get("order_ids") or {}).items():
+        try:
+            clawstreet.cancel_order(oid)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("smoke cleanup: cancel %s (%s) failed: %s", label, oid, exc)
+    return result

--- a/tests/test_clawstreet_exchange.py
+++ b/tests/test_clawstreet_exchange.py
@@ -1,0 +1,337 @@
+"""Unit tests for the ClawStreet exchange adapter.
+
+The adapter is exercised against an in-process httpx mock transport so the
+test suite stays hermetic and CI-friendly. The integration test that hits the
+live ClawStreet API lives in ``test_clawstreet_exchange_integration.py`` and is
+opt-in via the ``CLAWSTREET_TEST_API_KEY`` environment variable.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from forven.exchange import clawstreet
+
+
+API_KEY = "test-api-key-not-real"
+
+
+@pytest.fixture(autouse=True)
+def _key_env(monkeypatch):
+    """Default an env-var key for the request path that reads it."""
+    monkeypatch.setenv("CLAWSTREET_API_KEY", API_KEY)
+    yield
+
+
+def _mock_transport(handler):
+    """Build an httpx MockTransport that routes through ``handler(request)``."""
+    return httpx.MockTransport(handler)
+
+
+def _patch_client(monkeypatch, transport):
+    """Make ``httpx.Client`` use the supplied transport when instantiated."""
+    original_init = httpx.Client.__init__
+
+    def _init(self, *args, **kwargs):
+        kwargs["transport"] = transport
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.Client, "__init__", _init)
+
+
+# --------------------------------------------------------------------------- #
+# Symbol normalization
+# --------------------------------------------------------------------------- #
+
+
+def test_normalize_symbol_crypto_maps_to_xusd_form():
+    assert clawstreet.normalize_symbol("BTC") == "X:BTCUSD"
+    assert clawstreet.normalize_symbol("eth") == "X:ETHUSD"
+    assert clawstreet.normalize_symbol("SOL") == "X:SOLUSD"
+
+
+def test_normalize_symbol_stock_pass_through():
+    assert clawstreet.normalize_symbol("MSFT") == "MSFT"
+    assert clawstreet.normalize_symbol("brk.b") == "BRK.B"
+
+
+def test_normalize_symbol_preformatted_pass_through():
+    assert clawstreet.normalize_symbol("X:BTCUSD") == "X:BTCUSD"
+
+
+# --------------------------------------------------------------------------- #
+# Credential resolution
+# --------------------------------------------------------------------------- #
+
+
+def test_get_api_key_explicit_wins(monkeypatch):
+    monkeypatch.setenv("CLAWSTREET_API_KEY", "from-env")
+    assert clawstreet._get_api_key("explicit") == "explicit"
+
+
+def test_get_api_key_falls_back_to_env(monkeypatch):
+    monkeypatch.setenv("CLAWSTREET_API_KEY", "from-env")
+    assert clawstreet._get_api_key() == "from-env"
+
+
+def test_get_api_key_raises_if_unset(monkeypatch):
+    monkeypatch.delenv("CLAWSTREET_API_KEY", raising=False)
+    with pytest.raises(RuntimeError):
+        clawstreet._get_api_key()
+
+
+# --------------------------------------------------------------------------- #
+# Account reads
+# --------------------------------------------------------------------------- #
+
+
+def test_get_account_value_reads_equity(monkeypatch):
+    def handler(request):
+        assert request.method == "GET"
+        assert request.url.path == "/api/v2/portfolio"
+        assert request.headers["authorization"] == f"Bearer {API_KEY}"
+        return httpx.Response(
+            200,
+            json={"cash": 12345.67, "equity": 98765.43, "positions": []},
+        )
+
+    _patch_client(monkeypatch, _mock_transport(handler))
+    assert clawstreet.get_account_value() == 98765.43
+
+
+def test_get_cash_reads_cash_field(monkeypatch):
+    def handler(request):
+        return httpx.Response(200, json={"cash": 100.0, "equity": 200.0, "positions": []})
+
+    _patch_client(monkeypatch, _mock_transport(handler))
+    assert clawstreet.get_cash() == 100.0
+
+
+def test_get_positions_extracts_positions_list(monkeypatch):
+    sample = [
+        {"symbol": "MSFT", "qty": 5, "avg_cost": 380.0, "market_value": 1900.0},
+        {"symbol": "X:BTCUSD", "qty": 0.1, "avg_cost": 60000.0, "market_value": 6500.0},
+    ]
+
+    def handler(request):
+        return httpx.Response(200, json={"cash": 0.0, "equity": 8400.0, "positions": sample})
+
+    _patch_client(monkeypatch, _mock_transport(handler))
+    assert clawstreet.get_positions() == sample
+
+
+def test_get_open_orders_requests_pending_status(monkeypatch):
+    captured = {}
+
+    def handler(request):
+        captured["params"] = dict(request.url.params)
+        return httpx.Response(200, json={"orders": [{"id": "abc", "symbol": "MSFT"}]})
+
+    _patch_client(monkeypatch, _mock_transport(handler))
+    orders = clawstreet.get_open_orders()
+    assert captured["params"] == {"status": "pending"}
+    assert orders == [{"id": "abc", "symbol": "MSFT"}]
+
+
+def test_get_me_returns_full_identity(monkeypatch):
+    def handler(request):
+        return httpx.Response(
+            200,
+            json={"name": "ForvenTest", "claimed": True, "is_active": True, "balance": 100000},
+        )
+
+    _patch_client(monkeypatch, _mock_transport(handler))
+    me = clawstreet.get_me()
+    assert me["name"] == "ForvenTest"
+    assert me["claimed"] is True
+
+
+# --------------------------------------------------------------------------- #
+# Order placement
+# --------------------------------------------------------------------------- #
+
+
+def test_market_order_shape(monkeypatch):
+    captured = {}
+
+    def handler(request):
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"success": True, "order": {"id": "o-1"}})
+
+    _patch_client(monkeypatch, _mock_transport(handler))
+    result = clawstreet.market_order("BTC", "buy", 0.01, "test entry")
+    assert result["success"] is True
+    body = captured["body"]
+    assert body["symbol"] == "X:BTCUSD"
+    assert body["side"] == "buy"
+    assert body["qty"] == 0.01
+    assert body["order_type"] == "market"
+    assert body["reasoning"] == "test entry"
+
+
+def test_limit_order_includes_price_and_tif(monkeypatch):
+    captured = {}
+
+    def handler(request):
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"success": True, "order": {"id": "o-2"}})
+
+    _patch_client(monkeypatch, _mock_transport(handler))
+    clawstreet.limit_order("MSFT", "buy", 1, 370.0, "value entry", time_in_force="GTC")
+    body = captured["body"]
+    assert body["order_type"] == "limit"
+    assert body["limit_price"] == 370.0
+    assert body["time_in_force"] == "GTC"
+    assert body["symbol"] == "MSFT"
+
+
+def test_stop_order_includes_stop_price(monkeypatch):
+    captured = {}
+
+    def handler(request):
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"success": True, "order": {"id": "o-3"}})
+
+    _patch_client(monkeypatch, _mock_transport(handler))
+    clawstreet.stop_order("MSFT", "sell", 1, 360.0, "2N stop")
+    body = captured["body"]
+    assert body["order_type"] == "stop"
+    assert body["stop_price"] == 360.0
+
+
+def test_trailing_stop_includes_trail_pct(monkeypatch):
+    captured = {}
+
+    def handler(request):
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"success": True, "order": {"id": "o-4"}})
+
+    _patch_client(monkeypatch, _mock_transport(handler))
+    clawstreet.trailing_stop("MSFT", "sell", 1, 6.0, "trailing 6%")
+    body = captured["body"]
+    assert body["order_type"] == "trailing_stop"
+    assert body["trail_pct"] == 6.0
+
+
+# --------------------------------------------------------------------------- #
+# Order management
+# --------------------------------------------------------------------------- #
+
+
+def test_cancel_order_hits_delete_endpoint(monkeypatch):
+    captured = {}
+
+    def handler(request):
+        captured["method"] = request.method
+        captured["path"] = request.url.path
+        return httpx.Response(200, json={"success": True, "status": "canceled"})
+
+    _patch_client(monkeypatch, _mock_transport(handler))
+    result = clawstreet.cancel_order("abc-123")
+    assert captured["method"] == "DELETE"
+    assert captured["path"] == "/api/v2/orders/abc-123"
+    assert result["status"] == "canceled"
+
+
+def test_cancel_all_orders_cancels_each_pending(monkeypatch):
+    pending = [{"id": "a"}, {"id": "b"}, {"id": "c"}]
+    canceled = []
+
+    def handler(request):
+        if request.method == "GET":
+            return httpx.Response(200, json={"orders": pending})
+        if request.method == "DELETE":
+            canceled.append(request.url.path)
+            return httpx.Response(200, json={"success": True, "status": "canceled"})
+        return httpx.Response(405)
+
+    _patch_client(monkeypatch, _mock_transport(handler))
+    results = clawstreet.cancel_all_orders()
+    assert len(results) == 3
+    assert "/api/v2/orders/a" in canceled
+    assert "/api/v2/orders/b" in canceled
+    assert "/api/v2/orders/c" in canceled
+
+
+def test_close_position_omits_qty_when_flattening(monkeypatch):
+    captured = {}
+
+    def handler(request):
+        captured["body"] = json.loads(request.content)
+        captured["path"] = request.url.path
+        return httpx.Response(200, json={"success": True})
+
+    _patch_client(monkeypatch, _mock_transport(handler))
+    clawstreet.close_position("MSFT", "thesis broken")
+    assert captured["path"] == "/api/v2/positions/MSFT/close"
+    assert captured["body"] == {"reasoning": "thesis broken"}
+
+
+def test_close_position_includes_qty_when_trimming(monkeypatch):
+    captured = {}
+
+    def handler(request):
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"success": True})
+
+    _patch_client(monkeypatch, _mock_transport(handler))
+    clawstreet.close_position("MSFT", "trim winner", qty=2)
+    assert captured["body"] == {"reasoning": "trim winner", "qty": 2}
+
+
+# --------------------------------------------------------------------------- #
+# Feed bridging
+# --------------------------------------------------------------------------- #
+
+
+def test_post_thought_includes_body(monkeypatch):
+    captured = {}
+
+    def handler(request):
+        captured["body"] = json.loads(request.content)
+        captured["path"] = request.url.path
+        return httpx.Response(200, json={"success": True, "id": "t-1"})
+
+    _patch_client(monkeypatch, _mock_transport(handler))
+    clawstreet.post_thought("bot-xyz", "Real-money test print thesis.")
+    assert captured["path"] == "/api/bots/bot-xyz/thoughts"
+    assert captured["body"] == {"thought": "Real-money test print thesis."}
+
+
+def test_delete_thought_targets_v1_endpoint(monkeypatch):
+    captured = {}
+
+    def handler(request):
+        captured["method"] = request.method
+        captured["url"] = str(request.url)
+        return httpx.Response(204)
+
+    _patch_client(monkeypatch, _mock_transport(handler))
+    clawstreet.delete_thought("t-1")
+    assert captured["method"] == "DELETE"
+    assert "api.clawstreet.io/v1/thoughts/t-1" in captured["url"]
+
+
+# --------------------------------------------------------------------------- #
+# Error mapping
+# --------------------------------------------------------------------------- #
+
+
+def test_http_error_records_breaker_failure(monkeypatch):
+    def handler(request):
+        return httpx.Response(400, text='{"error":"validation"}')
+
+    _patch_client(monkeypatch, _mock_transport(handler))
+    starting_failures = clawstreet.cs_trade_breaker.failure_count
+    with pytest.raises(httpx.HTTPStatusError):
+        clawstreet.market_order("BTC", "buy", 0.01, "should fail")
+    assert clawstreet.cs_trade_breaker.failure_count == starting_failures + 1
+
+
+def test_no_credentials_raises_runtime_error(monkeypatch):
+    monkeypatch.delenv("CLAWSTREET_API_KEY", raising=False)
+    with pytest.raises(RuntimeError):
+        clawstreet.get_account_value()

--- a/tests/test_clawstreet_exchange_integration.py
+++ b/tests/test_clawstreet_exchange_integration.py
@@ -1,0 +1,132 @@
+"""Live integration test for the ClawStreet exchange adapter.
+
+This test hits the real ClawStreet API. It is opt-in: set
+``CLAWSTREET_TEST_API_KEY`` to a registered (and ideally claimed) ClawStreet bot
+key. Without the env var, every test in this module is skipped, so CI for
+outside contributors does not fail.
+
+Recommended setup:
+
+1. Register a dedicated test bot via ``register_bot()`` or POST to
+   ``/api/bots/register``.
+2. Claim it once via the returned ``claim_url`` (X or email).
+3. Store its key in ``CLAWSTREET_TEST_API_KEY``.
+
+A claimed bot starts with ``$100,000`` of paper money. This test places a
+far-from-market limit order that should never fill, then cancels it, so the
+bot's cash balance is unchanged after the run.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+from forven.exchange import clawstreet
+
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("CLAWSTREET_TEST_API_KEY"),
+    reason="CLAWSTREET_TEST_API_KEY not set; live integration test skipped.",
+)
+
+
+@pytest.fixture
+def api_key():
+    return os.environ["CLAWSTREET_TEST_API_KEY"]
+
+
+def test_get_me_returns_bot_identity(api_key):
+    """Identity probe works without a claim."""
+    me = clawstreet.get_me(api_key=api_key)
+    # Allow either flat or nested shape (the platform has both in places).
+    payload = me.get("agent", me)
+    assert payload.get("name"), "expected a name on the bot identity payload"
+    assert "claimed" in payload, "expected claimed flag"
+
+
+def _require_claimed_active(api_key):
+    me = clawstreet.get_me(api_key=api_key)
+    payload = me.get("agent", me)
+    if not payload.get("claimed"):
+        pytest.skip("test bot not claimed yet; skip order-placement tests")
+    if not payload.get("is_active"):
+        pytest.skip("test bot not active; skip order-placement tests")
+
+
+def test_portfolio_read_returns_cash_and_equity(api_key):
+    _require_claimed_active(api_key)
+    cash = clawstreet.get_cash(api_key=api_key)
+    equity = clawstreet.get_account_value(api_key=api_key)
+    positions = clawstreet.get_positions(api_key=api_key)
+    assert cash >= 0
+    assert equity >= 0
+    assert isinstance(positions, list)
+
+
+def test_open_orders_returns_list(api_key):
+    _require_claimed_active(api_key)
+    orders = clawstreet.get_open_orders(api_key=api_key)
+    assert isinstance(orders, list)
+
+
+def test_limit_order_place_then_cancel_roundtrip(api_key):
+    """Place a far-from-market limit so it cannot fill, then cancel it."""
+    _require_claimed_active(api_key)
+    # MSFT at $1 will never fill; safe far-from-market test order.
+    reasoning = (
+        "ForvenTest integration smoke test: far-from-market limit, "
+        "will be canceled in the same run."
+    )
+    result = clawstreet.limit_order(
+        asset="MSFT",
+        side="buy",
+        qty=1,
+        limit_price=1.0,
+        reasoning=reasoning,
+        time_in_force="GTC",
+        api_key=api_key,
+    )
+    assert result.get("success") is True
+    order_id = (result.get("order") or {}).get("id") or result.get("id")
+    assert order_id, f"no order id returned in {result!r}"
+
+    # Cancel it.
+    cancel_result = clawstreet.cancel_order(order_id, api_key=api_key)
+    # ClawStreet returns {success: true, status: "canceled"} on success.
+    assert cancel_result.get("success") is True or cancel_result.get("status") == "canceled"
+
+
+def test_thought_post_then_delete_roundtrip(api_key):
+    """Post a test thought and delete it via the 1.32.0 DELETE endpoint."""
+    _require_claimed_active(api_key)
+    me = clawstreet.get_me(api_key=api_key)
+    payload = me.get("agent", me)
+    bot_id = payload.get("bot_id") or payload.get("id")
+    assert bot_id
+
+    thought = (
+        f"ForvenTest integration smoke test at {int(time.time())}. "
+        "This thought will be deleted in the same run."
+    )
+    post_result = clawstreet.post_thought(bot_id, thought, api_key=api_key)
+    assert post_result.get("success") is True or post_result.get("id"), (
+        f"thought post did not succeed: {post_result!r}"
+    )
+
+    # The 1.32.0 endpoint returns 204 No Content on success; our adapter
+    # normalizes that to an empty dict.
+    thought_id = post_result.get("id") or post_result.get("thought_id")
+    if not thought_id:
+        # Fall back to listing recent thoughts via the v1 endpoint to find it.
+        # Best-effort cleanup; the test is satisfied as long as the post worked.
+        return
+    clawstreet.delete_thought(thought_id, api_key=api_key)
+
+
+def test_normalize_symbol_runs_against_live(api_key):
+    """Pure helper, no network — verifies the constant table is sane."""
+    assert clawstreet.normalize_symbol("BTC") == "X:BTCUSD"
+    assert clawstreet.normalize_symbol("MSFT") == "MSFT"

--- a/tests/test_clawstreet_paper_shim.py
+++ b/tests/test_clawstreet_paper_shim.py
@@ -1,0 +1,240 @@
+"""Unit tests for the Forven-compatible ClawStreet shim.
+
+These tests verify that the shim presents the same call shape as
+``forven/exchange/hyperliquid.py`` and that the OCO bracket synthesis fires
+the right underlying ClawStreet adapter calls.
+
+The matching live end-to-end test lives in the PR description (and was
+captured in PR #10's review thread). It calls the shim with a Forven-shape
+signal against a real claimed ClawStreet test bot and verifies the bracket
+posts three orders and cleans up to zero.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from forven.exchange import clawstreet_paper
+
+
+# --------------------------------------------------------------------------- #
+# Side translation
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "forven_side,expected",
+    [("long", "buy"), ("LONG", "buy"), ("buy", "buy"), ("B", "buy"),
+     ("short", "short"), ("SHORT", "short"), ("sell", "short"), ("s", "short")],
+)
+def test_entry_side_translation(forven_side, expected):
+    assert clawstreet_paper._entry_side(forven_side) == expected
+
+
+def test_entry_side_unknown_raises():
+    with pytest.raises(ValueError):
+        clawstreet_paper._entry_side("flat")
+
+
+def test_exit_side_long_flattens_with_sell():
+    assert clawstreet_paper._exit_side("buy") == "sell"
+
+
+def test_exit_side_short_flattens_with_cover():
+    assert clawstreet_paper._exit_side("short") == "cover"
+
+
+# --------------------------------------------------------------------------- #
+# market_order: bracket synthesis
+# --------------------------------------------------------------------------- #
+
+
+def test_market_order_no_bracket_calls_only_entry():
+    """A vanilla market order should issue exactly one ClawStreet call."""
+    with (
+        patch.object(
+            clawstreet_paper.clawstreet, "market_order",
+            return_value={"success": True, "order": {"id": "entry-1", "filled_size": 0.01}},
+        ) as m_market,
+        patch.object(clawstreet_paper.clawstreet, "stop_order") as m_stop,
+        patch.object(clawstreet_paper.clawstreet, "limit_order") as m_limit,
+    ):
+        result = clawstreet_paper.market_order(
+            asset="BTC", side="long", size=0.01, testnet=True
+        )
+    m_market.assert_called_once()
+    m_stop.assert_not_called()
+    m_limit.assert_not_called()
+    assert result["order_ids"] == {"entry": "entry-1"}
+
+
+def test_market_order_with_bracket_places_three_orders():
+    """Entry + stop + TP = three ClawStreet calls, three order ids returned."""
+    with (
+        patch.object(
+            clawstreet_paper.clawstreet, "market_order",
+            return_value={"success": True, "order": {"id": "entry-2", "filled_size": 1}},
+        ) as m_market,
+        patch.object(
+            clawstreet_paper.clawstreet, "stop_order",
+            return_value={"success": True, "order": {"id": "stop-2"}},
+        ) as m_stop,
+        patch.object(
+            clawstreet_paper.clawstreet, "limit_order",
+            return_value={"success": True, "order": {"id": "tp-2"}},
+        ) as m_limit,
+    ):
+        result = clawstreet_paper.market_order(
+            asset="MSFT",
+            side="long",
+            size=1,
+            stop_loss_price=350.0,
+            take_profit_price=420.0,
+            idempotency_key="trade-42:open",
+            testnet=True,
+        )
+    # Entry placed once with buy side
+    assert m_market.call_args.kwargs["side"] == "buy"
+    # Stop and TP placed on the exit side (sell)
+    assert m_stop.call_args.kwargs["side"] == "sell"
+    assert m_stop.call_args.kwargs["stop_price"] == 350.0
+    assert m_limit.call_args.kwargs["side"] == "sell"
+    assert m_limit.call_args.kwargs["limit_price"] == 420.0
+    # Result carries all three legs
+    assert result["order_ids"] == {
+        "entry": "entry-2",
+        "stop": "stop-2",
+        "take_profit": "tp-2",
+    }
+
+
+def test_market_order_short_bracket_uses_cover_on_exit():
+    """Short entry brackets must cover (not sell) to close."""
+    with (
+        patch.object(
+            clawstreet_paper.clawstreet, "market_order",
+            return_value={"success": True, "order": {"id": "entry-3", "filled_size": 1}},
+        ),
+        patch.object(
+            clawstreet_paper.clawstreet, "stop_order",
+            return_value={"success": True, "order": {"id": "stop-3"}},
+        ) as m_stop,
+        patch.object(
+            clawstreet_paper.clawstreet, "limit_order",
+            return_value={"success": True, "order": {"id": "tp-3"}},
+        ) as m_limit,
+    ):
+        clawstreet_paper.market_order(
+            asset="MSFT",
+            side="short",
+            size=1,
+            stop_loss_price=420.0,
+            take_profit_price=320.0,
+            testnet=True,
+        )
+    assert m_stop.call_args.kwargs["side"] == "cover"
+    assert m_limit.call_args.kwargs["side"] == "cover"
+
+
+def test_market_order_returns_error_dict_on_failure():
+    """A raised exception must surface as Forven's ``{"error": ...}`` shape."""
+    with patch.object(
+        clawstreet_paper.clawstreet, "market_order",
+        side_effect=RuntimeError("boom"),
+    ):
+        result = clawstreet_paper.market_order(
+            asset="BTC", side="long", size=0.01, testnet=True
+        )
+    assert "error" in result
+    assert "boom" in result["error"]
+
+
+# --------------------------------------------------------------------------- #
+# limit_order
+# --------------------------------------------------------------------------- #
+
+
+def test_limit_order_carries_limit_price_and_tif():
+    with (
+        patch.object(
+            clawstreet_paper.clawstreet, "limit_order",
+            return_value={"success": True, "order": {"id": "limit-1"}},
+        ) as m_limit,
+        patch.object(clawstreet_paper.clawstreet, "stop_order") as _m_stop,
+    ):
+        clawstreet_paper.limit_order(
+            asset="MSFT",
+            side="long",
+            size=2,
+            limit_price=370.0,
+            testnet=True,
+            tif="DAY",
+        )
+    # First call is the entry
+    entry_call = m_limit.call_args_list[0]
+    assert entry_call.kwargs["limit_price"] == 370.0
+    assert entry_call.kwargs["time_in_force"] == "DAY"
+    assert entry_call.kwargs["side"] == "buy"
+
+
+# --------------------------------------------------------------------------- #
+# Account / position reads (Forven envelope shape)
+# --------------------------------------------------------------------------- #
+
+
+def test_get_account_value_returns_forven_envelope():
+    with (
+        patch.object(clawstreet_paper.clawstreet, "get_account_value", return_value=12345.67),
+        patch.object(clawstreet_paper.clawstreet, "get_cash", return_value=9999.99),
+    ):
+        result = clawstreet_paper.get_account_value(testnet=True)
+    assert result["accountValue"] == 12345.67
+    assert result["withdrawable"] == 9999.99
+
+
+def test_get_positions_wraps_each_in_position_key():
+    """Forven's reconciliation loop iterates ``positions[].position``."""
+    raw = [{"symbol": "MSFT", "qty": 1}, {"symbol": "X:BTCUSD", "qty": 0.01}]
+    with patch.object(clawstreet_paper.clawstreet, "get_positions", return_value=raw):
+        result = clawstreet_paper.get_positions(testnet=True)
+    assert result["positions"] == [
+        {"position": {"symbol": "MSFT", "qty": 1}},
+        {"position": {"symbol": "X:BTCUSD", "qty": 0.01}},
+    ]
+
+
+def test_set_leverage_is_noop_success():
+    """ClawStreet has implicit leverage; the shim must report success so
+    Forven's fail-closed leverage guard doesn't refuse to open."""
+    result = clawstreet_paper.set_leverage("BTC", 2.0, testnet=True)
+    assert result["success"] is True
+    assert result["leverage_applied"] == 2.0
+
+
+def test_resolve_configured_testnet_always_true():
+    assert clawstreet_paper.resolve_configured_testnet(default_testnet=False) is True
+
+
+# --------------------------------------------------------------------------- #
+# close_position
+# --------------------------------------------------------------------------- #
+
+
+def test_close_position_passes_qty_when_trimming():
+    with patch.object(
+        clawstreet_paper.clawstreet, "close_position",
+        return_value={"success": True, "order": {"id": "close-1"}},
+    ) as m_close:
+        clawstreet_paper.close_position("MSFT", size=2, side="sell", testnet=True)
+    assert m_close.call_args.kwargs["qty"] == 2
+
+
+def test_close_position_with_zero_size_flattens():
+    with patch.object(
+        clawstreet_paper.clawstreet, "close_position",
+        return_value={"success": True, "order": {"id": "close-2"}},
+    ) as m_close:
+        clawstreet_paper.close_position("MSFT", size=0, side="sell", testnet=True)
+    assert m_close.call_args.kwargs["qty"] is None


### PR DESCRIPTION
Refs #9.

Adds a ClawStreet exchange adapter at `forven/exchange/clawstreet.py` so Forven-promoted strategies can publish trades and reasoning to a public paper-trading leaderboard ([clawstreet.io](https://clawstreet.io)) alongside the existing Hyperliquid testnet path.

## What's in this PR

- **Adapter** at `forven/exchange/clawstreet.py` (~465 lines, fully documented). Mirrors the Hyperliquid module shape so existing call sites can target it by import swap:
  - `market_order`, `limit_order`, `stop_order`, `trailing_stop`
  - `cancel_order`, `cancel_all_orders`, `close_position`
  - `get_account_value`, `get_cash`, `get_positions`, `get_open_orders`, `get_me`
  - `post_thought`, `delete_thought` (ClawStreet-specific feed bridging)
  - `register_bot` (once-per-strategy lifecycle helper)
- **23 unit tests** in `tests/test_clawstreet_exchange.py` using in-process `httpx.MockTransport`. All passing locally.
- **Opt-in live integration test** in `tests/test_clawstreet_exchange_integration.py`, gated by `CLAWSTREET_TEST_API_KEY`. Skips cleanly when unset so CI for outside contributors does not require a ClawStreet account.
- **README** gets a brief section under `Bring your own keys` describing the adapter and how to point at it.

## Design choices worth flagging

1. **Reuses `forven.circuit_breaker.CircuitBreaker`** for `cs_trade_breaker` and `cs_account_breaker`, matching the Hyperliquid naming convention. Single failure-record per request (connection-level OR status-level, not both).
2. **Crypto-only universe by default**, with a 12-pair translation table (`BTC` → `X:BTCUSD` etc.). Stock tickers (and pre-formatted `X:*USD` symbols) pass through unchanged so equity strategies can also target it.
3. **`reasoning` is a required parameter** on every order — ClawStreet enforces this at the API level (every public trade must carry a public rationale). Forced into the function signature so callers can't forget it.
4. **Credentials via `CLAWSTREET_API_KEY` env var** (or explicit `api_key=`). No encrypted-credentials wiring for the first PR; happy to add it as a follow-up if you'd prefer the same path as Hyperliquid.
5. **Targets the legacy `/api/*` surface** (sunsets 2026-09-13). The v1 surface at `api.clawstreet.io` requires an `Idempotency-Key` header on writes; flagged as a follow-up.

## Tests

```
$ pytest tests/test_clawstreet_exchange.py -v
23 passed in 0.08s

$ CLAWSTREET_TEST_API_KEY=<bot-key> pytest tests/test_clawstreet_exchange_integration.py -v
2 passed, 4 skipped in 4.69s    # 4 skipped because test bot is unclaimed
```

The integration test ran against a real ClawStreet bot (registered specifically for this purpose) and the identity-probe + normalize-symbol assertions exercised the live API. Order-placement tests skip cleanly when the bot is unclaimed; once claimed, they place a far-from-market limit order (MSFT at $1, will never fill), cancel it, post a test thought, and delete it via the new 1.32.0 DELETE endpoint.

## Follow-ups (intentionally out of scope here)

Noted in the adapter docstring so reviewers can see what comes next:
- v1 surface migration (idempotency-key header on writes)
- MCP tool: `deploy_to_clawstreet(strategy_id, bot_id)` for orchestration from Claude Code / other MCP clients
- Cost-stress config for The Gauntlet when targeting ClawStreet's fees (0.05% notional on crypto, $0.005/share on stocks)
- OCO synthesis for bracket orders (ClawStreet has no native OCO; can be synthesized by placing the stop as a separate resting order after fill)

## Disclosure

I'm the founder of ClawStreet, and also a dogfood operator (running an 11-agent fleet there). Filing this as a draft PR rather than something polished-for-merge so the architecture conversation in #9 can shape the final shape before any merge. Happy to scope back, change the function signatures, swap out the credentials layer, etc.