### PR TITLE
feat(ai): add Claude CLI as a local LLM provider

### DIFF
--- a/forven/agents/providers.py
+++ b/forven/agents/providers.py
@@ -714,6 +714,50 @@ class LMStudioProvider(ToolCallProvider):
             })
 
 
+class ClaudeCLIProvider(ToolCallProvider):
+    """Local Claude Code CLI as a text-only LLM backend.
+
+    The ``claude`` CLI is itself an agent that runs its own internal tool loop,
+    so it cannot hand Forven's runner a list of ``tool_calls`` to execute. This
+    adapter runs it with all tools disabled and returns a single final-text
+    turn (``stop=True``). Agents wired to Forven-side tools therefore get a
+    direct answer instead of a tool-using loop — acceptable for narrative and
+    analysis tasks, not for tool-dependent ones.
+    """
+
+    async def call(self, model_id, messages, system, tools, token):
+        from forven.claude_cli import flatten_messages, run_claude_cli
+
+        prompt = flatten_messages(messages)
+        text, usage = await run_claude_cli(
+            prompt=prompt,
+            system=str(system or "").strip() or None,
+            model=model_id,
+        )
+        text = text.strip()
+        return ProviderResponse(
+            text=text,
+            tool_calls=[],
+            stop=True,
+            raw_assistant_message={"role": "assistant", "content": text},
+            usage={
+                "input_tokens": usage.get("input_tokens", 0),
+                "output_tokens": usage.get("output_tokens", 0),
+            },
+        )
+
+    def append_assistant(self, messages, response):
+        messages.append(response.raw_assistant_message)
+
+    def append_tool_results(self, messages, results):
+        for tid, content in results:
+            messages.append({
+                "role": "tool",
+                "tool_call_id": tid,
+                "content": content,
+            })
+
+
 class ZAIProvider(ToolCallProvider):
     """Z.AI tool-call adapter supporting OpenAI- and Anthropic-compatible endpoints."""
 
@@ -1224,6 +1268,8 @@ def _construct_provider(name: str) -> ToolCallProvider:
         return MiniMaxProvider()
     if name == "lmstudio":
         return LMStudioProvider()
+    if name == "claude-cli":
+        return ClaudeCLIProvider()
     if name == "zai":
         return ZAIProvider()
     if name == "openrouter":

--- a/forven/ai.py
+++ b/forven/ai.py
@@ -185,6 +185,7 @@ _PROVIDER_ALIAS = {
 _KNOWN_PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "openai", "minimax", "lmstudio", "zai", "openrouter", "groq", "gemini",
     "cerebras", "mistral", "xai", "together", "opencode-zen", "opencode-go",
+    "claude-cli",
     "codex", "openai-codex", "local", "lm-studio", "z.ai", "z-ai",
     "open-router", "open_router",
 })
@@ -201,6 +202,7 @@ _KNOWN_PROVIDER_PREFIXES: frozenset[str] = frozenset({
 _PROVIDER_PASSTHROUGH: frozenset[str] = frozenset({
     "openrouter", "anthropic", "deepseek", "groq", "gemini",
     "cerebras", "mistral", "xai", "together", "opencode-zen", "opencode-go",
+    "claude-cli",
 })
 
 
@@ -978,6 +980,18 @@ async def _call_single(
             endpoint=ENDPOINTS["openrouter"],
             provider_label="openrouter",
         )
+    elif provider == "claude-cli":
+        # Local Claude Code CLI as a text-only LLM backend (keyless, uses the
+        # operator's local session/subscription instead of an HTTP API).
+        return await _call_claude_cli(
+            model,
+            messages,
+            max_tokens,
+            temperature,
+            system,
+            response_schema=response_schema,
+            response_schema_name=response_schema_name,
+        )
     elif provider in ("groq", "gemini", "cerebras", "mistral", "xai", "together", "opencode-zen", "opencode-go"):
         # All expose OpenAI-compatible Chat Completions endpoints, so route
         # through the shared OpenAI caller with the provider's endpoint/label.
@@ -1268,6 +1282,38 @@ async def _call_lmstudio(
     if last_error is not None:
         raise last_error
     raise RuntimeError("LM Studio request failed without raising an explicit error")
+
+
+async def _call_claude_cli(
+    model: str,
+    messages: list[dict],
+    max_tokens: int,
+    temperature: float,
+    system: str | None,
+    response_schema: dict | None = None,
+    response_schema_name: str = "structured_response",
+) -> str:
+    """Call the local Claude Code CLI as a text completion backend.
+
+    ``max_tokens``/``temperature`` are not exposed by ``claude -p`` print mode,
+    so they are accepted for interface parity but not forwarded (the CLI uses
+    the model's defaults).
+    """
+    from forven.claude_cli import flatten_messages, run_claude_cli
+
+    prompt = flatten_messages(messages)
+    system_prompt = str(system or "").strip() or None
+    if response_schema:
+        schema_instruction = (
+            "Return only valid JSON that matches this schema exactly: "
+            f"{json.dumps(response_schema, ensure_ascii=True, separators=(',', ':'))}"
+        )
+        system_prompt = (
+            f"{system_prompt}\n\n{schema_instruction}" if system_prompt else schema_instruction
+        )
+
+    text, _usage = await run_claude_cli(prompt=prompt, system=system_prompt, model=model)
+    return text
 
 
 async def _call_zai(

--- a/forven/api_core.py
+++ b/forven/api_core.py
@@ -277,7 +277,7 @@ def _parse_int_query(value: str | None, default: int = 0) -> int:
         return default
 
 
-_SUPPORTED_AUTH_PROVIDERS: list[str] = ["openai", "minimax", "lmstudio", "zai", "openrouter", "anthropic", "deepseek", "groq", "gemini", "cerebras", "mistral", "xai", "together", "opencode-zen", "opencode-go"]
+_SUPPORTED_AUTH_PROVIDERS: list[str] = ["openai", "minimax", "lmstudio", "zai", "openrouter", "anthropic", "deepseek", "groq", "gemini", "cerebras", "mistral", "xai", "together", "opencode-zen", "opencode-go", "claude-cli"]
 _AUTH_PROVIDER_ENV_VARS = {
     "openai": "OPENAI_API_KEY",
     "minimax": "MINIMAX_API_KEY",
@@ -294,6 +294,7 @@ _AUTH_PROVIDER_ENV_VARS = {
     "together": "TOGETHER_API_KEY",
     "opencode-zen": "OPENCODE_ZEN_API_KEY",
     "opencode-go": "OPENCODE_GO_API_KEY",
+    "claude-cli": "CLAUDE_CLI_BIN",
 }
 _AUTH_OAUTH_SESSIONS: dict[str, dict[str, dict[str, object]]] = {}
 _AUTH_OAUTH_CALLBACKS: dict[str, dict[str, str]] = {}
@@ -405,6 +406,7 @@ _MODEL_PROVIDER_DISPLAY_NAMES = {
     "together": "Together AI",
     "opencode-zen": "OpenCode Zen",
     "opencode-go": "OpenCode GO",
+    "claude-cli": "Claude CLI (local)",
 }
 _LOCAL_PROVIDER_DEFAULT_BASE_URLS = {
     "lmstudio": "http://127.0.0.1:1234",
@@ -441,6 +443,9 @@ _AGENT_MODEL_CATALOG = [
     {"provider": "minimax", "model_id": "MiniMax-M2.1-highspeed", "label": "MiniMax M2.1 Highspeed"},
     {"provider": "minimax", "model_id": "MiniMax-M2", "label": "MiniMax M2"},
     {"provider": "lmstudio", "model_id": "local-model", "label": "LM Studio Local Model"},
+    {"provider": "claude-cli", "model_id": "sonnet", "label": "Claude CLI — Sonnet (local)"},
+    {"provider": "claude-cli", "model_id": "opus", "label": "Claude CLI — Opus (local)"},
+    {"provider": "claude-cli", "model_id": "haiku", "label": "Claude CLI — Haiku (local)"},
     {"provider": "zai", "model_id": "glm-5.1", "label": "Z.AI GLM-5.1"},
     {"provider": "zai", "model_id": "glm-5", "label": "Z.AI GLM-5"},
     {"provider": "zai", "model_id": "glm-5-turbo", "label": "Z.AI GLM-5 Turbo"},

--- a/forven/auth/store.py
+++ b/forven/auth/store.py
@@ -20,7 +20,7 @@ log = logging.getLogger("forven.auth.store")
 
 LOCK_PATH = AUTH_FILE.with_suffix(".lock")
 REFRESH_BUFFER_MS = 5 * 60 * 1000  # 5 minutes before expiry
-_SUPPORTED_AUTH_PROVIDERS = {"openai", "minimax", "lmstudio", "zai", "openrouter", "anthropic", "deepseek", "groq", "gemini", "cerebras", "mistral", "xai", "together", "opencode-zen", "opencode-go"}
+_SUPPORTED_AUTH_PROVIDERS = {"openai", "minimax", "lmstudio", "zai", "openrouter", "anthropic", "deepseek", "groq", "gemini", "cerebras", "mistral", "xai", "together", "opencode-zen", "opencode-go", "claude-cli"}
 _AUTH_SECRET_FIELDS = {"access", "refresh", "token", "id_token", "api_key", "api_secret"}
 
 # Runtime-only marker attached to a profile whose ciphertext could not be
@@ -64,6 +64,8 @@ _ENV_BASE_URL_KEYS = {
     "together": ("TOGETHER_BASE_URL",),
     "opencode-zen": ("OPENCODE_ZEN_BASE_URL",),
     "opencode-go": ("OPENCODE_GO_BASE_URL",),
+    # claude-cli stores the binary path under "base_url" (keyless local CLI).
+    "claude-cli": ("CLAUDE_CLI_BIN",),
 }
 
 
@@ -338,6 +340,21 @@ def get_profile(provider: str) -> dict | None:
     store = load_auth()
     stored = store["profiles"].get(f"{provider}:default")
     env_override = _env_profile(provider)
+
+    # claude-cli is a keyless local provider: it is "connected" whenever the
+    # `claude` binary is reachable, with no UI step. Synthesize a default
+    # profile (binary path under base_url) so connection/selection checks pass.
+    if str(provider or "").strip().lower() == "claude-cli" and not stored:
+        try:
+            from forven.claude_cli import _default_binary, binary_available
+
+            if binary_available():
+                synthetic = {"provider": "claude-cli", "base_url": _default_binary()}
+                if env_override:
+                    synthetic.update(env_override)
+                return synthetic
+        except Exception:
+            pass
     if is_profile_opaque(stored):
         if env_override:
             env_override["provider"] = str(provider or "").strip().lower()
@@ -439,6 +456,11 @@ def get_token(provider: str) -> str:
             or ""
         ).strip()
 
+    if provider == "claude-cli":
+        # Keyless: the local CLI authenticates via the operator's own Claude
+        # Code session; there is no token to hand back.
+        return ""
+
     if _is_expired(profile):
         refresher = REFRESHERS.get(provider)
         if refresher and profile.get("refresh"):
@@ -508,6 +530,16 @@ def credential_status(provider: str) -> str:
     # An explicit env-var credential always counts as usable.
     if _env_profile(prov):
         return "ok"
+    # Keyless local CLI: usable whenever the `claude` binary resolves; it has no
+    # stored credential, so the profile-based checks below would wrongly call it
+    # "missing".
+    if prov == "claude-cli":
+        try:
+            from forven.claude_cli import binary_available
+
+            return "ok" if binary_available() else "missing"
+        except Exception:
+            return "missing"
     store = load_auth()
     stored = store.get("profiles", {}).get(f"{prov}:default")
     if stored is None:

--- a/forven/claude_cli.py
+++ b/forven/claude_cli.py
@@ -1,0 +1,242 @@
+"""Local Claude Code CLI as an LLM provider backend.
+
+Shells out to the ``claude`` binary in headless print mode
+(``claude -p --output-format json``) and returns the model's text. This uses
+the operator's local Claude Code session/subscription — there is no API key
+and no per-token API spend, so it is a *keyless* provider like ``lmstudio``.
+
+The CLI is itself an agent with its own tool loop; when we use it purely as a
+text LLM we (a) replace its system prompt with the caller's via
+``--system-prompt``, (b) disable every tool so it can never touch the
+filesystem or run commands, and (c) strip the per-machine dynamic system-prompt
+sections (cwd/git/memory/env) to cut the ~16k-token overhead and avoid leaking
+host context into the prompt.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import shutil
+
+log = logging.getLogger("forven.claude_cli")
+
+DEFAULT_BIN = "claude"
+DEFAULT_TIMEOUT = 180.0
+
+# Tools the CLI must never use while acting as a plain text LLM. Passed to
+# ``--disallowed-tools`` (variadic). Belt-and-suspenders: the prompts we send
+# never ask for tools, but a borrowed model should not be able to shell out.
+_DISALLOWED_TOOLS = (
+    "Bash", "Edit", "Write", "Read", "NotebookEdit",
+    "WebFetch", "WebSearch", "Task", "Glob", "Grep",
+)
+
+# Short model_ids we expose in the catalog map straight onto the CLI's model
+# aliases; anything else is passed through unchanged (full model names work).
+_MODEL_ALIASES = {"opus": "opus", "sonnet": "sonnet", "haiku": "haiku"}
+
+# Neutral working dir so the CLI does not pick up the project's CLAUDE.md or
+# git status. Created lazily on first call.
+_CWD = os.path.join(os.path.expanduser("~/.forven"), "claude_cli_cwd")
+
+
+def _binary_exists(binary: str) -> bool:
+    if os.path.sep in binary:
+        return os.path.isfile(binary) and os.access(binary, os.X_OK)
+    return shutil.which(binary) is not None
+
+
+# Common install locations checked when ``claude`` is not on PATH. The server
+# process (uvicorn) often runs with a minimal PATH that omits ``~/.local/bin``
+# where the per-user CLI installs, so PATH lookup alone is not enough.
+_FALLBACK_BIN_PATHS = (
+    os.path.expanduser("~/.local/bin/claude"),
+    "/usr/local/bin/claude",
+    "/usr/bin/claude",
+    os.path.expanduser("~/.claude/local/claude"),
+)
+
+
+def _default_binary() -> str:
+    """Resolve the binary to an ABSOLUTE path when possible (env > PATH > known
+    install locations), never consulting the auth store.
+
+    Returning an absolute path matters: the server process may not have the
+    CLI's install dir on PATH, so ``create_subprocess_exec`` needs the full
+    path. Used by ``get_profile`` synthesis and ``binary_available`` so they
+    cannot recurse back into ``get_profile`` (which builds the profile).
+    """
+    env = os.environ.get("CLAUDE_CLI_BIN", "").strip()
+    if env:
+        return env
+    found = shutil.which(DEFAULT_BIN)
+    if found:
+        return found
+    for path in _FALLBACK_BIN_PATHS:
+        if os.path.isfile(path) and os.access(path, os.X_OK):
+            return path
+    return DEFAULT_BIN
+
+
+def binary_available() -> bool:
+    """True when the ``claude`` binary is reachable (no auth-store lookup)."""
+    return _binary_exists(_default_binary())
+
+
+def resolve_binary() -> str:
+    """Resolve the ``claude`` executable at call time: profile override > default.
+
+    Safe to consult the auth store here: a stored profile short-circuits before
+    synthesis, and the synthetic profile's ``base_url`` is itself
+    ``_default_binary()`` — so no recursion.
+    """
+    try:
+        from forven.auth.store import get_profile
+
+        profile = get_profile("claude-cli") or {}
+    except Exception:
+        profile = {}
+    candidate = str(profile.get("bin") or profile.get("base_url") or "").strip()
+    return candidate or _default_binary()
+
+
+def _map_model(model: str | None) -> str:
+    raw = str(model or "").strip()
+    if not raw:
+        return "sonnet"
+    if ":" in raw:  # tolerate a leftover provider prefix
+        raw = raw.split(":", 1)[1].strip()
+    return _MODEL_ALIASES.get(raw.lower(), raw)
+
+
+def _serialize_content(content: object) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                text = item.strip()
+            elif isinstance(item, dict):
+                text = str(item.get("text") or item.get("content") or "").strip()
+            else:
+                text = ""
+            if text:
+                parts.append(text)
+        return "\n".join(parts)
+    if isinstance(content, dict):
+        return str(content.get("text") or content.get("content") or "").strip()
+    return str(content).strip()
+
+
+def flatten_messages(messages: list[dict] | None) -> str:
+    """Flatten a chat history into a single prompt transcript for ``-p``."""
+    if not messages:
+        return ""
+    if len(messages) == 1:
+        only = _serialize_content(messages[0].get("content"))
+        if only:
+            return only
+    parts: list[str] = []
+    for message in messages:
+        role = str(message.get("role") or "user").strip().upper() or "USER"
+        content = _serialize_content(message.get("content"))
+        if content:
+            parts.append(f"{role}: {content}")
+    return "\n\n".join(parts)
+
+
+async def run_claude_cli(
+    *,
+    prompt: str,
+    system: str | None = None,
+    model: str | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> tuple[str, dict]:
+    """Run ``claude -p`` for a single text turn. Returns ``(text, usage)``.
+
+    Raises ``RuntimeError`` on a non-zero exit, unparseable output, an error
+    result, or a timeout — so the caller's provider-health classification and
+    fallback chain see a normal exception.
+    """
+    binary = resolve_binary()
+    args = [binary, "-p", "--output-format", "json", "--model", _map_model(model),
+            "--exclude-dynamic-system-prompt-sections"]
+    sys_prompt = str(system or "").strip()
+    if sys_prompt:
+        args += ["--system-prompt", sys_prompt]
+    args += ["--disallowed-tools", *_DISALLOWED_TOOLS]
+
+    try:
+        os.makedirs(_CWD, exist_ok=True)
+        cwd = _CWD
+    except Exception:
+        cwd = None
+
+    # The server's PATH may omit the CLI's install dir; make sure the binary's
+    # own directory and ~/.local/bin are reachable for any helper it spawns.
+    env = dict(os.environ)
+    extra_paths = [os.path.dirname(binary), os.path.expanduser("~/.local/bin")]
+    existing = env.get("PATH", "")
+    prefix = os.pathsep.join(p for p in extra_paths if p and p not in existing.split(os.pathsep))
+    if prefix:
+        env["PATH"] = prefix + (os.pathsep + existing if existing else "")
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *args,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=cwd,
+            env=env,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            f"claude CLI not found ({binary!r}). Install Claude Code or set "
+            f"CLAUDE_CLI_BIN."
+        ) from exc
+
+    try:
+        out, err = await asyncio.wait_for(
+            proc.communicate(input=(prompt or "").encode("utf-8")), timeout=timeout
+        )
+    except asyncio.TimeoutError as exc:
+        try:
+            proc.kill()
+        except Exception:
+            pass
+        raise RuntimeError(f"claude CLI timed out after {timeout:.0f}s") from exc
+
+    if proc.returncode != 0:
+        detail = (err or b"").decode("utf-8", "replace").strip()[:500]
+        raise RuntimeError(
+            f"claude CLI exited {proc.returncode}: {detail or 'no stderr'}"
+        )
+
+    try:
+        data = json.loads((out or b"").decode("utf-8", "replace"))
+    except Exception as exc:
+        raise RuntimeError("claude CLI returned non-JSON output") from exc
+
+    if data.get("is_error") or data.get("subtype") not in (None, "success"):
+        status = data.get("api_error_status") or data.get("subtype") or "error"
+        raise RuntimeError(f"claude CLI error result: {status}")
+
+    text = str(data.get("result") or "").strip()
+    raw_usage = data.get("usage") or {}
+    usage = {
+        "input_tokens": int(raw_usage.get("input_tokens", 0) or 0),
+        "output_tokens": int(raw_usage.get("output_tokens", 0) or 0),
+        "cost_usd": data.get("total_cost_usd"),
+    }
+    log.info(
+        "claude-cli/%s: %s in / %s out tokens",
+        _map_model(model), usage["input_tokens"], usage["output_tokens"],
+    )
+    return text, usage

--- a/forven/model_routing.py
+++ b/forven/model_routing.py
@@ -27,6 +27,7 @@ _SUPPORTED_PROVIDERS: tuple[str, ...] = (
     "together",
     "opencode-zen",
     "opencode-go",
+    "claude-cli",
 )
 _MODEL_ROUTING_STORAGE_KEY = "forven:model-routing"
 _LEGACY_MODEL_ALIASES: dict[str, dict[str, str]] = {}
@@ -123,6 +124,7 @@ _DEFAULT_MODEL_ROUTING = {
         "together": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
         "opencode-zen": "grok-code",
         "opencode-go": "glm-5.2",
+        "claude-cli": "sonnet",
     },
     # Every default chain is SELF-ONLY (fail-closed): a slot NEVER silently falls
     # back to a provider the operator didn't choose for it. A throttled/failed
@@ -173,6 +175,9 @@ _DEFAULT_MODEL_ROUTING = {
         ],
         "opencode-go": [
             {"provider": "opencode-go", "model_id": "glm-5.2"},
+        ],
+        "claude-cli": [
+            {"provider": "claude-cli", "model_id": "sonnet"},
         ],
     },
     "auxiliary": copy.deepcopy(_DEFAULT_AUXILIARY_ROUTING),

--- a/forven/model_selection.py
+++ b/forven/model_selection.py
@@ -143,7 +143,7 @@ def unmark_provider_connected(provider: str) -> None:
 # returns "" by design and there is no spend to authorize. For these a
 # configured profile (a base URL) is enough to be usable — requiring a bearer
 # token would make them permanently unconnectable AND uncallable.
-_KEYLESS_PROVIDERS = {"lmstudio"}
+_KEYLESS_PROVIDERS = {"lmstudio", "claude-cli"}
 
 
 def _provider_has_token(provider: str) -> bool:


### PR DESCRIPTION
<!--
Heads up: Forven is NOT yet accepting external code contributions — a contributor agreement (CLA) isn't in place, so outside pull requests can't be merged for now. See CONTRIBUTING.md. Issues, ideas, and discussion are very welcome.

If you're the maintainer (or PRs have since opened), fill in the below.
-->

## Summary

Adds a new **`claude-cli`** AI provider that shells out to the locally installed [Claude Code](https://claude.com/claude-code) CLI (`claude -p --output-format json`) instead of calling an HTTP API.

**Why:** it lets an operator drive the agents/brain with Claude (Sonnet/Opus/Haiku) using their own local Claude session/subscription, with **no API key and no per-token API spend** — the same "keyless local provider" shape as the existing `lmstudio` backend.

**How it works**

- New `forven/claude_cli.py` — an async `asyncio.create_subprocess_exec` wrapper that:
  - replaces the CLI's system prompt with the caller's (`--system-prompt`) so it behaves as a plain text LLM rather than the Claude Code coding agent;
  - **disables every tool** (`--disallowed-tools …`) so the "model" can never touch the filesystem or run commands;
  - strips per-machine dynamic prompt sections (`--exclude-dynamic-system-prompt-sections`) to cut the system-prompt token overhead and avoid leaking host context;
  - resolves the binary to an **absolute path** (env `CLAUDE_CLI_BIN` → PATH → common install locations such as `~/.local/bin/claude`) and augments the child `PATH`, because the server process often runs with a minimal PATH that omits the per-user install dir.
- Wires the provider into **both** call paths: the simple completion path (`forven/ai.py::_call_single` → `_call_claude_cli`), and the agentic tool-call factory (`forven/agents/providers.py::ClaudeCLIProvider`).
- Registers it across the supporting lists: model routing (`_SUPPORTED_PROVIDERS`, default + fallback models), the agent model catalog and auth-provider lists (`api_core`), keyless handling (`model_selection`), and the auth store (supported set, `CLAUDE_CLI_BIN` env var, a synthetic keyless profile, and keyless `get_token` / `credential_status`).

**Models exposed:** `claude-cli:sonnet`, `claude-cli:opus`, `claude-cli:haiku`.

### Known limitation (by design)

The Claude CLI is itself an agent that runs its **own** internal tool loop, so it cannot hand Forven's runner a list of `tool_calls` to execute. The agentic adapter therefore returns a single **text-only** turn (`stop=True`). This is ideal for the brain / chat / narrative-analysis work, but agents that depend on Forven-side tools (ChromaDB search, backtests, …) will get a direct answer instead of a tool-using loop. Bridging Forven's tools into the CLI (e.g. via MCP) is left as possible follow-up.

## Related issues

Closes # _(none — opportunistic contribution)_

## Testing

- [x] `python -m pytest tests -q` (or the relevant subset) passes — ran the subset covering this change (`-k "provider or model_selection or model_routing or auth or catalog or brain_model"`): **218 passed, 3 skipped**. The 4 failures observed are **pre-existing and unrelated to this PR** (this commit touches only the 7 files listed above — not `runtime_worker.py` nor the OAuth code): `tests/test_brain_model_selection.py` (×2) fail with `TypeError: _fake_call_with_tools() got an unexpected keyword argument 'agent_id'` — the test's local mock is stale vs. the existing `_call_with_tools(..., agent_id=...)` signature; `tests/test_oauth_ux_rework.py` (×2) fail with `OSError: [Errno 98] Address already in use` (port 1455) — an environment/port-bind conflict in the callback-listener test. Also verified manually end-to-end: `import forven.api` loads cleanly; `call_ai("claude-cli", model="sonnet", …)` returns the expected text; `ClaudeCLIProvider().call(…)` returns a populated `ProviderResponse`; live API with brain set to `claude-cli:sonnet`, `POST /api/brain/chat/direct` returns a real CLI-generated answer and `/api/agents/provider-health` reports `claude-cli: ok`.
- [x] `python -m ruff check forven tests` is clean (only a pre-existing, unrelated `# noqa` warning in `tests/test_assistant_session.py`).
- [ ] `cd frontend && npm run check` passes (if frontend touched) — N/A, this change is backend-only; no frontend files touched.

## Checklist

- [x] No secrets, credentials, or personal info added — the provider is keyless; it authenticates via the operator's local Claude Code session.
- [x] Defaults remain safe (paper/testnet; no new outbound calls to any server) — the provider is **opt-in**: it is only used when an operator explicitly connects and selects it. Default model routing is unchanged, so no new outbound traffic occurs by default. When selected, the local `claude` CLI makes the outbound call (to Anthropic) on the operator's behalf — no new network path is added inside Forven itself.
- [ ] Docs / `.env.example` updated if behavior or config changed — adds one optional env var, `CLAUDE_CLI_BIN` (overrides the `claude` binary path). Not added to `.env.example`/docs in this PR — happy to include if desired.