### PR TITLE
fix(gauntlet): correct DSR selection-bias accounting end to end

### DIFF
--- a/forven/agents/tools_assistant.py
+++ b/forven/agents/tools_assistant.py
@@ -49,7 +49,8 @@ _COMMON_FAMILIES = (
         "Use this to answer 'how are we doing?' / risk questions."
     ),
     input_schema={"type": "object", "properties": {}, "required": []},
-    permissions={"brain", None},
+    # risk-manager: read-only introspection for the scheduled risk audit.
+    permissions={"brain", "role:risk-manager", None},
 )
 def _tool_get_portfolio_status() -> str:
     from forven.db import get_open_trades, kv_get
@@ -129,7 +130,8 @@ def _tool_get_market_regime() -> str:
         },
         "required": ["strategy_id"],
     },
-    permissions={"brain", None},
+    # risk-manager: read-only introspection for the scheduled risk audit.
+    permissions={"brain", "role:risk-manager", None},
 )
 def _tool_get_strategy_detail(strategy_id: str) -> str:
     sid = str(strategy_id or "").strip()
@@ -400,7 +402,8 @@ def _tool_get_gate_report(strategy_id: str) -> str:
         },
         "required": [],
     },
-    permissions={"brain", None},
+    # risk-manager: read-only introspection for the scheduled risk audit.
+    permissions={"brain", "role:risk-manager", None},
 )
 def _tool_get_recent_trades(status: str = "", strategy_id: str = "", limit: int = 20) -> str:
     from forven.db import get_open_trades, get_recent_trades
@@ -628,7 +631,8 @@ def _tool_list_hypotheses(status: str = "", search: str = "", limit: int = 20) -
         "status, open positions, closed trades, realized PnL."
     ),
     input_schema={"type": "object", "properties": {}, "required": []},
-    permissions={"brain", None},
+    # risk-manager: read-only introspection for the scheduled risk audit.
+    permissions={"brain", "role:risk-manager", None},
 )
 def _tool_list_bots() -> str:
     from forven.api_domains.bot_factory import api_list_bots

--- a/forven/api_core.py
+++ b/forven/api_core.py
@@ -11241,8 +11241,26 @@ def post_optimization_submit(body: OptimizationSubmitBody):
             metrics_for_storage["status"] = "succeeded"
             if isinstance(best_params, dict):
                 metrics_for_storage["best_params"] = best_params
-            if body.n_trials is not None:
+            # Persist the ACTUAL selection breadth (combos evaluated, stamped by the
+            # optimizer) — the caller's requested budget is only a fallback. This is
+            # what the Deflated Sharpe reads as n_trials; storing the request
+            # understates the deflation when the grid ran wider than asked.
+            try:
+                actual_trials = int(opt_result.get("n_trials") or 0)
+            except (TypeError, ValueError):
+                actual_trials = 0
+            if actual_trials > 0:
+                metrics_for_storage["n_trials"] = actual_trials
+            elif body.n_trials is not None:
                 metrics_for_storage.setdefault("n_trials", int(body.n_trials))
+            # Cross-trial Sharpe dispersion: lets the DSR use the real trial
+            # variance instead of its conservative estimator proxy.
+            if opt_result.get("trial_sharpe_var") is not None:
+                try:
+                    metrics_for_storage["trial_sharpe_var"] = float(opt_result["trial_sharpe_var"])
+                    metrics_for_storage["trial_sharpe_count"] = int(opt_result.get("trial_sharpe_count") or 0)
+                except (TypeError, ValueError):
+                    pass
             if body_objective is not None:
                 metrics_for_storage.setdefault("objective", body_objective)
             if opt_result.get("wfa_verdict") is not None:

--- a/forven/gauntlet/deflated_sharpe.py
+++ b/forven/gauntlet/deflated_sharpe.py
@@ -15,6 +15,14 @@ default off) so its behaviour can be watched before it blocks anything.
 
 Note: returns scale cancels in the Sharpe / skew / kurtosis, so per-trade pnl in
 ratio or percent units gives the same DSR — no unit normalisation needed.
+
+Swarm-level selection (issue #17): the optimizer trial count only corrects for
+parameter search WITHIN one strategy. The agent swarm also tries many sibling
+hypotheses per idea-cluster (family x asset) and only survivors reach the
+gauntlet, so a survivor's effective trial count is per-strategy trials x cluster
+attempts. compute_strategy_dsr() therefore multiplies n_trials by (1 + disproven
+same-cluster hypotheses, reusing the graveyard clustering in forven.hypotheses)
+when the strategy's origin hypothesis is known.
 """
 
 from __future__ import annotations
@@ -120,6 +128,75 @@ def deflated_sharpe_ratio(
     }
 
 
+def _extract_trade_returns(trades: list) -> list[float]:
+    """Per-trade returns in field-preference order (see comment in the loop)."""
+    returns: list[float] = []
+    for tr in trades:
+        if not isinstance(tr, dict):
+            continue
+        # Prefer the scale-invariant per-trade RETURN fields. ``pnl`` is compounded
+        # dollars off a growing equity base — a TIME-VARYING scale that distorts
+        # sr_hat/skew/kurt (and thus the DSR + its SR0 benchmark). ``return_pct``
+        # (= ratio*100, present on every normalized trade) is a constant scale of the
+        # true ratio, so it yields the intended scale-invariant DSR; demote ``pnl``
+        # to a last resort.
+        r = tr.get("net_pnl_pct")
+        if r is None:
+            r = tr.get("pnl_pct")
+        if r is None:
+            r = tr.get("return_pct")
+        if r is None:
+            r = tr.get("pnl")
+        if r is None:
+            continue
+        try:
+            rv = float(r)
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(rv):
+            returns.append(rv)
+    return returns
+
+
+def per_trade_sharpe(trades: list, *, min_trades: int = 5) -> float | None:
+    """Per-trade Sharpe (population mean/std of per-trade returns) for ONE trial.
+
+    Same definition as ``sr_hat`` in deflated_sharpe_ratio, so a variance computed
+    ACROSS trials from these values lives on the same scale as the observed Sharpe
+    (the whole point: it feeds ``trial_sharpe_var``). Returns None below
+    ``min_trades`` — an SR estimate from a handful of trades is estimation noise,
+    not trial dispersion — and on zero variance.
+    """
+    rs = _extract_trade_returns(trades if isinstance(trades, list) else [])
+    if len(rs) < max(int(min_trades), 2):
+        return None
+    mean_r = sum(rs) / len(rs)
+    var_r = sum((r - mean_r) ** 2 for r in rs) / len(rs)
+    if var_r <= 1e-24:
+        return None
+    return mean_r / math.sqrt(var_r)
+
+
+def _latest_trial_sharpe_var(opt_metrics: dict | None, opt_config: dict | None) -> float | None:
+    """Persisted cross-trial Sharpe variance from the latest optimization, if usable.
+
+    Requires >= 5 contributing trials — a dispersion estimated from fewer is too
+    noisy, and an under-estimate would INFLATE the DSR; the conservative
+    estimator proxy stays the fallback.
+    """
+    for blob in (opt_metrics, opt_config):
+        if not isinstance(blob, dict) or blob.get("trial_sharpe_var") is None:
+            continue
+        try:
+            var = float(blob.get("trial_sharpe_var"))
+            count = int(blob.get("trial_sharpe_count") or 0)
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(var) and var > 0 and count >= 5:
+            return var
+    return None
+
+
 def _latest_n_trials(opt_metrics: dict | None, opt_config: dict | None, default_trials: int) -> int:
     for blob in (opt_metrics, opt_config):
         if isinstance(blob, dict) and blob.get("n_trials") is not None:
@@ -132,11 +209,51 @@ def _latest_n_trials(opt_metrics: dict | None, opt_config: dict | None, default_
     return max(int(default_trials), 1)
 
 
+def _swarm_cluster_attempts(strategy_id: str, lookback_days: int) -> int:
+    """Disproven same-cluster (family x asset) hypothesis siblings of the strategy's
+    origin hypothesis — the swarm-level selection pressure behind this survivor.
+    Returns 0 (no adjustment) when the strategy has no hypothesis link (manual /
+    imported strategies) and on ANY error: the swarm factor is advisory and must
+    never take down the base DSR."""
+    try:
+        from forven.db import get_db
+        from forven.hypotheses import disproven_cluster_count, get_hypothesis
+
+        with get_db() as conn:
+            row = conn.execute(
+                "SELECT hypothesis_id, origin_crucible_id FROM strategies WHERE id = ?",
+                (str(strategy_id),),
+            ).fetchone()
+        if not row:
+            return 0
+        hyp_id = row["hypothesis_id"] or row["origin_crucible_id"]
+        if not hyp_id:
+            return 0
+        hyp = get_hypothesis(str(hyp_id))
+        if not hyp:
+            return 0
+        return max(
+            0,
+            int(
+                disproven_cluster_count(
+                    title=hyp.get("title"),
+                    market_thesis=hyp.get("market_thesis"),
+                    mechanism=hyp.get("mechanism"),
+                    target_assets=hyp.get("target_assets") or [],
+                    lookback_days=max(0, int(lookback_days)),
+                )
+            ),
+        )
+    except Exception:
+        return 0
+
+
 def compute_strategy_dsr(strategy_id: str, *, default_trials: int | None = None) -> dict | None:
     """Best-effort DSR for a strategy's latest backtest. Returns None on any issue.
 
     Pulls per-trade returns from the latest backtest result and the trial count
-    from the latest optimization result (falling back to the configured default).
+    from the latest optimization result (falling back to the configured default),
+    then scales the trial count by the swarm-level cluster attempts (issue #17).
     Never raises — DSR is advisory, not on the critical path.
     """
     try:
@@ -144,13 +261,16 @@ def compute_strategy_dsr(strategy_id: str, *, default_trials: int | None = None)
 
         from forven.db import get_db
 
+        try:
+            from forven.policy import load_pipeline_config
+
+            rob = load_pipeline_config().get("robustness_thresholds", {}) or {}
+        except Exception:
+            rob = {}
         if default_trials is None:
             try:
-                from forven.policy import load_pipeline_config
-
-                rob = load_pipeline_config().get("robustness_thresholds", {}) or {}
                 default_trials = int(rob.get("deflated_sharpe_default_trials", 50) or 50)
-            except Exception:
+            except (TypeError, ValueError):
                 default_trials = 50
 
         with get_db() as conn:
@@ -180,44 +300,39 @@ def compute_strategy_dsr(strategy_id: str, *, default_trials: int | None = None)
         if not isinstance(trades, list) or not trades:
             return None
 
-        returns: list[float] = []
-        for tr in trades:
-            if not isinstance(tr, dict):
-                continue
-            # Prefer the scale-invariant per-trade RETURN fields. ``pnl`` is compounded
-            # dollars off a growing equity base — a TIME-VARYING scale that distorts
-            # sr_hat/skew/kurt (and thus the DSR + its SR0 benchmark). ``return_pct``
-            # (= ratio*100, present on every normalized trade) is a constant scale of the
-            # true ratio, so it yields the intended scale-invariant DSR; demote ``pnl``
-            # to a last resort.
-            r = tr.get("net_pnl_pct")
-            if r is None:
-                r = tr.get("pnl_pct")
-            if r is None:
-                r = tr.get("return_pct")
-            if r is None:
-                r = tr.get("pnl")
-            if r is None:
-                continue
-            try:
-                rv = float(r)
-            except (TypeError, ValueError):
-                continue
-            if math.isfinite(rv):
-                returns.append(rv)
-
+        returns = _extract_trade_returns(trades)
         if len(returns) < 2:
             return None
 
         opt_metrics = json.loads(opt["metrics_json"]) if opt and opt["metrics_json"] else None
         opt_config = json.loads(opt["config_json"]) if opt and opt["config_json"] else None
-        n_trials = _latest_n_trials(
+        n_trials_base = _latest_n_trials(
             opt_metrics if isinstance(opt_metrics, dict) else None,
             opt_config if isinstance(opt_config, dict) else None,
             default_trials,
         )
-        result = deflated_sharpe_ratio(returns, n_trials)
-        result["trials_source"] = "optimization_result" if opt else "default"
+
+        # Effective trials = optimizer trials x cluster attempts (the survivor
+        # itself + disproven same-cluster siblings). 0 siblings -> unchanged.
+        swarm_attempts = 0
+        if bool(rob.get("dsr_swarm_trials_enabled", True)):
+            try:
+                lookback = int(rob.get("dsr_swarm_lookback_days", 90))
+            except (TypeError, ValueError):
+                lookback = 90
+            swarm_attempts = _swarm_cluster_attempts(strategy_id, lookback)
+
+        n_trials = n_trials_base * (1 + swarm_attempts)
+        trial_var = _latest_trial_sharpe_var(
+            opt_metrics if isinstance(opt_metrics, dict) else None,
+            opt_config if isinstance(opt_config, dict) else None,
+        )
+        result = deflated_sharpe_ratio(returns, n_trials, trial_var)
+        result["trials_source"] = ("optimization_result" if opt else "default") + (
+            "+swarm" if swarm_attempts > 0 else ""
+        )
+        result["n_trials_base"] = int(n_trials_base)
+        result["swarm_cluster_attempts"] = int(swarm_attempts)
         return result
     except Exception:
         return None

--- a/forven/gauntlet/status.py
+++ b/forven/gauntlet/status.py
@@ -249,6 +249,16 @@ def get_strategy_gauntlet_status(strategy_id: str) -> dict[str, Any]:
     composite = strategy_metrics.get("composite_robustness_score")
     if composite is None:
         composite = strategy_metrics.get("robustness_score") or strategy_metrics.get("robustness") or strategy_metrics.get("gauntlet_score")
+    # Scale-blend guard: legacy writers stored these keys as 0-1 fractions (every
+    # pre-v3 `robustness` value in prod is <= 1.0) while this payload's contract —
+    # and the floor it is compared against — is 0-100. Mirror the frontend history
+    # readers' convention (abs(v) <= 1 -> x100) so a legacy 0.726 surfaces as 72.6
+    # instead of rendering as "0.7 / 100" and false-failing the floor.
+    try:
+        if composite is not None and abs(float(composite)) <= 1.0:
+            composite = round(float(composite) * 100.0, 1)
+    except (TypeError, ValueError):
+        pass
 
     min_robustness = gauntlet_cfg.get("min_robustness_score")
     try:

--- a/forven/policy.py
+++ b/forven/policy.py
@@ -182,6 +182,15 @@ DEFAULT_PIPELINE_CONFIG = {
         "deflated_sharpe_gate_enabled": False,
         "min_deflated_sharpe": 0.90,
         "deflated_sharpe_default_trials": 50,
+        # Swarm-level selection bias (issue #17): the swarm tries many sibling
+        # hypotheses per idea-cluster (family x asset) and only survivors reach
+        # the gauntlet, so the per-strategy optimizer trial count understates the
+        # true selection pressure. When enabled, DSR n_trials is multiplied by
+        # (1 + disproven same-cluster hypotheses within the lookback window;
+        # 0 = unbounded). Safe to leave on: it only changes the computed DSR —
+        # the reject gate above stays opt-in.
+        "dsr_swarm_trials_enabled": True,
+        "dsr_swarm_lookback_days": 90,
     },
     "paper_trading": {
         "min_paper_days": 14,
@@ -3786,10 +3795,18 @@ def _evaluate_gauntlet_gate(strategy_id: str, config: dict) -> tuple[bool, str]:
         if dsr_val is not None:
             min_dsr = float(rob_thresholds.get("min_deflated_sharpe", 0.90))
             if float(dsr_val) < min_dsr:
+                swarm_n = int(dsr_info.get("swarm_cluster_attempts") or 0)
+                if swarm_n > 0:
+                    trials_note = (
+                        f"~{dsr_info.get('n_trials')} effective trials "
+                        f"({dsr_info.get('n_trials_base')} optimizer x "
+                        f"{swarm_n + 1} swarm attempts in this idea-cluster)"
+                    )
+                else:
+                    trials_note = f"{dsr_info.get('n_trials')} trials"
                 return False, (
                     f"DSR REJECT: Deflated Sharpe {float(dsr_val):.2f} below {min_dsr:.2f} "
-                    f"target (likely an optimizer selection artifact across "
-                    f"{dsr_info.get('n_trials')} trials)"
+                    f"target (likely a selection artifact across {trials_note})"
                 )
 
     # S00552: Profit Factor enforcement at gauntlet (in addition to quick_screen).

--- a/forven/strategies/optimizer.py
+++ b/forven/strategies/optimizer.py
@@ -525,6 +525,8 @@ def grid_search(
             metrics = bt.get("metrics", {})
             fitness = score_strategy(metrics)
             objective_score = _objective_value(metrics, normalized_objective)
+            from forven.gauntlet.deflated_sharpe import per_trade_sharpe
+
             return {
                 "params": param_overrides,
                 "full_params": params,
@@ -535,6 +537,11 @@ def grid_search(
                 "objective": normalized_objective,
                 "objective_value": objective_score,
                 "trades": metrics.get("total_trades", 0),
+                # This trial's per-trade Sharpe estimate — the raw material for the
+                # cross-trial dispersion the Deflated Sharpe Ratio needs (see
+                # _stamp_trial_sharpe_stats). Computed here because the trade list
+                # is discarded with the backtest payload.
+                "trade_sharpe": per_trade_sharpe(bt.get("trades") or []),
             }
         except Exception as e:
             log.debug("Grid search combo %d failed: %s", i, e)
@@ -607,8 +614,39 @@ def grid_search(
     for r in results:
         if isinstance(r, dict):
             r["trials_evaluated"] = len(combos)
+    _stamp_trial_sharpe_stats(results)
 
     return results[:TOP_N]
+
+
+def _stamp_trial_sharpe_stats(results: list) -> None:
+    """Cross-trial per-trade-Sharpe dispersion for the Deflated Sharpe Ratio.
+
+    The DSR's expected-max-Sharpe benchmark wants the variance of the Sharpe
+    estimates ACROSS the optimizer's trials; when absent it falls back to a
+    conservative single-strategy estimator proxy that overstates dispersion on
+    small trade samples (real neighboring-param trials are highly correlated, so
+    their true spread is far narrower). Must run over ALL valid trials BEFORE the
+    top-N truncation; stamped on every surviving result so the winner carries it
+    to persistence. Needs >= 5 contributing trials for a meaningful spread.
+    """
+    sharpes = []
+    for r in results:
+        if not isinstance(r, dict):
+            continue
+        s = r.get("trade_sharpe")
+        if isinstance(s, (int, float)) and math.isfinite(float(s)):
+            sharpes.append(float(s))
+    if len(sharpes) < 5:
+        return
+    mean_s = sum(sharpes) / len(sharpes)
+    var_s = sum((s - mean_s) ** 2 for s in sharpes) / len(sharpes)
+    if var_s <= 0:
+        return
+    for r in results:
+        if isinstance(r, dict):
+            r["trial_sharpe_var"] = var_s
+            r["trial_sharpe_count"] = len(sharpes)
 
 
 def optimize_strategy(
@@ -813,6 +851,10 @@ def optimize_strategy(
         # The genuine selection breadth = combos actually evaluated (for the DSR
         # deflation), falling back to the caller's requested budget.
         "n_trials": int(best.get("trials_evaluated") or 0) or n_trials,
+        # Cross-trial Sharpe dispersion (None when < 5 trials contributed) — lets
+        # the DSR use the real trial variance instead of its conservative proxy.
+        "trial_sharpe_var": best.get("trial_sharpe_var"),
+        "trial_sharpe_count": best.get("trial_sharpe_count"),
         "top_results": grid_results[:3],
     }
 

--- a/forven/strategy_diversity.py
+++ b/forven/strategy_diversity.py
@@ -51,6 +51,27 @@ FAMILY_PATTERNS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("cross_asset", ("cross_asset", "cross-asset", "dominance", "relative_value", "relative value", "rotation")),
 )
 
+def _pattern_regex(pattern: str) -> re.Pattern[str]:
+    """Compile a family pattern with token boundaries at its alphanumeric edges.
+
+    Bare substring matching classified any text containing "pe-rsi-stence",
+    "reve-rsi-on" or "dive-rsi-fied" as the rsi family (checked FIRST, so it
+    swallowed other families' hypotheses — 80% of the rsi graveyard was such
+    false positives). Normalization maps punctuation to "_", so "_", space, "-"
+    and "%" all count as separators: "rsi_period"/"RSI(14)" still match, while
+    "persistence" no longer does. Edge-only anchoring keeps prefix patterns like
+    "bb_" matching "bb_width".
+    """
+    prefix = r"(?<![a-z0-9])" if re.match(r"[a-z0-9]", pattern) else ""
+    suffix = r"(?![a-z0-9])" if re.search(r"[a-z0-9]$", pattern) else ""
+    return re.compile(prefix + re.escape(pattern) + suffix)
+
+
+_FAMILY_PATTERN_REGEXES: tuple[tuple[str, tuple[re.Pattern[str], ...]], ...] = tuple(
+    (family, tuple(_pattern_regex(p) for p in patterns)) for family, patterns in FAMILY_PATTERNS
+)
+
+
 def _normalize_text(value: Any) -> str:
     return str(value or "").strip()
 
@@ -69,8 +90,8 @@ def _flatten_payload(value: Any) -> str:
 def infer_strategy_family(*values: Any) -> str:
     text = " ".join(_flatten_payload(value) for value in values)
     normalized = re.sub(r"[^a-z0-9_% -]+", "_", text.lower())
-    for family, patterns in FAMILY_PATTERNS:
-        if any(pattern in normalized for pattern in patterns):
+    for family, regexes in _FAMILY_PATTERN_REGEXES:
+        if any(rx.search(normalized) for rx in regexes):
             return family
     return "other"
 

--- a/frontend/src/lib/api/lifecycle.ts
+++ b/frontend/src/lib/api/lifecycle.ts
@@ -716,6 +716,24 @@ export interface GauntletTestEntry {
 	stale?: boolean | null;
 }
 
+// Deflated Sharpe payload embedded in the gauntlet status response. n_trials is
+// the EFFECTIVE trial count: optimizer trials (n_trials_base) x swarm attempts
+// (1 + swarm_cluster_attempts disproven same-cluster hypotheses, issue #17).
+export interface DeflatedSharpeInfo {
+	dsr: number | null;
+	sr_hat?: number;
+	sr0_benchmark?: number;
+	n_obs?: number;
+	n_trials?: number;
+	n_trials_base?: number;
+	swarm_cluster_attempts?: number;
+	skew?: number;
+	kurtosis?: number;
+	trial_var_source?: string;
+	trials_source?: string;
+	reason?: string;
+}
+
 export interface GauntletStatus {
 	ok: boolean;
 	strategy_id: string;
@@ -726,6 +744,7 @@ export interface GauntletStatus {
 	status: string | null;
 	composite_robustness_score: number | null;
 	min_robustness_score?: number | null;
+	deflated_sharpe?: DeflatedSharpeInfo | null;
 	tests: Record<GauntletTestKey, GauntletTestEntry | null>;
 	tests_completed: number;
 	tests_passed: number;

--- a/frontend/src/lib/components/robustness/GauntletStatusCard.svelte
+++ b/frontend/src/lib/components/robustness/GauntletStatusCard.svelte
@@ -2,6 +2,7 @@
 	import { createEventDispatcher, onDestroy, onMount } from 'svelte';
 	import {
 		getGauntletStatus,
+		type DeflatedSharpeInfo,
 		type GauntletStatus,
 		type GauntletTestEntry,
 		type GauntletTestKey,
@@ -154,6 +155,38 @@
 		return 'border-red-900 bg-red-500/10 text-red-400';
 	}
 
+	function dsrTone(dsr: number): string {
+		// Informational thresholds (the reject gate is opt-in): ~0.95 is the
+		// conventional significance bar for the Deflated Sharpe probability.
+		if (dsr >= 0.95) return 'border-emerald-900 bg-emerald-500/10 text-emerald-400';
+		if (dsr >= 0.8) return 'border-yellow-900 bg-yellow-500/10 text-yellow-400';
+		return 'border-red-900 bg-red-500/10 text-red-400';
+	}
+
+	function dsrTrialsLine(info: DeflatedSharpeInfo): string {
+		if (info.n_trials == null) return '';
+		const swarm = info.swarm_cluster_attempts ?? 0;
+		if (swarm > 0 && info.n_trials_base != null) {
+			return `${info.n_trials} trials · ${info.n_trials_base} opt × ${swarm + 1} swarm`;
+		}
+		return `${info.n_trials} trials`;
+	}
+
+	function dsrTitle(info: DeflatedSharpeInfo): string {
+		const swarm = info.swarm_cluster_attempts ?? 0;
+		const base =
+			'Deflated Sharpe Ratio: probability the edge is real after correcting for selection bias ' +
+			`across ${info.n_trials ?? '?'} effective trials (~0.95 = conventional significance).`;
+		if (swarm > 0) {
+			return (
+				base +
+				` Trial count includes swarm-level selection: ${info.n_trials_base ?? '?'} optimizer trials x ` +
+				`${swarm + 1} attempts in this idea-cluster (${swarm} sibling hypotheses already disproven).`
+			);
+		}
+		return base;
+	}
+
 	function pillTone(entry: GauntletTestEntry | null | undefined): string {
 		const s = (entry?.status ?? 'not_started').toLowerCase();
 		const v = (entry?.verdict ?? '').toUpperCase();
@@ -258,6 +291,18 @@
 					/ 100{status.min_robustness_score != null ? ` · floor ${status.min_robustness_score}` : ''}
 				</div>
 			</div>
+			{#if status.deflated_sharpe?.dsr != null}
+				{@const dsrInfo = status.deflated_sharpe}
+				<div
+					data-testid="gauntlet-dsr"
+					class={`border px-3 py-2 ${dsrTone(Number(dsrInfo.dsr))}`}
+					title={dsrTitle(dsrInfo)}
+				>
+					<div class="text-[9px] font-bold uppercase tracking-widest opacity-80">Deflated Sharpe</div>
+					<div class="text-lg font-bold leading-tight">{Number(dsrInfo.dsr).toFixed(2)}</div>
+					<div class="text-[9px] uppercase tracking-wider opacity-70">{dsrTrialsLine(dsrInfo)}</div>
+				</div>
+			{/if}
 			<div class="flex flex-col gap-0.5 text-[11px]">
 				<div class="text-[#888]">
 					<span class="text-white font-medium">{displayTestsPassed}</span> / {status.tests_total} passed

--- a/frontend/src/lib/settings/manifest.ts
+++ b/frontend/src/lib/settings/manifest.ts
@@ -1150,6 +1150,33 @@ export const SETTINGS_MANIFEST: SettingsEntry[] = [
       'Deflated Sharpe Ratio floor (a probability in 0-1; ~0.95 = conventional significance). Enforced only when the Deflated Sharpe gate is enabled.',
     usedBy: ['forven.policy'],
   },
+  {
+    id: 'pipeline.robustness_thresholds.dsr_swarm_trials_enabled',
+    label: 'DSR swarm-trials factor',
+    default: true,
+    type: 'toggle',
+    area: 'lab',
+    subsection: 'lab-pipeline-robustness-gauntlet',
+    backendSection: 'pipeline',
+    backendPath: 'robustness_thresholds.dsr_swarm_trials_enabled',
+    description:
+      'Fold swarm-level selection bias into the Deflated Sharpe trial count: the agent swarm tries many hypothesis variants per idea-cluster (family x asset) and only survivors reach the gauntlet, so the DSR trial count is multiplied by (1 + disproven same-cluster hypotheses). OFF = correct for per-strategy optimizer trials only.',
+    usedBy: ['forven.gauntlet.deflated_sharpe'],
+  },
+  {
+    id: 'pipeline.robustness_thresholds.dsr_swarm_lookback_days',
+    label: 'DSR swarm lookback',
+    unit: 'days',
+    default: 90,
+    type: 'number',
+    area: 'lab',
+    subsection: 'lab-pipeline-robustness-gauntlet',
+    backendSection: 'pipeline',
+    backendPath: 'robustness_thresholds.dsr_swarm_lookback_days',
+    description:
+      'Window for counting disproven same-cluster hypotheses in the DSR swarm-trials factor. 0 = unbounded (count the full graveyard).',
+    usedBy: ['forven.gauntlet.deflated_sharpe'],
+  },
   // Parameter-jitter compute bounds (the heaviest robustness step: N full-window
   // backtests). These keep the sweep under the step timeout so it can't wedge the
   // gauntlet at param_jitter.

--- a/tests/test_deflated_sharpe.py
+++ b/tests/test_deflated_sharpe.py
@@ -102,3 +102,240 @@ def test_compute_strategy_dsr_best_effort(forven_db):
     from forven.gauntlet.deflated_sharpe import compute_strategy_dsr
 
     assert compute_strategy_dsr("does-not-exist") is None
+
+
+# --- swarm-level trials factor (issue #17) -----------------------------------
+
+def _seed_hypothesis(hid: str, title: str, *, status: str, assets: list[str]):
+    import json
+
+    from forven.db import get_db
+
+    with get_db() as conn:
+        conn.execute(
+            "INSERT INTO hypotheses "
+            "(id,title,market_thesis,mechanism,target_assets,target_timeframes,lane,"
+            " source_type,status,manager_state,novelty_score,created_at,updated_at) "
+            "VALUES (?,?,?,?,?,?,?,?,?,?,?,datetime('now'),datetime('now'))",
+            (hid, title, title, title, json.dumps(assets), json.dumps(["4h"]),
+             "momentum", "agent", status, "active", 0.5),
+        )
+
+
+def _seed_strategy(sid: str, *, hypothesis_id: str | None = None, origin_crucible_id: str | None = None):
+    from forven.db import get_db
+
+    with get_db() as conn:
+        conn.execute(
+            "INSERT INTO strategies (id, name, hypothesis_id, origin_crucible_id) VALUES (?,?,?,?)",
+            (sid, sid, hypothesis_id, origin_crucible_id),
+        )
+
+
+def _seed_ema_cluster(survivor_id: str, disproven: int):
+    _seed_hypothesis(survivor_id, "SOL EMA Cross Trend", status="proven", assets=["SOL"])
+    for i in range(disproven):
+        _seed_hypothesis(f"HD{i}", f"SOL EMA Variant {i}", status="disproven", assets=["SOL"])
+
+
+def test_swarm_cluster_attempts_counts_disproven_siblings(forven_db):
+    from forven.gauntlet.deflated_sharpe import _swarm_cluster_attempts
+
+    _seed_ema_cluster("HS", disproven=2)
+    _seed_hypothesis("HX1", "BTC EMA Cross", status="disproven", assets=["BTC"])    # diff asset
+    _seed_hypothesis("HX2", "SOL RSI Momentum", status="disproven", assets=["SOL"])  # diff family
+    _seed_strategy("S1", hypothesis_id="HS")
+
+    assert _swarm_cluster_attempts("S1", 0) == 2
+
+
+def test_swarm_cluster_attempts_origin_crucible_fallback(forven_db):
+    from forven.gauntlet.deflated_sharpe import _swarm_cluster_attempts
+
+    _seed_ema_cluster("HS", disproven=1)
+    _seed_strategy("S1", origin_crucible_id="HS")  # linked via crucible, not hypothesis_id
+
+    assert _swarm_cluster_attempts("S1", 0) == 1
+
+
+def test_swarm_cluster_attempts_fail_open(forven_db):
+    from forven.gauntlet.deflated_sharpe import _swarm_cluster_attempts
+
+    _seed_strategy("S-nolink")
+    assert _swarm_cluster_attempts("S-nolink", 0) == 0  # no hypothesis link -> no penalty
+    assert _swarm_cluster_attempts("missing", 0) == 0   # unknown strategy -> no penalty
+
+
+def test_swarm_cluster_attempts_respects_lookback_window(forven_db):
+    from forven.db import get_db
+    from forven.gauntlet.deflated_sharpe import _swarm_cluster_attempts
+
+    _seed_ema_cluster("HS", disproven=1)
+    _seed_strategy("S1", hypothesis_id="HS")
+    with get_db() as conn:
+        conn.execute("UPDATE hypotheses SET updated_at = '2020-01-01T00:00:00+00:00' WHERE id = 'HD0'")
+
+    assert _swarm_cluster_attempts("S1", 30) == 0  # disproven outside the window
+    assert _swarm_cluster_attempts("S1", 0) == 1   # 0 = unbounded
+
+
+def _seed_backtest_rows(sid: str, opt_trials: int):
+    import json
+
+    from forven.db import get_db
+
+    with get_db() as conn:
+        conn.execute(
+            "INSERT INTO backtest_results (result_id, strategy_id, result_type, metrics_json) VALUES (?,?,?,?)",
+            (f"bt-{sid}", sid, "backtest", "{}"),
+        )
+        conn.execute(
+            "INSERT INTO backtest_results (result_id, strategy_id, result_type, metrics_json) VALUES (?,?,?,?)",
+            (f"opt-{sid}", sid, "optimization", json.dumps({"n_trials": opt_trials})),
+        )
+
+
+def test_compute_strategy_dsr_applies_swarm_factor(forven_db, monkeypatch):
+    from forven.gauntlet.deflated_sharpe import compute_strategy_dsr
+
+    _seed_ema_cluster("HS", disproven=3)
+    _seed_strategy("S-swarm", hypothesis_id="HS")
+    _seed_strategy("S-solo")  # same returns/trials, no hypothesis link
+    _seed_backtest_rows("S-swarm", opt_trials=10)
+    _seed_backtest_rows("S-solo", opt_trials=10)
+
+    trades = [{"net_pnl_pct": r} for r in _STRONG]
+    monkeypatch.setattr(
+        "forven.api_core.get_backtest_result",
+        lambda result_id, remote_skip=True: {"trades": trades},
+    )
+
+    swarm = compute_strategy_dsr("S-swarm")
+    solo = compute_strategy_dsr("S-solo")
+
+    assert solo["n_trials"] == 10 and solo["swarm_cluster_attempts"] == 0
+    assert solo["trials_source"] == "optimization_result"
+    assert swarm["n_trials_base"] == 10
+    assert swarm["swarm_cluster_attempts"] == 3
+    assert swarm["n_trials"] == 40  # 10 optimizer x (1 survivor + 3 disproven siblings)
+    assert swarm["trials_source"] == "optimization_result+swarm"
+    assert swarm["dsr"] <= solo["dsr"]  # more effective trials -> more deflation
+
+
+def test_compute_strategy_dsr_swarm_knob_off(forven_db, monkeypatch):
+    from forven.gauntlet.deflated_sharpe import compute_strategy_dsr
+
+    _seed_ema_cluster("HS", disproven=3)
+    _seed_strategy("S-swarm", hypothesis_id="HS")
+    _seed_backtest_rows("S-swarm", opt_trials=10)
+
+    trades = [{"net_pnl_pct": r} for r in _STRONG]
+    monkeypatch.setattr(
+        "forven.api_core.get_backtest_result",
+        lambda result_id, remote_skip=True: {"trades": trades},
+    )
+    monkeypatch.setattr(
+        "forven.policy.load_pipeline_config",
+        lambda: {"robustness_thresholds": {"dsr_swarm_trials_enabled": False}},
+    )
+
+    out = compute_strategy_dsr("S-swarm")
+    assert out["n_trials"] == 10
+    assert out["swarm_cluster_attempts"] == 0
+    assert out["trials_source"] == "optimization_result"
+
+
+def test_swarm_defaults_present():
+    from forven.policy import DEFAULT_PIPELINE_CONFIG
+
+    rob = DEFAULT_PIPELINE_CONFIG["robustness_thresholds"]
+    assert rob["dsr_swarm_trials_enabled"] is True
+    assert int(rob["dsr_swarm_lookback_days"]) >= 0
+
+
+# --- real cross-trial variance (replaces the conservative proxy) --------------
+
+def test_per_trade_sharpe_matches_sr_hat_definition():
+    from forven.gauntlet.deflated_sharpe import per_trade_sharpe
+
+    rs = [1.0, -0.5, 2.0, 0.5, -1.0, 1.5]
+    mean = sum(rs) / len(rs)
+    sd = math.sqrt(sum((r - mean) ** 2 for r in rs) / len(rs))  # population, like sr_hat
+    got = per_trade_sharpe([{"pnl_pct": r} for r in rs])
+    assert math.isclose(got, mean / sd, rel_tol=1e-9)
+
+    assert per_trade_sharpe([{"pnl_pct": r} for r in rs[:4]]) is None  # < min_trades
+    assert per_trade_sharpe([{"pnl_pct": 1.0}] * 10) is None           # zero variance
+    assert per_trade_sharpe([]) is None
+
+
+def test_optimizer_stamps_cross_trial_variance():
+    from forven.strategies.optimizer import _stamp_trial_sharpe_stats
+
+    results = [{"trade_sharpe": s} for s in (0.10, 0.14, 0.08, 0.12, 0.11)]
+    results.append({"trade_sharpe": None})       # degenerate trial: excluded, not fatal
+    _stamp_trial_sharpe_stats(results)
+    assert results[0]["trial_sharpe_count"] == 5
+    assert results[0]["trial_sharpe_var"] > 0
+    assert results[-1]["trial_sharpe_var"] == results[0]["trial_sharpe_var"]  # stamped on all
+
+    sparse = [{"trade_sharpe": 0.1}, {"trade_sharpe": 0.2}]
+    _stamp_trial_sharpe_stats(sparse)
+    assert "trial_sharpe_var" not in sparse[0]   # < 5 contributing trials -> no stamp
+
+
+def _seed_opt_row(sid: str, metrics: dict):
+    import json
+
+    from forven.db import get_db
+
+    with get_db() as conn:
+        conn.execute(
+            "INSERT INTO backtest_results (result_id, strategy_id, result_type, metrics_json) VALUES (?,?,?,?)",
+            (f"bt-{sid}", sid, "backtest", "{}"),
+        )
+        conn.execute(
+            "INSERT INTO backtest_results (result_id, strategy_id, result_type, metrics_json) VALUES (?,?,?,?)",
+            (f"opt-{sid}", sid, "optimization", json.dumps(metrics)),
+        )
+
+
+def test_compute_strategy_dsr_uses_persisted_trial_variance(forven_db, monkeypatch):
+    from forven.gauntlet.deflated_sharpe import compute_strategy_dsr
+
+    _seed_strategy("S-var")
+    _seed_strategy("S-proxy")
+    # Real neighboring-param trials are tightly clustered -> tiny true variance.
+    _seed_opt_row("S-var", {"n_trials": 50, "trial_sharpe_var": 1e-4, "trial_sharpe_count": 20})
+    _seed_opt_row("S-proxy", {"n_trials": 50})
+
+    trades = [{"net_pnl_pct": r} for r in _STRONG]
+    monkeypatch.setattr(
+        "forven.api_core.get_backtest_result",
+        lambda result_id, remote_skip=True: {"trades": trades},
+    )
+
+    real = compute_strategy_dsr("S-var")
+    proxy = compute_strategy_dsr("S-proxy")
+
+    assert real["trial_var_source"] == "trials"
+    assert proxy["trial_var_source"] == "estimator_proxy"
+    # Tight true dispersion -> lower expected-max benchmark -> DSR can only improve.
+    assert real["sr0_benchmark"] < proxy["sr0_benchmark"]
+    assert real["dsr"] >= proxy["dsr"]
+
+
+def test_trial_variance_ignored_when_too_few_trials(forven_db, monkeypatch):
+    from forven.gauntlet.deflated_sharpe import compute_strategy_dsr
+
+    _seed_strategy("S-thin")
+    _seed_opt_row("S-thin", {"n_trials": 50, "trial_sharpe_var": 1e-4, "trial_sharpe_count": 3})
+
+    trades = [{"net_pnl_pct": r} for r in _STRONG]
+    monkeypatch.setattr(
+        "forven.api_core.get_backtest_result",
+        lambda result_id, remote_skip=True: {"trades": trades},
+    )
+
+    out = compute_strategy_dsr("S-thin")
+    assert out["trial_var_source"] == "estimator_proxy"  # too few trials -> keep the proxy

--- a/tests/test_gauntlet_workflow_status.py
+++ b/tests/test_gauntlet_workflow_status.py
@@ -188,3 +188,26 @@ def test_gauntlet_status_payload_is_strict_json_with_poisoned_step(forven_db):
     # The strict encoder (FastAPI uses allow_nan=False) must accept the payload.
     json.dumps(payload, allow_nan=False)
     assert payload["ok"] is True
+
+
+def test_gauntlet_status_rescales_legacy_fraction_composite(forven_db):
+    # Legacy strategies carry `metrics.robustness` as a 0-1 fraction; the status
+    # payload contract (and the min_robustness_score floor) is 0-100. A 0.726 must
+    # surface as 72.6 — not render as "0.7 / 100" and false-fail the floor.
+    strategy_id = _create_strategy()
+    with get_db() as conn:
+        conn.execute(
+            "UPDATE strategies SET metrics = ? WHERE id = ?",
+            (json.dumps({"robustness": 0.726}), strategy_id),
+        )
+    status = get_strategy_gauntlet_status(strategy_id)
+    assert status["composite_robustness_score"] == 72.6
+
+    # Modern 0-100 values pass through untouched.
+    with get_db() as conn:
+        conn.execute(
+            "UPDATE strategies SET metrics = ? WHERE id = ?",
+            (json.dumps({"composite_robustness_score": 64.0}), strategy_id),
+        )
+    status = get_strategy_gauntlet_status(strategy_id)
+    assert status["composite_robustness_score"] == 64.0

--- a/tests/test_strategy_diversity.py
+++ b/tests/test_strategy_diversity.py
@@ -80,3 +80,25 @@ def test_filter_recall_records_limits_one_family_dominance():
     assert rsi_count < 8
     assert any("macd" in record["document"] for record in filtered)
     assert any("donchian" in record["document"] for record in filtered)
+
+
+def test_family_matching_requires_token_boundaries():
+    # Bare substring matching classified "pe-rsi-stence" / "reve-rsi-on" /
+    # "dive-rsi-fied" texts as the rsi family (checked first, so it swallowed
+    # other families' rows — observed live: 80% of the disproven rsi graveyard
+    # never mentioned RSI). Family tokens must sit on their own boundaries.
+    from forven.strategy_diversity import infer_strategy_family
+
+    assert infer_strategy_family("Taker-Flow Persistence Breakout") != "rsi"
+    assert infer_strategy_family("Diversified Momentum Basket") == "other"
+    assert infer_strategy_family("OI Divergence Reversal Signal") != "rsi"
+
+    # Real mentions still classify, across the separator alphabet ("_", space,
+    # "-", "%" — normalization maps punctuation to "_").
+    assert infer_strategy_family("RSI(14) Pullback") == "rsi"
+    assert infer_strategy_family("rsi_period: 14") == "rsi"
+    assert infer_strategy_family("Connors RSI2 Dip Buyer") == "rsi"
+    assert infer_strategy_family("bb_width squeeze regime") == "bollinger"
+    assert infer_strategy_family("BTC-EMA_CROSS-S00001") == "ema"
+    assert infer_strategy_family("Williams %R oversold bounce") == "williams_r"
+    assert infer_strategy_family("taker flow imbalance joint predictor") == "volume"


### PR DESCRIPTION
Closes #17

## What this fixes

**Issue #17 — swarm-level selection bias.** `compute_strategy_dsr()` only corrected for one strategy's optimizer trials, ignoring that the agent swarm tries many sibling hypotheses per idea-cluster and only survivors reach the gauntlet. DSR `n_trials` is now multiplied by (1 + disproven same-cluster hypotheses) via the strategy's origin hypothesis, reusing `disproven_cluster_count()`. Fail-open to factor 1 when there is no hypothesis link. New Settings-editable knobs: `dsr_swarm_trials_enabled` (default on) and `dsr_swarm_lookback_days` (90, 0 = unbounded). The DSR reject gate itself stays opt-in OFF.

**Real cross-trial variance.** The optimizer now computes each trial's per-trade Sharpe and persists the cross-trial variance (`trial_sharpe_var`/`trial_sharpe_count`, >= 5 qualifying trials) so the DSR uses measured trial dispersion instead of its conservative estimator proxy. Also persists the ACTUAL `trials_evaluated` instead of the caller's requested budget (latent bug).

**`infer_strategy_family` substring bug.** Bare substring matching classified "pe-rsi-stence"/"reve-rsi-on"/"dive-rsi-fied" texts as the rsi family — 80% of the 90d disproven rsi graveyard never mentioned RSI, poisoning novelty penalties, saturation stats, and the swarm counts (observed: 707 → 222 attempts after fix). Patterns now require token boundaries.

**UI.** First actual DSR render: GauntletStatusCard tile next to Composite with the trials breakdown and tooltip; legacy 0-1 fraction composites normalized to the 0-100 payload scale in gauntlet status.

## Verification

- 25 tests in the DSR suite, plus new classifier-boundary and status-scale tests; optimizer suites green (41 tests)
- Verified live end to end: fresh optimization persisted `trial_sharpe_var` across 38 trials and the strategy's DSR moved 0.41 (proxy) → 0.98 (`trial_var_source: "trials"`); swarm-linked strategy computes 50 × 223 effective trials via the fixed clustering
- Note: also carries 91bee7e (risk-manager read-only tools) from `fixes`, which was not yet in main

🤖 Generated with [Claude Code](https://claude.com/claude-code)