### PR TITLE
fix(backend): loop-starvation cache + windowed DEGRADED banner; GO-LIVE-1 ceiling on session cards

### DIFF
--- a/forven/api_domains/paper.py
+++ b/forven/api_domains/paper.py
@@ -631,6 +631,17 @@ def _collect_compat_paper_sessions(
     # daemon snapshot (no per-session exchange round-trip — WS-starvation safe).
     real_account = _resolve_real_account_snapshot(daemon_state)
 
+    # GO-LIVE-1 ceilings, read once — live opens above the ceiling are refused,
+    # so the session card must show (and let the operator edit) the bound.
+    live_ceilings: dict = {}
+    if include_deployed:
+        try:
+            from forven.exchange.risk import get_live_notional_ceilings
+
+            live_ceilings = get_live_notional_ceilings()
+        except Exception:
+            live_ceilings = {}
+
     sessions: list[dict] = []
     for row in rows:
         strategy_row = dict(row)
@@ -757,7 +768,13 @@ def _collect_compat_paper_sessions(
         account_margin_used: float | None = None
         account_network: str | None = None
         account_synced_at: str | None = None
+        live_notional_ceiling_usd: float | None = None
         if is_deployed:
+            ceiling_entry = live_ceilings.get(strategy_id)
+            if isinstance(ceiling_entry, dict):
+                ceiling_value = trading_domain._coerce_optional_float(ceiling_entry.get("ceiling_usd"))
+                if ceiling_value and ceiling_value > 0:
+                    live_notional_ceiling_usd = ceiling_value
             if real_account["available"]:
                 account_value = float(real_account["account_value"])
                 account_withdrawable = real_account["withdrawable"]
@@ -873,6 +890,9 @@ def _collect_compat_paper_sessions(
                 "balance_source": balance_source,
                 "account_network": account_network,
                 "account_synced_at": account_synced_at,
+                # GO-LIVE-1: per-asset notional ceiling enforced on every live
+                # open (None = no per-strategy cap; deployed sessions only).
+                "live_notional_ceiling_usd": live_notional_ceiling_usd,
                 "total_pnl": total_pnl,
                 "total_pnl_pct": total_pnl_pct,
                 "total_trades": len(all_closed_trade_views),

--- a/forven/loop_watchdog.py
+++ b/forven/loop_watchdog.py
@@ -70,6 +70,7 @@ class LoopLagMonitor:
     def snapshot(self) -> dict:
         recent = sorted(self.samples)
         p95 = recent[int(len(recent) * 0.95)] if recent else 0.0
+        recent_max = recent[-1] if recent else 0.0
         return {
             "last_lag_ms": round(self.last_lag * 1000, 1),
             "p95_lag_ms": round(p95 * 1000, 1),
@@ -77,6 +78,12 @@ class LoopLagMonitor:
             "max_lag_at": self.max_lag_at,
             "stalls_over_warn": self.stall_count,
             "stalls_over_ws_risk": self.ws_risk_count,
+            # Recent = within the rolling sample window (~5 min of ticks). The
+            # health issue keys off these so DEGRADED clears once a storm passes;
+            # the lifetime counters above stay for telemetry/correlation.
+            "recent_max_lag_ms": round(recent_max * 1000, 1),
+            "recent_stalls_over_warn": sum(1 for s in recent if s >= WARN_LAG_SECONDS),
+            "recent_stalls_over_ws_risk": sum(1 for s in recent if s >= WS_RISK_LAG_SECONDS),
             "window_ticks": len(self.samples),
             "tick_seconds": TICK_SECONDS,
         }
@@ -91,13 +98,20 @@ def loop_lag_snapshot() -> dict:
 
 
 def loop_lag_issues() -> list[str]:
-    """Health-check issues derived from recent lag (empty when healthy)."""
+    """Health-check issues derived from recent lag (empty when healthy).
+
+    Keyed off the rolling sample window, NOT the lifetime counters: a stall
+    storm hours ago must not pin the dashboard on DEGRADED until restart.
+    """
     snap = _MONITOR.snapshot()
     issues: list[str] = []
-    if snap["stalls_over_ws_risk"] > 0:
+    if snap["recent_stalls_over_ws_risk"] > 0:
+        window_minutes = snap["window_ticks"] * snap["tick_seconds"] / 60
         issues.append(
             f"event loop stalled >= {WS_RISK_LAG_SECONDS:.1f}s "
-            f"{snap['stalls_over_ws_risk']}x (WS drop risk; max {snap['max_lag_ms']:.0f}ms "
+            f"{snap['recent_stalls_over_ws_risk']}x in the last ~{window_minutes:.0f}min "
+            f"(WS drop risk; recent max {snap['recent_max_lag_ms']:.0f}ms; "
+            f"{snap['stalls_over_ws_risk']}x since start, worst {snap['max_lag_ms']:.0f}ms "
             f"at {snap['max_lag_at']})"
         )
     return issues

--- a/forven/strategies/params.py
+++ b/forven/strategies/params.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 
 log = logging.getLogger("forven.strategies.params")
 _EMITTED_UNKNOWN_PARAM_WARNINGS: set[tuple[str, tuple[str, ...], tuple[str, ...]]] = set()
+_NOVEL_FAMILY_LOGGED: set[str] = set()
 
 
 __all__ = [
@@ -661,7 +662,17 @@ def canonicalize_params(family_type: str, params: dict) -> CanonicalParams:
 
     if resolved_family_type not in SUPPORTED_PARAM_FAMILIES:
 
-        log.info(f"Novel strategy family: {family_type} — accepting all params")
+        # Once per family per process: registry hydration canonicalizes every
+        # active row, so per-call INFO here was >100k log lines a day.
+        if family_type not in _NOVEL_FAMILY_LOGGED:
+
+            _NOVEL_FAMILY_LOGGED.add(family_type)
+
+            log.info(f"Novel strategy family: {family_type} — accepting all params")
+
+        else:
+
+            log.debug(f"Novel strategy family: {family_type} — accepting all params")
 
         return CanonicalParams(family_type, dict(params), [], [])
 

--- a/forven/strategies/registry.py
+++ b/forven/strategies/registry.py
@@ -5,6 +5,8 @@ import inspect
 import json
 import logging
 import pkgutil
+import threading
+import time
 from collections.abc import Mapping
 from datetime import datetime, timezone
 from pathlib import Path
@@ -38,6 +40,22 @@ IMPORTED_TYPE_PREFIX = "imported__"
 _FAILED_CUSTOM_MODULES: set[str] = set()
 _FAILED_CUSTOM_LOGGED: set[str] = set()
 
+# get_active() hydration cache. Hydrating every deployed/paper row is seconds of
+# GIL-held work (JSON + type resolution + instantiation) and was historically
+# re-run PER STRATEGY per scan — dozens of concurrent full sweeps per minute that
+# starved the uvicorn event loop (the "event loop stalled" DEGRADED storms).
+# Entries: (hydrated_map, rows_signature, monotonic_stamp). Within the TTL the
+# cache is returned as-is; after it, a cheap COUNT/MAX(updated_at) signature
+# probe decides whether the hydrate actually needs to re-run.
+_ACTIVE_CACHE: tuple[dict, tuple | None, float] | None = None
+_ACTIVE_CACHE_LOCK = threading.Lock()
+_ACTIVE_CACHE_TTL_SECONDS = 10.0
+
+# Bad-row warnings deduped per (strategy_id, error) per process: the same broken
+# rows re-fail on every hydrate and were emitting thousands of identical
+# warnings a day.
+_BAD_ROW_LOGGED: set[tuple[str, str]] = set()
+
 _discovered = False
 _builtin_discovered = False
 _custom_discovered = False
@@ -56,6 +74,7 @@ _DISAMBIGUATION_MAP: dict[str, str] = {
 def register(strategy: BaseStrategy):
     """Register a strategy instance."""
     _registry[strategy.strategy_id] = strategy
+    invalidate_active_cache()
     log.debug("Registered strategy: %s (%s)", strategy.strategy_id, strategy.name)
 
 
@@ -105,11 +124,62 @@ def get_all() -> dict[str, BaseStrategy]:
     return dict(_registry)
 
 
+def invalidate_active_cache() -> None:
+    """Drop the get_active() hydration cache (next call re-hydrates)."""
+    global _ACTIVE_CACHE
+    _ACTIVE_CACHE = None
+
+
+def _active_rows_signature() -> tuple | None:
+    """Cheap change signature for the deployed/paper rows (None if unreadable)."""
+    try:
+        from forven.db import get_db
+        with get_db() as conn:
+            row = conn.execute(
+                "SELECT COUNT(*), COALESCE(MAX(updated_at), '') FROM strategies "
+                "WHERE status IN ('deployed', 'paper')"
+            ).fetchone()
+        return (int(row[0]), str(row[1]))
+    except Exception:
+        return None
+
+
 def get_active() -> dict[str, BaseStrategy]:
-    """Get strategies eligible for scanning (registered + DB deployed/paper)."""
-    active = dict(_registry)
-    _load_db_strategies(active)
-    return active
+    """Get strategies eligible for scanning (registered + DB deployed/paper).
+
+    Hydration is cached: callers throughout a scan (including per-strategy
+    fallbacks) share one hydrate instead of each re-reading and re-instantiating
+    every row. Staleness is bounded by _ACTIVE_CACHE_TTL_SECONDS, after which a
+    signature probe re-hydrates only if the underlying rows actually changed.
+    """
+    global _ACTIVE_CACHE
+    cached = _ACTIVE_CACHE
+    now = time.monotonic()
+    if cached is not None and (now - cached[2]) < _ACTIVE_CACHE_TTL_SECONDS:
+        return dict(cached[0])
+
+    with _ACTIVE_CACHE_LOCK:
+        cached = _ACTIVE_CACHE
+        now = time.monotonic()
+        if cached is not None and (now - cached[2]) < _ACTIVE_CACHE_TTL_SECONDS:
+            return dict(cached[0])
+
+        sig = _active_rows_signature()
+        if cached is not None and sig is not None and sig == cached[1]:
+            _ACTIVE_CACHE = (cached[0], sig, now)
+            return dict(cached[0])
+        if cached is not None and sig is None:
+            # Signature probe failed (DB contention): serve the stale cache
+            # rather than pile a full hydrate onto a struggling database.
+            _ACTIVE_CACHE = (cached[0], cached[1], now)
+            return dict(cached[0])
+
+        active = dict(_registry)
+        _load_db_strategies(active)
+        # Signature AFTER the hydrate: it may backfill runtime_type (bumping
+        # updated_at), and the post-write state is what the cache now mirrors.
+        _ACTIVE_CACHE = (active, _active_rows_signature(), time.monotonic())
+        return dict(active)
 
 
 def build_strategy_from_row(row: Mapping[str, object]) -> BaseStrategy:
@@ -601,11 +671,16 @@ def _load_archived_custom_runtime_type(runtime_name: str) -> bool:
     module_name = _ARCHIVED_CUSTOM_MODULES.get(str(runtime_name or "").strip().lower())
     if not module_name:
         return False
+    if module_name in _FAILED_CUSTOM_MODULES:
+        return False
     try:
         _load_custom_strategy_module(module_name)
-    except RegistryTypeError:
-        # Broken archived module — don't let the contract error escape the
-        # runtime-type resolver; the type simply stays unresolved.
+    except (RegistryTypeError, ImportError):
+        # Broken/guard-rejected archived module — don't let the error escape the
+        # runtime-type resolver (the type simply stays unresolved), and remember
+        # the failure so every later hydrate doesn't re-read and re-execute the
+        # same broken file.
+        _FAILED_CUSTOM_MODULES.add(module_name)
         return False
     return str(runtime_name or "").strip() in _TYPE_MAP
 
@@ -712,7 +787,12 @@ def _load_db_strategies(target: dict):
                     _inject_regime_metadata(strategy, compatible_regimes, is_all_rounder)
                     target[sid] = strategy
                 except Exception as row_exc:
-                    log.warning("Skipping bad strategy row %s: %s", sid, row_exc)
+                    dedupe_key = (sid, str(row_exc))
+                    if dedupe_key in _BAD_ROW_LOGGED:
+                        log.debug("Skipping bad strategy row %s: %s", sid, row_exc)
+                    else:
+                        _BAD_ROW_LOGGED.add(dedupe_key)
+                        log.warning("Skipping bad strategy row %s: %s", sid, row_exc)
     except Exception as e:
         log.warning("Could not hydrate DB strategies: %s", e)
 
@@ -924,6 +1004,8 @@ def reset():
     _FAILED_CUSTOM_MODULES.clear()
     _FAILED_CUSTOM_LOGGED.clear()
     _SCAN_VERDICT_CACHE.clear()
+    _BAD_ROW_LOGGED.clear()
+    invalidate_active_cache()
     _builtin_discovered = False
     _custom_discovered = False
     _discovered = False

--- a/frontend/src/lib/api/paper.ts
+++ b/frontend/src/lib/api/paper.ts
@@ -142,6 +142,9 @@ export interface PaperTradingSession {
 	balance_source?: 'exchange' | 'books_only' | 'books_aggregate' | 'simulated' | 'unavailable' | string | null;
 	account_network?: string | null;
 	account_synced_at?: string | null;
+	// GO-LIVE-1: per-asset notional ceiling (USD) enforced on every live open;
+	// null = no per-strategy cap. Deployed/live sessions only.
+	live_notional_ceiling_usd?: number | null;
 	total_pnl: number;
 	total_pnl_pct: number | null;
 	total_trades: number;

--- a/frontend/src/lib/components/trading/PaperTrades.svelte
+++ b/frontend/src/lib/components/trading/PaperTrades.svelte
@@ -23,6 +23,7 @@
 		listLifecycleStrategies,
 		getLifecycleStrategy
 	} from '$lib/api';
+	import { setLiveNotionalCeiling } from '$lib/api/forven';
 	import type {
 		Strategy,
 		Dataset,
@@ -116,6 +117,11 @@
 	let openLeverageInput = '1';
 	let openSlInput = '';
 	let openTpInput = '';
+	// GO-LIVE-1 ceiling inline editor (live sessions only). ceilingEditFor holds
+	// the strategy_id being edited so switching sessions closes the editor.
+	let ceilingEditFor: string | null = null;
+	let ceilingInput = '';
+	let ceilingSaving = false;
 	let pendingConfirm: { label: string; detail: string; run: () => Promise<PaperTradingSession> } | null = null;
 	const MANUAL_INPUT_CLASS =
 		'bg-[#0a0a0a] border border-[#333] text-white px-1 py-0.5 text-[10px] focus:outline-none focus:border-gray-500';
@@ -1291,6 +1297,37 @@
 		if (!selectedSession || !pos) return;
 		const paused = !pos.manual_pause;
 		void runManualAction(() => setPaperAutoManagement(selectedSession!.id, paused));
+	}
+
+	function startCeilingEdit(): void {
+		const sid = selectedSession?.strategy_id;
+		if (!sid) return;
+		ceilingInput =
+			selectedSession?.live_notional_ceiling_usd != null
+				? String(selectedSession.live_notional_ceiling_usd)
+				: '';
+		ceilingEditFor = sid;
+	}
+
+	async function handleSaveCeiling(): Promise<void> {
+		const sid = selectedSession?.strategy_id;
+		if (!selectedSession || !sid || ceilingSaving) return;
+		const value = Number(ceilingInput);
+		if (!Number.isFinite(value) || value <= 0) {
+			error = 'Enter a ceiling > 0 (USD).';
+			return;
+		}
+		ceilingSaving = true;
+		error = null;
+		try {
+			await setLiveNotionalCeiling(sid, value);
+			updateSession({ ...selectedSession, live_notional_ceiling_usd: value });
+			ceilingEditFor = null;
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to update the live notional ceiling.';
+		} finally {
+			ceilingSaving = false;
+		}
 	}
 
 	function handleAdjustLevel(kind: 'sl' | 'tp', clear = false): void {
@@ -2859,6 +2896,35 @@
 						<span class="text-gray-500">Default</span>
 						<span class="text-white font-bold ml-1">{humanizeLabel(selectedSession.trade_mode ?? 'long_only')}</span>
 					</span>
+					{#if isLiveSelected}
+						<span class="inline-flex items-center" title="Go-live notional ceiling: the largest order notional (USD) this strategy may open live. Opens above the ceiling are refused, not downsized.">
+							<span class="text-gray-500">Ceiling</span>
+							{#if ceilingEditFor === selectedSession.strategy_id}
+								<input
+									class="{MANUAL_INPUT_CLASS} w-16 ml-1"
+									type="number"
+									min="1"
+									step="50"
+									bind:value={ceilingInput}
+									disabled={ceilingSaving}
+									on:keydown={(e) => {
+										if (e.key === 'Enter') void handleSaveCeiling();
+										if (e.key === 'Escape') ceilingEditFor = null;
+									}}
+								/>
+								<button class="{MANUAL_BTN_CLASS} ml-1" disabled={ceilingSaving} on:click={handleSaveCeiling}>Save</button>
+								<button class="{MANUAL_BTN_CLASS} ml-1" disabled={ceilingSaving} on:click={() => (ceilingEditFor = null)}>Cancel</button>
+							{:else}
+								<span class="text-white font-bold ml-1">
+									{selectedSession.live_notional_ceiling_usd != null ? formatPrice(selectedSession.live_notional_ceiling_usd) : 'none'}
+								</span>
+								<button
+									class="text-[#888] hover:text-white text-[10px] uppercase font-bold ml-1"
+									on:click={startCeilingEdit}
+								>Edit</button>
+							{/if}
+						</span>
+					{/if}
 					{#if blockedMarkers.length > 0}
 						{@const lastBlocked = latestBlockedMarker()}
 						<span title={lastBlocked?.reason ?? 'Blocked signal'}>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,4 +139,12 @@ def forven_db(tmp_path):
     except Exception:
         pass
 
+    # Drop the get_active() hydration cache: it is per-process and would
+    # otherwise serve strategies hydrated from a PREVIOUS test's database.
+    try:
+        import forven.strategies.registry as _registry_mod
+        _registry_mod.invalidate_active_cache()
+    except Exception:
+        pass
+
     return db_path

--- a/tests/test_loop_starvation_fixes.py
+++ b/tests/test_loop_starvation_fixes.py
@@ -49,6 +49,24 @@ def test_loop_lag_issues_flag_ws_risk_only(monkeypatch):
     assert "WS drop risk" in issues[0]
 
 
+def test_loop_lag_issue_clears_once_stall_leaves_sample_window(monkeypatch):
+    monitor = lw.LoopLagMonitor()
+    monkeypatch.setattr(lw, "_MONITOR", monitor)
+    monitor.record(3.0)  # WS-drop-risk stall
+    assert len(lw.loop_lag_issues()) == 1
+
+    # A healthy stretch pushes the stall out of the rolling window: the health
+    # issue must clear (no DEGRADED-until-restart), lifetime counters must stay.
+    for _ in range(monitor.samples.maxlen):
+        monitor.record(0.0)
+
+    assert lw.loop_lag_issues() == []
+    snap = monitor.snapshot()
+    assert snap["stalls_over_ws_risk"] == 1
+    assert snap["recent_stalls_over_ws_risk"] == 0
+    assert snap["max_lag_ms"] == 3000.0
+
+
 def test_health_summary_includes_event_loop(forven_db, monkeypatch):
     monitor = lw.LoopLagMonitor()
     monitor.record(0.05)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -310,3 +310,119 @@ def test_prebuilt_catalog_includes_eth_15m_vwap_pullback_template_without_live_i
         getattr(strategy, "strategy_type", "") != "vwap_pullback_eth_15m"
         for strategy in registry_mod.get_all().values()
     )
+
+
+# ── get_active() hydration cache ─────────────────────────────────────────────
+# Hydration used to re-run per call (per strategy per scan) — the GIL-held
+# sweeps behind the "event loop stalled" DEGRADED storms.
+
+
+def test_get_active_caches_hydration_within_ttl(forven_db, monkeypatch):
+    registry_mod.reset()
+    registry_mod.register_type("macd", DummyStrategy)
+    _insert_strategy_row(
+        "S-CACHED",
+        strategy_type="macd",
+        params=json.dumps({"fast_period": 5}),
+    )
+
+    hydrations = []
+    real_load = registry_mod._load_db_strategies
+
+    def _counting_load(target):
+        hydrations.append(1)
+        real_load(target)
+
+    monkeypatch.setattr(registry_mod, "_load_db_strategies", _counting_load)
+
+    first = registry_mod.get_active()
+    second = registry_mod.get_active()
+
+    assert "S-CACHED" in first
+    assert "S-CACHED" in second
+    assert len(hydrations) == 1
+
+
+def test_get_active_rehydrates_when_rows_change_after_ttl(forven_db):
+    registry_mod.reset()
+    registry_mod.register_type("macd", DummyStrategy)
+    _insert_strategy_row("S-FIRST", strategy_type="macd", params=json.dumps({}))
+
+    assert "S-FIRST" in registry_mod.get_active()
+
+    _insert_strategy_row("S-SECOND", strategy_type="macd", params=json.dumps({}))
+    # Expire the TTL without sleeping: rewind the cache stamp.
+    hydrated, sig, stamp = registry_mod._ACTIVE_CACHE
+    registry_mod._ACTIVE_CACHE = (
+        hydrated,
+        sig,
+        stamp - registry_mod._ACTIVE_CACHE_TTL_SECONDS - 1,
+    )
+
+    active = registry_mod.get_active()
+
+    assert "S-FIRST" in active
+    assert "S-SECOND" in active
+
+
+def test_get_active_skips_rehydrate_when_signature_unchanged(forven_db, monkeypatch):
+    registry_mod.reset()
+    registry_mod.register_type("macd", DummyStrategy)
+    _insert_strategy_row("S-STABLE", strategy_type="macd", params=json.dumps({}))
+
+    assert "S-STABLE" in registry_mod.get_active()
+
+    hydrated, sig, stamp = registry_mod._ACTIVE_CACHE
+    registry_mod._ACTIVE_CACHE = (
+        hydrated,
+        sig,
+        stamp - registry_mod._ACTIVE_CACHE_TTL_SECONDS - 1,
+    )
+
+    def _fail_load(target):
+        raise AssertionError("unchanged rows must not re-hydrate")
+
+    monkeypatch.setattr(registry_mod, "_load_db_strategies", _fail_load)
+
+    assert "S-STABLE" in registry_mod.get_active()
+
+
+def test_get_active_serves_stale_cache_when_signature_probe_fails(forven_db, monkeypatch):
+    registry_mod.reset()
+    registry_mod.register_type("macd", DummyStrategy)
+    _insert_strategy_row("S-STALE-OK", strategy_type="macd", params=json.dumps({}))
+
+    assert "S-STALE-OK" in registry_mod.get_active()
+
+    hydrated, sig, stamp = registry_mod._ACTIVE_CACHE
+    registry_mod._ACTIVE_CACHE = (
+        hydrated,
+        sig,
+        stamp - registry_mod._ACTIVE_CACHE_TTL_SECONDS - 1,
+    )
+    monkeypatch.setattr(registry_mod, "_active_rows_signature", lambda: None)
+
+    def _fail_load(target):
+        raise AssertionError("probe failure must serve the stale cache, not hydrate")
+
+    monkeypatch.setattr(registry_mod, "_load_db_strategies", _fail_load)
+
+    assert "S-STALE-OK" in registry_mod.get_active()
+
+
+def test_load_archived_custom_runtime_type_negative_caches_broken_module(monkeypatch):
+    registry_mod.reset()
+    registry_mod._ARCHIVED_CUSTOM_MODULES["broken_type_s99999"] = "broken_type_s99999"
+
+    attempts = []
+
+    def _always_fails(modname):
+        attempts.append(modname)
+        raise ImportError("rejected by the AST security guard")
+
+    monkeypatch.setattr(registry_mod, "_load_custom_strategy_module", _always_fails)
+
+    assert registry_mod._load_archived_custom_runtime_type("broken_type_s99999") is False
+    assert registry_mod._load_archived_custom_runtime_type("broken_type_s99999") is False
+    assert len(attempts) == 1
+    assert "broken_type_s99999" in registry_mod._FAILED_CUSTOM_MODULES


### PR DESCRIPTION
Two change sets from the 2026-07-03 session, tests green locally (27 passed in test_loop_starvation_fixes + test_registry).

**Loop starvation root cause.** get_active() re-hydrated the full registry (GIL-held seconds) per strategy per scan, starving the single uvicorn event loop — the "event loop stalled" DEGRADED storms. Hydration is now cached (10s TTL + COUNT/MAX(updated_at) signature probe, explicit invalidation, per-test reset in conftest). The health banner keys off stalls in the rolling window so DEGRADED clears when a storm passes instead of pinning until restart. Two per-hydrate log floods deduped.

**GO-LIVE-1 ceiling visibility.** Live opens above the per-strategy notional ceiling are refused at the gate but the bound was invisible; deployed session payloads now carry live_notional_ceiling_usd and the session card shows it with an inline editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)