### PR TITLE
docs(robustness): clarify Monte Carlo tests path stability, not edge existence

### DIFF
--- a/forven/assistant_guide.py
+++ b/forven/assistant_guide.py
@@ -501,7 +501,9 @@ CONCEPTS: dict[str, dict] = {
             "The automated evaluation a strategy must survive before paper: backtest → optimization → "
             "robustness suite (walk-forward, Monte Carlo, parameter jitter, cost stress, regime split) → "
             "verdict. Results are PERSISTED artifacts — the paper gate reads the stored robustness "
-            "verdict, not a fresh opinion."
+            "verdict, not a fresh opinion. Scope note: Monte Carlo bootstraps the realized trades, so it "
+            "tests path/sequencing stability and tail risk — NOT whether the edge is real; that is "
+            "walk-forward's and regime-split's job."
         ),
     },
     "gates": {

--- a/forven/routers/robustness.py
+++ b/forven/routers/robustness.py
@@ -1055,6 +1055,14 @@ def _run_monte_carlo_analysis(body: MonteCarloBody) -> dict:
 
     return {
         "method": "trade_bootstrap",
+        # Interpretation guard (issue #19): this test bootstraps the trades the
+        # baseline ALREADY produced, so a PASS certifies sequencing/tail-risk
+        # stability of that trade set — it is not evidence the edge is real.
+        "scope_note": (
+            "Bootstrap of realized trade returns: tests stability of the trade "
+            "sequence and bounds tail risk. It does not test whether the "
+            "underlying edge is real — walk-forward and regime-split do that."
+        ),
         "original_sharpe": round(original_sharpe, 3),
         "original_return": round(original_return, 2),
         "n_simulations": int(body.n_simulations),

--- a/forven/routers/strategies.py
+++ b/forven/routers/strategies.py
@@ -331,6 +331,7 @@ def get_ai_dropzone_context():
             "Derivatives enrichment columns (funding_rate, open_interest, ls_ratio, taker_buy_sell_ratio, ...) join only when collected and may have shallow in-sample history. Guard `if col in df.columns` and probe that in_sample.total_trades > 0 before committing to a flow-based design.",
             "Rare-entry designs starve the gates: you need >= 15 trades total and enough out-of-sample trades for walk-forward folds (~1y window, ~70/30 IS/OOS split).",
             "Transient verdict probes do NOT count toward promotion. Only the persisted robustness endpoints (/api/robustness/*/submit) write the validation artifacts the paper gate reads.",
+            "A Monte Carlo PASS is NOT evidence the edge is real — it bootstraps the realized trades, so it only certifies sequencing/tail-risk stability of that trade set. Never cite it as edge proof when arguing for promotion; edge existence is what walk-forward and regime-split test.",
         ],
         "sessions": {
             "purpose": "A session is a lightweight grouping token. Tag registrations and backtests with session_id to make 'what did I try in iteration #7' queryable.",

--- a/frontend/src/lib/api/backtesting.ts
+++ b/frontend/src/lib/api/backtesting.ts
@@ -995,6 +995,7 @@ export interface MonteCarloRobustnessResult {
 	drawdown_histogram: RobustnessHistogram;
 	sharpe_histogram: RobustnessHistogram;
 	method?: string;
+	scope_note?: string;
 	job_id?: string;
 	persisted_result_id?: string;
 }

--- a/frontend/src/lib/components/robustness/RobustnessPanel.svelte
+++ b/frontend/src/lib/components/robustness/RobustnessPanel.svelte
@@ -972,6 +972,12 @@
 			: 'mt-3 border border-red-900 bg-red-500/5 px-3 py-2 text-xs text-red-400';
 	}
 
+	// Scope guard (issue #19): MC bootstraps the baseline's realized trades, so a
+	// PASS certifies path/tail-risk stability of that trade set — not edge existence.
+	// Fallback for stored results persisted before the backend emitted scope_note.
+	const MC_SCOPE_NOTE =
+		'Tests stability of the realized trade sequence and bounds tail risk — it does not test whether the underlying edge is real (walk-forward and regime split do that).';
+
 	// ── Scorecard data ──
 	const suiteTests: Array<{ key: SuiteTestKey; label: string; accent: string }> = [
 		{ key: 'walk_forward', label: 'Walk-Forward', accent: 'violet' },
@@ -1336,7 +1342,7 @@
 		on:click={() => toggleSection('monte_carlo')}
 	>
 		<div class="flex items-center gap-3">
-			<span class="text-[10px] font-bold uppercase tracking-widest text-[#888]">Monte Carlo Simulation</span>
+			<span class="text-[10px] font-bold uppercase tracking-widest text-[#888]" title={MC_SCOPE_NOTE}>Monte Carlo Simulation</span>
 			<span class={`border px-1.5 py-0.5 text-[10px] font-bold ${verdictBadge(scorecardVerdicts['monte_carlo'])}`}>{verdictLabel(scorecardVerdicts['monte_carlo'])}</span>
 			{#if loading.monte_carlo}<span class="animate-pulse text-[10px] text-yellow-400">running...</span>{/if}
 		</div>
@@ -1374,6 +1380,9 @@
 							<span class="border border-[#333] bg-black px-1.5 py-0.5 text-[10px] text-[#888]">{methodLabel(monteCarloResult.method)}</span>
 						{/if}
 						<span class="text-[10px] text-[#555]">{monteCarloResult.n_simulations} sims / {monteCarloResult.n_trades} trades</span>
+					</div>
+					<div class="mb-3 border border-[#1a1a1a] bg-black px-2.5 py-1.5 text-[11px] text-[#666]" data-testid="mc-scope-note">
+						{monteCarloResult.scope_note ?? MC_SCOPE_NOTE}
 					</div>
 					{#if monteCarloResult.verdict_reasons?.length}
 						<div class="mb-3 border border-red-900 bg-red-500/5 px-2.5 py-2 text-[11px] text-red-400" data-testid="mc-verdict-reasons">

--- a/frontend/src/lib/help/content.ts
+++ b/frontend/src/lib/help/content.ts
@@ -386,7 +386,7 @@ The process divides history into multiple rolling windows. Each window has a tra
 			'Training period should be 3-5x longer than test period',
 			'Look for consistent performance across ALL folds, not just average',
 			'Run WFA with different window sizes - robust strategies hold up',
-			'Combine with Monte Carlo simulation for even more rigor'
+			'Combine with Monte Carlo for tail-risk context — WFA tests edge existence, MC tests path stability'
 		],
 		examples: [
 			{
@@ -449,6 +449,46 @@ Overfitting is the #1 reason trading strategies fail in production. A 2016 study
 		references: [
 			'Bailey, D.H. et al. (2014). "The Probability of Backtest Overfitting." Journal of Computational Finance.',
 			'López de Prado, M. (2018). "Advances in Financial Machine Learning." Wiley.'
+		]
+	},
+
+	monte_carlo: {
+		id: 'monte_carlo',
+		term: 'Monte Carlo Simulation',
+		shortDescription: 'Bootstrap of realized trade returns measuring path stability and tail risk — not edge existence.',
+		category: 'risk',
+		fullDescription: `Forven's Monte Carlo test resamples the trades from a baseline backtest (bootstrap with replacement) thousands of times, building alternate equity paths from the same trade set in different orders. The distributions of final return and maximum drawdown reveal how much of the backtest's outcome depends on the lucky sequencing of one historical path.
+
+What it tests: given the trades this strategy actually produced, how bad can the drawdown tail get, and how often does a reshuffled path still end profitable? The verdict requires a minimum share of profitable resamples and caps the 95th-percentile drawdown.
+
+What it does NOT test: whether the underlying edge is real. The bootstrap assumes the trade set is valid and only randomizes its ordering — a curve-fitted strategy with a lucky trade set will pass Monte Carlo easily. Edge existence is tested by walk-forward analysis (unseen future data), regime split (does it survive different market conditions), and the deflated Sharpe guard (selection bias). A Monte Carlo PASS means "the trade sequence is stable and ruin risk is bounded", never "the edge is proven".`,
+		interpretations: [
+			{ range: 'Prob profitable ≥ 65%', label: 'Pass floor', color: 'green', description: 'Most reshuffled paths stay profitable — the outcome is not one lucky ordering.' },
+			{ range: 'P95 max DD ≤ 40%', label: 'Tail cap', color: 'green', description: 'Even the bad tail of reshuffled paths keeps drawdown inside the ceiling.' },
+			{ range: 'P95 max DD > 40%', label: 'Tail risk', color: 'red', description: 'A plausible reordering of the same trades breaches the drawdown ceiling.' }
+		],
+		limitations: [
+			'Assumes the baseline trade set is valid — cannot detect an overfit or curve-fitted edge',
+			'Resampling breaks serial correlation between trades (clustered losses may be understated)',
+			'Only randomizes trade ordering, not entry timing against the price series',
+			'Results are conditional on the backtest window; a different window gives a different trade set'
+		],
+		proTips: [
+			'Read a PASS as "path-stable and tail-bounded", not as evidence of edge',
+			'Pair with walk-forward analysis and regime split — those test edge existence',
+			'Watch P95 max drawdown even on a PASS: it is a better sizing guide than the backtest’s single realized drawdown'
+		],
+		examples: [
+			{
+				scenario: '1000 resamples of a 60-trade baseline with +18% total return',
+				calculation: '82% of resampled paths end profitable; P95 max drawdown = 24%',
+				result: 'PASS',
+				interpretation: 'The trade sequence is robust to reordering and tail risk is bounded. Says nothing about whether the entries have predictive power.'
+			}
+		],
+		relatedTerms: ['walk_forward_analysis', 'overfitting', 'max_drawdown'],
+		references: [
+			'Aronson, D. (2006). "Evidence-Based Technical Analysis." Wiley.'
 		]
 	},
 


### PR DESCRIPTION
Closes #19.

## What

The gauntlet's Monte Carlo step bootstraps the baseline's realized trade returns (`_run_monte_carlo_analysis`, `rng.choice(returns_arr, replace=True)`), so a PASS certifies **sequencing/tail-risk stability of the trade set the backtest already produced** — it is not evidence the underlying edge is real. As #19 points out, nothing in the UI or docs stated that negative, so a green MC verdict could be over-read as edge proof.

This PR is interpretation-clarity only — **no threshold, verdict, or gating changes**:

- `forven/routers/robustness.py` — every persisted MC artifact now carries a static `scope_note` field, so all consumers (UI, gate reports, agents reading artifacts) self-describe.
- `RobustnessPanel.svelte` — `title` tooltip on the Monte Carlo section header + a muted scope caption in the results box (renders the backend `scope_note`, local fallback for artifacts persisted before this change). Covers both the Lab panel and the strategy detail robustness tab, which embed the same component.
- `frontend/src/lib/help/content.ts` — new `monte_carlo` help topic with an explicit "what it tests / what it does NOT test" structure; the WFA pro-tip now says "WFA tests edge existence, MC tests path stability" instead of "for even more rigor".
- `forven/assistant_guide.py` — the gauntlet concept the in-app chat draws on carries the scope note.
- `forven/routers/strategies.py` — new Drop Zone gotcha: agents must never cite an MC pass as edge proof when arguing for promotion.

The public docs site gets the matching fix in a companion PR on judder659/forven-site (gauntlet page caveat, pipeline page no longer claims all five tests "prove the edge is real", glossary entry).

The issue's longer-term alternative — an entry-time permutation test that directly falsifies edge existence — is deliberately out of scope here; note that walk-forward, regime-split, and the deflated-Sharpe guard (#17) already cover edge existence today.

## Verification

- `tests/test_robustness_math_regression.py` + `tests/test_robustness_router.py`: 31 passed
- `frontend/src/tests/robustnessPanel.test.ts`: 4 passed
- `py_compile` clean on all touched Python files

Note: the `assistant_guide.py` and Drop Zone gotcha strings take effect on the next backend restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)