### PR TITLE
fix(planner+gauntlet+paper): fruitless-develop 3-strike park; unjudgeable WFA folds block promotion; itemized paper close costs

### DIFF
--- a/forven/api_domains/paper.py
+++ b/forven/api_domains/paper.py
@@ -249,6 +249,23 @@ def _build_compat_paper_trade(trade_row: dict, strategy_name: str, symbol: str) 
             # it matches the realized close path; leverage stays in pnl_pct only.
             pnl = (exit_price - entry_price) * size * signed
 
+    # Real close costs. fees_pct/net_pnl_pct are leverage-inclusive fractions of
+    # margin written at close (scanner._close_trade_db / risk fee-recovery), and
+    # funding_usd is realized funding PAID since open (positive = cost). Convert
+    # to dollars via margin = notional / leverage so the UI can show what the
+    # trade actually netted instead of a zero-filled breakdown.
+    margin = (entry_price * size / leverage) if (entry_price > 0 and size > 0 and leverage > 0) else 0.0
+    fees_pct = trading_domain._coerce_optional_float(trade_row.get("fees_pct"))
+    net_pnl_pct = _normalize_trade_percent_value(trade_row.get("net_pnl_pct"))
+    funding_usd = trading_domain._coerce_optional_float(
+        signal_data.get("funding_usd") if signal_data.get("funding_usd") is not None else signal_data.get("close_funding_usd")
+    ) or 0.0
+    fees_paid = fees_pct * margin if (fees_pct is not None and margin > 0) else 0.0
+    # fees_pct models both legs at the same per-side rate (2 * fee_bps * leverage);
+    # back out the per-side bps so the UI can price each fill's fee off its own leg.
+    per_side_fee_bps = (fees_pct * 10000.0) / (2.0 * leverage) if (fees_pct is not None and leverage > 0) else 0.0
+    net_pnl = pnl - fees_paid - funding_usd if pnl is not None else None
+
     return {
         "id": str(trade_row.get("id") or ""),
         "symbol": symbol,
@@ -262,12 +279,12 @@ def _build_compat_paper_trade(trade_row: dict, strategy_name: str, symbol: str) 
         "pnl_pct": pnl_pct,
         "strategy_name": strategy_name,
         "gross_pnl": pnl,
-        "fees_paid": 0.0,
-        "funding_pnl": 0.0,
-        "net_pnl": pnl,
-        "net_pnl_pct": pnl_pct,
-        "entry_fee_bps": 0.0,
-        "exit_fee_bps": 0.0,
+        "fees_paid": fees_paid,
+        "funding_pnl": -funding_usd,
+        "net_pnl": net_pnl,
+        "net_pnl_pct": net_pnl_pct if net_pnl_pct is not None else pnl_pct,
+        "entry_fee_bps": per_side_fee_bps,
+        "exit_fee_bps": per_side_fee_bps,
         "close_reason": close_reason,
         "close_incomplete": close_incomplete,
     }

--- a/forven/api_domains/paper.py
+++ b/forven/api_domains/paper.py
@@ -249,22 +249,38 @@ def _build_compat_paper_trade(trade_row: dict, strategy_name: str, symbol: str) 
             # it matches the realized close path; leverage stays in pnl_pct only.
             pnl = (exit_price - entry_price) * size * signed
 
-    # Real close costs. fees_pct/net_pnl_pct are leverage-inclusive fractions of
-    # margin written at close (scanner._close_trade_db / risk fee-recovery), and
-    # funding_usd is realized funding PAID since open (positive = cost). Convert
-    # to dollars via margin = notional / leverage so the UI can show what the
-    # trade actually netted instead of a zero-filled breakdown.
+    # Real close costs, two provenances:
+    #  * kernel paper / bot rows persist exact DOLLAR costs in signal_data at close
+    #    (execution_kernel.cost_breakdown_usd) — their pnl_usd is already NET of
+    #    every cost and gross_pnl_usd is the reconstructed pure price PnL;
+    #  * live rows record fees_pct/net_pnl_pct as leverage-inclusive fractions of
+    #    margin (scanner._close_trade_db / risk fee-recovery) with a GROSS pnl_usd,
+    #    plus cost-positive funding_usd in signal_data.
     margin = (entry_price * size / leverage) if (entry_price > 0 and size > 0 and leverage > 0) else 0.0
     fees_pct = trading_domain._coerce_optional_float(trade_row.get("fees_pct"))
     net_pnl_pct = _normalize_trade_percent_value(trade_row.get("net_pnl_pct"))
     funding_usd = trading_domain._coerce_optional_float(
         signal_data.get("funding_usd") if signal_data.get("funding_usd") is not None else signal_data.get("close_funding_usd")
     ) or 0.0
-    fees_paid = fees_pct * margin if (fees_pct is not None and margin > 0) else 0.0
-    # fees_pct models both legs at the same per-side rate (2 * fee_bps * leverage);
-    # back out the per-side bps so the UI can price each fill's fee off its own leg.
-    per_side_fee_bps = (fees_pct * 10000.0) / (2.0 * leverage) if (fees_pct is not None and leverage > 0) else 0.0
-    net_pnl = pnl - fees_paid - funding_usd if pnl is not None else None
+    sd_fee_bps = trading_domain._coerce_optional_float(signal_data.get("fee_bps"))
+    sd_entry_fee = trading_domain._coerce_optional_float(signal_data.get("entry_fee_usd"))
+    sd_exit_fee = trading_domain._coerce_optional_float(signal_data.get("exit_fee_usd"))
+    sd_total_fees = trading_domain._coerce_optional_float(signal_data.get("total_fees_usd"))
+    sd_slippage = trading_domain._coerce_optional_float(signal_data.get("slippage_usd")) or 0.0
+    sd_gross = trading_domain._coerce_optional_float(signal_data.get("gross_pnl_usd"))
+    if sd_gross is not None:
+        gross_pnl = sd_gross
+        fees_paid = sd_total_fees if sd_total_fees is not None else (sd_entry_fee or 0.0) + (sd_exit_fee or 0.0)
+        net_pnl = pnl
+        entry_fee_bps = exit_fee_bps = sd_fee_bps or 0.0
+    else:
+        gross_pnl = pnl
+        fees_paid = fees_pct * margin if (fees_pct is not None and margin > 0) else 0.0
+        # fees_pct models both legs at the same per-side rate (2 * fee_bps * leverage);
+        # back out the per-side bps so the UI can price each fill's fee off its own leg.
+        per_side_fee_bps = (fees_pct * 10000.0) / (2.0 * leverage) if (fees_pct is not None and leverage > 0) else 0.0
+        entry_fee_bps = exit_fee_bps = sd_fee_bps if sd_fee_bps is not None else per_side_fee_bps
+        net_pnl = pnl - fees_paid - funding_usd if pnl is not None else None
 
     return {
         "id": str(trade_row.get("id") or ""),
@@ -278,13 +294,16 @@ def _build_compat_paper_trade(trade_row: dict, strategy_name: str, symbol: str) 
         "pnl": pnl,
         "pnl_pct": pnl_pct,
         "strategy_name": strategy_name,
-        "gross_pnl": pnl,
+        "gross_pnl": gross_pnl,
         "fees_paid": fees_paid,
         "funding_pnl": -funding_usd,
         "net_pnl": net_pnl,
         "net_pnl_pct": net_pnl_pct if net_pnl_pct is not None else pnl_pct,
-        "entry_fee_bps": per_side_fee_bps,
-        "exit_fee_bps": per_side_fee_bps,
+        "entry_fee_bps": entry_fee_bps,
+        "exit_fee_bps": exit_fee_bps,
+        "entry_fee_usd": sd_entry_fee,
+        "exit_fee_usd": sd_exit_fee,
+        "slippage_usd": sd_slippage,
         "close_reason": close_reason,
         "close_incomplete": close_incomplete,
     }

--- a/forven/api_domains/paper_control.py
+++ b/forven/api_domains/paper_control.py
@@ -260,23 +260,26 @@ def _validate_protective_level(kind: str, price: float, mid: float, direction: s
 # --------------------------------------------------------------------------- #
 # Close
 # --------------------------------------------------------------------------- #
-def _manual_paper_close_pnl_override(trade: dict, exit_price: float) -> dict | None:
+def _manual_paper_close_pnl_override(trade: dict, exit_price: float) -> tuple[dict | None, dict | None]:
     """Net PnL for a manual close of a KERNEL-managed paper trade, using the kernel's
     own cost convention ((price_return*sign*lev - round_trip_drag) * size_fraction).
 
     Manual closes are operator actions and stay EXCLUDED from the promotion gate (no
     pnl_is_equity_fraction flag, by design — see policy._PARITY_PNL_FILTER), but their
     pnl_usd feeds the paper sandbox equity that sizes every subsequent trade — booking
-    them cost-free (the old behaviour) silently inflated the book. Returns None for
-    non-kernel rows (close_trade_record's default computation stands)."""
+    them cost-free (the old behaviour) silently inflated the book. Returns
+    ``(pnl_override, cost_signal_data)`` — the second element itemizes the drag the
+    net PnL charged (for the trade's signal_data). ``(None, None)`` for non-kernel
+    rows (close_trade_record's default computation stands)."""
     sd = parse_trade_signal_data(trade.get("signal_data"))
     size_frac = _coerce_optional_float(sd.get("kernel_size_fraction"))
     if not size_frac:
-        return None
+        return None, None
     entry = _coerce_optional_float(trade.get("fill_entry_price")) or _coerce_optional_float(trade.get("entry_price"))
     if not entry or not exit_price or exit_price <= 0:
-        return None
+        return None, None
     from forven.db import kv_get
+    from forven.strategies.execution_kernel import cost_breakdown_usd
 
     lev = _coerce_optional_float(trade.get("leverage")) or 1.0
     sign = -1.0 if _normalize_trade_direction(trade.get("direction")) == "short" else 1.0
@@ -289,10 +292,17 @@ def _manual_paper_close_pnl_override(trade: dict, exit_price: float) -> dict | N
     drag = 2.0 * (fee_bps + slip_bps) / 10000.0 * max(lev, 0.0)
     pnl_eq = (((float(exit_price) - entry) / entry) * sign * lev - drag) * float(size_frac)
     equity_at_entry = _coerce_optional_float(sd.get("kernel_equity_at_entry")) or 10000.0
-    return {
-        "net_pnl_pct": round(pnl_eq, 8),
-        "pnl_usd": round(equity_at_entry * pnl_eq, 4),
-    }
+    pnl_usd = round(equity_at_entry * pnl_eq, 4)
+    return (
+        {
+            "net_pnl_pct": round(pnl_eq, 8),
+            "pnl_usd": pnl_usd,
+        },
+        cost_breakdown_usd(
+            equity_at_entry=equity_at_entry, leverage=lev, size_fraction=float(size_frac),
+            fee_bps=fee_bps, slippage_bps=slip_bps, net_pnl_usd=pnl_usd,
+        ),
+    )
 
 
 def close_paper_position(session_id: str, reason: str | None = None) -> dict:
@@ -303,6 +313,7 @@ def close_paper_position(session_id: str, reason: str | None = None) -> dict:
         _live_close_trade(trade, close_reason="manual_close", note=note)
     else:
         mid = _fresh_manual_mark(session, trade)
+        pnl_override, cost_signal_data = _manual_paper_close_pnl_override(trade, mid)
         closed = close_trade_record(
             str(trade["id"]),
             signal_exit_price=mid,
@@ -314,8 +325,9 @@ def close_paper_position(session_id: str, reason: str | None = None) -> dict:
                 "source": "manual",
                 "manually_closed_at": _iso_now(),
                 "manual_close_note": note,
+                **(cost_signal_data or {}),
             },
-            pnl_override=_manual_paper_close_pnl_override(trade, mid),
+            pnl_override=pnl_override,
         )
         if not closed or not closed.get("updated"):
             raise HTTPException(status_code=502, detail="Failed to close position.")

--- a/forven/crucible_planner.py
+++ b/forven/crucible_planner.py
@@ -60,6 +60,15 @@ def _is_pending_expiry(status: object, error: object) -> bool:
 
 _REFINE_DURABLE_TOOLS = {"update_hypothesis_fields", "attach_hypothesis_artifact"}
 
+# Tool calls that durably persist a strategy row. Kept in sync with the
+# strategy-creation subset of forven.agents.runner._ARTIFACT_TOOLS.
+_DEVELOP_STRATEGY_CREATE_TOOLS = {
+    "create_strategy",
+    "forven_create_strategy",
+    "register_strategy",
+    "forven_register_strategy_file",
+}
+
 
 def _refine_task_has_durable_update(
     payload: dict[str, Any],
@@ -88,6 +97,43 @@ def _refine_task_has_durable_update(
     return any(f"[ok] {tool_name}" in response for tool_name in _REFINE_DURABLE_TOOLS)
 
 
+def _develop_task_spawned_strategy(output_data: object) -> bool:
+    """True if a completed develop_candidate task durably created a strategy.
+
+    Mirrors _refine_task_has_durable_update: agents that refuse a
+    substrate-blocked candidate (LESSONS L141/L142) still complete the task
+    'successfully', so refusals never hit the failed-retry cap and the planner
+    re-dispatched the same crucible every cycle forever (585 dispatches/48h at
+    its worst). A success-status develop_candidate whose tool evidence shows no
+    successful strategy-creation call must count as a failed attempt instead.
+
+    Tasks with no readable tool evidence at all are treated as fruitful so a
+    missing/legacy trace can never park a healthy crucible.
+    """
+    output = _parse_input_data(output_data)
+    if not output:
+        return True
+
+    has_evidence = False
+    trace = output.get("tool_trace")
+    if isinstance(trace, list):
+        for call in trace:
+            if not isinstance(call, dict):
+                continue
+            has_evidence = True
+            tool_name = str(call.get("tool_name") or "").strip()
+            if tool_name in _DEVELOP_STRATEGY_CREATE_TOOLS and bool(call.get("ok")):
+                return True
+
+    response = str(output.get("response") or "")
+    if response:
+        has_evidence = True
+        if any(f"[ok] {tool_name}" in response for tool_name in _DEVELOP_STRATEGY_CREATE_TOOLS):
+            return True
+
+    return not has_evidence
+
+
 @dataclass(frozen=True)
 class CrucibleTaskIndex:
     open_actions: set[tuple[str, str | None]]
@@ -95,6 +141,7 @@ class CrucibleTaskIndex:
     successful_actions: set[tuple[str, str | None]]
     failed_action_counts: dict[tuple[str, str | None], int]
     failed_backtest_counts: dict[tuple[str | None, str | None], int]
+    fruitless_develop_counts: dict[str | None, int]
 
     @classmethod
     def build(cls) -> "CrucibleTaskIndex":
@@ -113,6 +160,7 @@ class CrucibleTaskIndex:
         successful_actions: set[tuple[str, str | None]] = set()
         failed_action_counts: dict[tuple[str, str | None], int] = defaultdict(int)
         failed_backtest_counts: dict[tuple[str | None, str | None], int] = defaultdict(int)
+        fruitless_develop_counts: dict[str | None, int] = defaultdict(int)
 
         for row in rows:
             payload = _parse_input_data(row["input_data"])
@@ -129,6 +177,8 @@ class CrucibleTaskIndex:
             effective_success = status in _SUCCESS_STATUSES
             if effective_success and action_kind == "refine_crucible":
                 effective_success = _refine_task_has_durable_update(payload, row["output_data"])
+            elif effective_success and action_kind == "develop_candidate":
+                effective_success = _develop_task_spawned_strategy(row["output_data"])
 
             if status in _OPEN_STATUSES:
                 open_actions.add(key)
@@ -138,9 +188,15 @@ class CrucibleTaskIndex:
                 prior_actions.add(key)
             if (
                 status in _FAILED_STATUSES
-                or (status in _SUCCESS_STATUSES and action_kind == "refine_crucible" and not effective_success)
+                or (
+                    status in _SUCCESS_STATUSES
+                    and action_kind in ("refine_crucible", "develop_candidate")
+                    and not effective_success
+                )
             ) and not expired_pending:
                 failed_action_counts[key] += 1
+                if action_kind == "develop_candidate" and status in _SUCCESS_STATUSES:
+                    fruitless_develop_counts[crucible_id] += 1
                 if action_kind == "run_backtest":
                     strategy_id = str(payload.get("strategy_id") or "").strip() or None
                     failed_backtest_counts[(crucible_id, strategy_id)] += 1
@@ -151,6 +207,7 @@ class CrucibleTaskIndex:
             successful_actions=successful_actions,
             failed_action_counts=dict(failed_action_counts),
             failed_backtest_counts=dict(failed_backtest_counts),
+            fruitless_develop_counts=dict(fruitless_develop_counts),
         )
 
     def open_action_exists(self, action_kind: str, crucible_id: str | None) -> bool:
@@ -179,6 +236,11 @@ class CrucibleTaskIndex:
 
     def failed_action_count(self, action_kind: str, crucible_id: str | None) -> int:
         return int(self.failed_action_counts.get(_action_key(action_kind, crucible_id), 0))
+
+    def fruitless_develop_count(self, crucible_id: str | None) -> int:
+        """Completed develop_candidate tasks that durably created no strategy."""
+        key = str(crucible_id or "").strip() or None
+        return int(self.fruitless_develop_counts.get(key, 0))
 
     def failed_strategy_backtest_count(self, crucible_id: str | None, strategy_id: str | None) -> int:
         crucible_key = str(crucible_id or "").strip() or None
@@ -503,7 +565,15 @@ def _plan_for_crucible(
                 # Parked for good: the retry cap never resets, so this crucible
                 # can never be planned again. Archive it (attributably) instead
                 # of leaving a zombie occupying an active-pool slot forever.
-                _archive_parked_crucible(crucible, reason="develop_retries_exhausted")
+                # Fruitless completions (agent refusals, e.g. substrate-blocked)
+                # get their own reason so ops can tell "kept refusing" apart
+                # from "kept erroring".
+                reason = (
+                    "develop_fruitless_3x"
+                    if index.fruitless_develop_count(crucible_id) >= _MAX_FAILED_ACTION_RETRIES
+                    else "develop_retries_exhausted"
+                )
+                _archive_parked_crucible(crucible, reason=reason)
                 return None
             return _action(
                 action_kind="develop_candidate",

--- a/forven/evolution.py
+++ b/forven/evolution.py
@@ -1825,7 +1825,10 @@ def _run_testing_step_impl(code_first: bool = True) -> dict:
         # promoted to paper off a boundary WFA while param_jitter was mid-run, real
         # gauntlet never finished). Defer until the workflow reaches a terminal state.
         try:
-            from forven.gauntlet.store import has_active_workflow_for_strategy
+            from forven.gauntlet.store import (
+                get_latest_workflow_for_strategy,
+                has_active_workflow_for_strategy,
+            )
 
             if has_active_workflow_for_strategy(strat_id):
                 deferred_ids = list(outcome.get("workflow_deferred_ids") or [])
@@ -1833,6 +1836,28 @@ def _run_testing_step_impl(code_first: bool = True) -> dict:
                 outcome["workflow_deferred_ids"] = deferred_ids
                 log.debug("Evolution: %s deferred to active gauntlet workflow", strat_id)
                 continue
+            # A TERMINALLY failed/cancelled workflow is a VERDICT, not an absence.
+            # The v3 workflow judged this strategy on the full sweep-before-gate
+            # sequence and rejected it (or an operator cancelled it); the lean
+            # fast-path/readiness gate below judges weaker evidence and used to
+            # re-promote such strategies minutes later (S05925: workflow
+            # failed_gate at 02:47 -> "Auto-promoted after gauntlet gate pass"
+            # at 02:57 off the same artifacts). Once a workflow has reached a
+            # terminal non-passed state, promotion ownership stays with the
+            # workflow system: a fresh workflow run is the only path to paper.
+            # quick_screen-stage candidates are unaffected (no workflow yet).
+            if stage_name == "gauntlet":
+                latest_workflow = get_latest_workflow_for_strategy(strat_id)
+                workflow_status = str((latest_workflow or {}).get("status") or "").strip().lower()
+                if workflow_status in {"failed_gate", "cancelled"}:
+                    blocked_ids = list(outcome.get("workflow_failed_blocked_ids") or [])
+                    blocked_ids.append(strat_id)
+                    outcome["workflow_failed_blocked_ids"] = blocked_ids
+                    log.debug(
+                        "Evolution: %s blocked from fast-path promotion (latest workflow %s)",
+                        strat_id, workflow_status,
+                    )
+                    continue
         except Exception as exc:
             log.warning("Evolution: workflow-deferral check failed for %s: %s", strat_id, exc)
 

--- a/forven/gauntlet/status.py
+++ b/forven/gauntlet/status.py
@@ -127,11 +127,29 @@ def _latest_robustness_results(strategy_id: str) -> dict[str, dict[str, Any]]:
         metrics = _parse_json(row["metrics_json"], {})
         config = _parse_json(row["config_json"], {})
         verdict = metrics.get("verdict") if isinstance(metrics, dict) else None
+        # A walk-forward run where EVERY fold is below wfa_min_fold_trades judged
+        # nothing — the window was too short for the strategy's trade rate. Its
+        # PASS/FAIL verdict is noise either way: surface it as retryable absence
+        # (blocked_runtime) so run_paper_promotion_gate buckets it as
+        # absent_missing (re-queue) instead of merit failed_gate or a pass.
+        insufficient_wfa = False
+        if step_key == "walk_forward" and isinstance(metrics, dict):
+            try:
+                from forven.policy import wfa_insufficient_fold_evidence
+
+                insufficient_wfa = wfa_insufficient_fold_evidence(metrics)
+            except Exception:
+                insufficient_wfa = False
         latest[step_key] = {
             "result_id": row["result_id"],
             "result_type": result_type,
-            "status": _result_status_to_step_status(str(config.get("status") or ""), verdict),
-            "verdict": str(verdict).upper() if verdict else None,
+            "status": (
+                "blocked_runtime"
+                if insufficient_wfa
+                else _result_status_to_step_status(str(config.get("status") or ""), verdict)
+            ),
+            "verdict": "INSUFFICIENT" if insufficient_wfa else (str(verdict).upper() if verdict else None),
+            "insufficient_fold_evidence": insufficient_wfa or None,
             "submitted_at": config.get("submitted_at") if isinstance(config, dict) else None,
             "completed_at": config.get("completed_at") if isinstance(config, dict) else None,
             "created_at": row["created_at"],

--- a/forven/hypothesis_promotion.py
+++ b/forven/hypothesis_promotion.py
@@ -194,7 +194,14 @@ def _dispatch_task(hypothesis: dict[str, Any]) -> int | None:
 def run_promotion_loop(*, top_k: int = 3, max_in_flight: int = MAX_IN_FLIGHT_DEFAULT) -> dict[str, Any]:
     """Tick: pick up to top_k hypotheses by promise, dispatch one task each."""
     in_flight = _current_in_flight_task_count()
-    skipped = {"disproven": 0, "cooldown": 0, "archived": 0, "in_flight": 0, "candidate_open": 0}
+    skipped = {
+        "disproven": 0,
+        "cooldown": 0,
+        "archived": 0,
+        "in_flight": 0,
+        "candidate_open": 0,
+        "develop_exhausted": 0,
+    }
     dispatched_ids: list[str] = []
 
     if in_flight >= max_in_flight:
@@ -220,7 +227,11 @@ def run_promotion_loop(*, top_k: int = 3, max_in_flight: int = MAX_IN_FLIGHT_DEF
     # Share the candidate dedup family with the crucible planner: skip a pick if a
     # develop_candidate / expand_viable_crucible task is already open for it, so the
     # two dispatchers don't both fire for the same crucible in one window.
-    from forven.crucible_planner import CrucibleTaskIndex
+    from forven.crucible_planner import (
+        _MAX_FAILED_ACTION_RETRIES,
+        CrucibleTaskIndex,
+        _strategy_count,
+    )
 
     task_index = CrucibleTaskIndex.build()
     now_iso = datetime.now(timezone.utc).isoformat()
@@ -228,8 +239,20 @@ def run_promotion_loop(*, top_k: int = 3, max_in_flight: int = MAX_IN_FLIGHT_DEF
         hypothesis = get_hypothesis(candidate["id"])
         if not hypothesis:
             continue
-        if task_index.candidate_action_open(str(hypothesis["id"])):
+        hypothesis_id = str(hypothesis["id"])
+        if task_index.candidate_action_open(hypothesis_id):
             skipped["candidate_open"] += 1
+            continue
+        # Mirror the planner's develop-retry cap: a crucible with no live
+        # strategies whose develop attempts are exhausted (failed OR completed
+        # fruitlessly, e.g. substrate-blocked refusals) must not be re-picked —
+        # dispatching it just burns another agent run on the same refusal.
+        if (
+            task_index.failed_action_count("develop_candidate", hypothesis_id)
+            >= _MAX_FAILED_ACTION_RETRIES
+            and _strategy_count(hypothesis_id) == 0
+        ):
+            skipped["develop_exhausted"] += 1
             continue
         task_id = _dispatch_task(hypothesis)
         if task_id is None:

--- a/forven/policy.py
+++ b/forven/policy.py
@@ -1678,6 +1678,70 @@ def _canonicalize_gauntlet_verdict_test(name: object) -> str:
     return _GAUNTLET_VERDICT_ALIASES.get(normalized, normalized)
 
 
+def _wfa_fold_stats(splits: object, min_fold_trades: int) -> dict:
+    """Fold-level OOS evidence for a walk-forward artifact.
+
+    evaluated = folds with >= min_fold_trades OOS trades (judgeable);
+    reporting = folds that carry an explicit OOS trade count at all (modern
+    artifacts always do; legacy rows / test fixtures may not);
+    insufficient = folds exist and report counts, but NONE is judgeable —
+    the window was too short for the strategy's trade rate.
+    """
+    passed = 0
+    evaluated = 0
+    raw_passed = 0
+    reporting = 0
+    total = 0
+    for split in splits if isinstance(splits, list) else []:
+        if not isinstance(split, dict):
+            continue
+        total += 1
+        oos = split.get("out_of_sample") if isinstance(split.get("out_of_sample"), dict) else {}
+        sharpe = _coerce_float(oos.get("sharpe", oos.get("sharpe_ratio")), 0.0)
+        if sharpe > 0:
+            raw_passed += 1
+        if "total_trades" in oos or "trades" in oos:
+            reporting += 1
+        oos_trades = int(_coerce_float(oos.get("total_trades", oos.get("trades")), 0.0) or 0)
+        if oos_trades < min_fold_trades:
+            continue
+        evaluated += 1
+        if sharpe > 0:
+            passed += 1
+    return {
+        "total": total,
+        "reporting": reporting,
+        "evaluated": evaluated,
+        "passed": passed,
+        "raw_passed": raw_passed,
+        "insufficient": total > 0 and reporting > 0 and evaluated == 0,
+    }
+
+
+def wfa_insufficient_fold_evidence(metrics: dict) -> bool:
+    """True when a walk-forward artifact has NO judgeable fold: every fold
+    reports an OOS trade count below robustness_thresholds.wfa_min_fold_trades.
+
+    Such a run is ABSENCE of evidence (the window was too short for the
+    strategy's trade rate), not a merit verdict in either direction. Grading
+    those coin-flip folds anyway is how S05925 reached paper on 2/5 positive
+    folds of 1-3 trades each. Shared with gauntlet.status so the workflow gate
+    and the UI classify it as retryable absence rather than pass or merit fail.
+    """
+    if not isinstance(metrics, dict):
+        return False
+    splits = metrics.get("splits")
+    if not isinstance(splits, list) or not splits:
+        return False
+    try:
+        min_fold_trades = int(
+            (load_pipeline_config().get("robustness_thresholds") or {}).get("wfa_min_fold_trades", 5) or 5
+        )
+    except Exception:
+        min_fold_trades = 5
+    return bool(_wfa_fold_stats(splits, min_fold_trades)["insufficient"])
+
+
 def _validation_row_to_verdict_payload(result_type: str, metrics: dict, config: dict) -> dict:
     verdict = str(metrics.get("verdict") or "").strip().upper()
     raw_status = str(metrics.get("status") or config.get("status") or "").strip().lower()
@@ -1707,31 +1771,27 @@ def _validation_row_to_verdict_payload(result_type: str, metrics: dict, config: 
             )
         except Exception:
             _min_fold_trades = 5
-        passed_splits = 0
-        evaluated_splits = 0
-        raw_passed = 0  # sharpe>0 over ALL splits — legacy/fixture fallback
-        for split in splits:
-            if not isinstance(split, dict):
-                continue
-            oos = split.get("out_of_sample") if isinstance(split.get("out_of_sample"), dict) else {}
-            sharpe = _coerce_float(oos.get("sharpe", oos.get("sharpe_ratio")), 0.0)
-            if sharpe > 0:
-                raw_passed += 1
-            oos_trades = int(_coerce_float(oos.get("total_trades", oos.get("trades")), 0.0) or 0)
-            if oos_trades < _min_fold_trades:
-                continue  # too few trades to judge this fold either way
-            evaluated_splits += 1
-            if sharpe > 0:
-                passed_splits += 1
-        if evaluated_splits > 0:
-            fold_count = evaluated_splits
-            pass_rate = float(passed_splits / evaluated_splits)
+        stats = _wfa_fold_stats(splits, _min_fold_trades)
+        insufficient = bool(stats["insufficient"])
+        if stats["evaluated"] > 0:
+            fold_count = int(stats["evaluated"])
+            pass_rate = float(stats["passed"] / stats["evaluated"])
+        elif insufficient:
+            # Every fold REPORTED an OOS trade count and every one was below the
+            # judgeable floor: there is nothing here to grade. The old fallback
+            # graded these coin-flip folds by raw sharpe>0 anyway — S05925
+            # reached paper on 2/5 positive folds of 1-3 trades each (one a
+            # 2-trade fold at the +10 Sharpe clamp). Insufficient evidence is
+            # ABSENCE, not a pass and not a merit fail; the gate blocks with an
+            # actionable "window too short" reason below.
+            fold_count = 0
+            pass_rate = 0.0
         else:
             # No fold reported a per-fold trade count (legacy results / test
             # fixtures): fall back to the raw sharpe-based rate over all splits so
             # the de-noising never makes pass_rate worse than the old behavior.
             fold_count = len(splits)
-            pass_rate = float(raw_passed / fold_count) if fold_count > 0 else 0.0
+            pass_rate = float(stats["raw_passed"] / fold_count) if fold_count > 0 else 0.0
         # For walk_forward, 'passed' and 'status' MUST reflect actual fold pass rate,
         # not just the raw verdict string (which may fail for non-fold reasons like
         # negative avg IS Sharpe or IS->OOS degradation). If enough OOS folds are
@@ -1758,8 +1818,15 @@ def _validation_row_to_verdict_payload(result_type: str, metrics: dict, config: 
             _fold_min = 0.6
         # Use fold pass rate as the sole paper-gate criterion, regardless of the
         # overall WFA verdict (which may fail for non-fold reasons like negative IS).
-        wfa_passed = (pass_rate >= _fold_min if fold_count > 0 else status == "pass")
-        wfa_status = "pass" if wfa_passed else "fail"
+        if insufficient:
+            # Not graded at all: passed=False keeps scoring conservative, and the
+            # explicit marker routes the gate to an actionable "window too short"
+            # block instead of a merit verdict.
+            wfa_passed = False
+            wfa_status = "insufficient"
+        else:
+            wfa_passed = (pass_rate >= _fold_min if fold_count > 0 else status == "pass")
+            wfa_status = "pass" if wfa_passed else "fail"
         aggregate_oos = metrics.get("aggregate_oos") if isinstance(metrics.get("aggregate_oos"), dict) else {}
         oos_trades = (
             metrics.get("total_oos_trades")
@@ -1781,9 +1848,11 @@ def _validation_row_to_verdict_payload(result_type: str, metrics: dict, config: 
             # consistency check passes, report PASS here so _verdict_payload_failed
             # does not re-reject on the raw stored verdict (which may be FAIL for
             # non-fold reasons like negative avg IS Sharpe).
-            "verdict": "PASS" if wfa_passed else verdict,
+            "verdict": "PASS" if wfa_passed else ("INSUFFICIENT" if insufficient else verdict),
             "raw_verdict": verdict,  # preserve for auditability
         }
+        if insufficient:
+            payload["insufficient_fold_evidence"] = True
         if oos_trades is not None:
             payload["total_oos_trades"] = int(_coerce_float(oos_trades, 0.0) or 0)
         return payload
@@ -3701,6 +3770,18 @@ def _evaluate_gauntlet_gate(strategy_id: str, config: dict) -> tuple[bool, str]:
 
     wfa_payload = verdict_payloads.get("walk_forward")
     if wfa_payload:
+        if wfa_payload.get("insufficient_fold_evidence"):
+            # Every OOS fold fell below wfa_min_fold_trades: the run judged
+            # nothing (window too short for the strategy's trade rate). This is
+            # ABSENCE of evidence — block with an actionable reason rather than
+            # grading coin-flip folds (S05925) or emitting a merit reject. The
+            # trade-frequency-aware default window (forven.wfa_window) makes the
+            # re-run produce judgeable folds.
+            _min_fold_trades_msg = int((rob_thresholds or {}).get("wfa_min_fold_trades", 5) or 5)
+            return False, (
+                "S00552 BLOCK: walk-forward window insufficient — no OOS fold reached "
+                f"{_min_fold_trades_msg} trades; re-run WFA on the trade-frequency-aware window"
+            )
         # F4(b): at the paper gate the WFA fold-consistency floor fires whenever
         # walk_forward actually ran — narrowing required_tests must NOT disable a
         # ran-but-failed safety check (the membership-gating was a bypass lever).

--- a/forven/routers/robustness.py
+++ b/forven/routers/robustness.py
@@ -2509,6 +2509,39 @@ def _submit_result(
     return {"job_id": job_id, "status": "running", "result_id": result_id}
 
 
+@router.get("/api/robustness/walk-forward/window-recommendation/{strategy_id}")
+def get_walk_forward_window_recommendation(
+    strategy_id: str,
+    timeframe: str | None = None,
+    n_splits: int | None = None,
+    train_ratio: float | None = None,
+):
+    """Recommend a WFA window sized to the strategy's measured trade rate.
+
+    Single source of truth = forven.wfa_window (the same rule that floors the
+    canonical runner's defaulted window), so the UI default and the gauntlet
+    re-runs can never disagree about what an adequate window is. Also returns
+    concrete start/end dates for direct use by the Robustness tab.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    from forven.wfa_window import recommended_wfa_window
+
+    row = _load_strategy_row(strategy_id)
+    resolved_timeframe = str(timeframe or row["timeframe"] or "1h").strip() or "1h"
+    recommendation = recommended_wfa_window(
+        strategy_id,
+        resolved_timeframe,
+        n_splits=n_splits,
+        train_ratio=train_ratio,
+    )
+    end = datetime.now(timezone.utc).date()
+    start = end - timedelta(days=int(recommendation["window_days"]))
+    recommendation["recommended_start_date"] = start.isoformat()
+    recommendation["recommended_end_date"] = end.isoformat()
+    return recommendation
+
+
 @router.post("/api/robustness/walk-forward")
 def post_walk_forward(body: WalkForwardBody):
     context = _prepare_walk_forward_context(body)

--- a/forven/scanner.py
+++ b/forven/scanner.py
@@ -34,6 +34,7 @@ from forven.exchange.risk import (
     sync_from_trades,
 )
 from forven.strategies import sizing as _sizing
+from forven.strategies.execution_kernel import cost_breakdown_usd as _kernel_cost_breakdown_usd
 from forven.market_cache import (
     load_price_snapshot,
     load_candle_snapshot,
@@ -5652,6 +5653,10 @@ def _kernel_open_paper_trade(strat_id: str, strat: dict, action, *, sizing_equit
         _coerce_positive_float((p.get("execution_profile") or {}).get("risk_per_trade"))
         or min(float(size_fraction), 1.0)
     )
+    # Entry-leg fee at open (fee_bps on the entry notional) so the position shows its
+    # fee immediately, like an exchange fill. The close overwrites both legs with the
+    # close-time breakdown; this stamp is display-only (the drag is charged at close).
+    _fee_bps_open = max(_scanner_float_setting("backtest_fee_bps", 4.5), 0.0)
     signal_data = {
         "kernel_managed": True,
         # Match key is ALWAYS the kernel's historical entry_time, even for a late hop-in,
@@ -5660,6 +5665,8 @@ def _kernel_open_paper_trade(strat_id: str, strat: dict, action, *, sizing_equit
         "kernel_entry_bar": int(pos.get("entry_bar") or 0),
         "kernel_size_fraction": round(float(size_fraction), 8),
         "kernel_equity_at_entry": round(float(sizing_equity), 4),
+        "fee_bps": _fee_bps_open,
+        "entry_fee_usd": round((_fee_bps_open / 10000.0) * float(sizing_equity) * float(leverage) * float(size_fraction), 6),
         "kernel_regime": pos.get("regime"),
         "price": entry_price,
         "direction": direction,
@@ -5880,6 +5887,13 @@ def _kernel_close_recorded(
                 "kernel_exit_time": trade.get("exit_time"), "kernel_managed": bool(sd.get("kernel_managed", True)),
                 "close_fill_now": fresh_exit, "close_mark_fill": mark_fill,
                 "funding_cost_pct": _funding_pct,
+                # Itemize the costs the net _pnl_eq already charged (drag + funding)
+                # so reporting can show paper fees/slippage/funding, not a bare net.
+                **_kernel_cost_breakdown_usd(
+                    equity_at_entry=equity_at_entry, leverage=_lev, size_fraction=_size_frac,
+                    fee_bps=_fee_bps, slippage_bps=_slip_bps,
+                    funding_gain_pct=_funding_pct, net_pnl_usd=_pnl_usd_eq,
+                ),
             },
             pnl_override={
                 "pnl_pct": round(_pnl_eq, 8), "net_pnl_pct": round(_pnl_eq, 8),
@@ -5899,10 +5913,32 @@ def _kernel_close_recorded(
     # pnl_override so close_trade_record writes status=CLOSED + pnl/pnl_pct/net_pnl_pct/
     # pnl_usd + closed_at + the pnl_is_equity_fraction flag in ONE atomic transaction (no
     # separate override UPDATE that a crash could tear, leaving a wrong-scale unflagged row).
+    # Itemize the drag/funding the kernel already netted out of pnl_pct: the same
+    # backtest_* settings drove this scan's simulate() call, size_fraction_raw is the
+    # exact fraction the price/funding legs used, and funding_cost_pct is the kernel's
+    # gain-positive funding term (_apply_funding_to_trades).
+    _fee_bps_f = max(_scanner_float_setting("backtest_fee_bps", 4.5), 0.0)
+    _slip_bps_f = max(_scanner_float_setting("backtest_slippage_bps", 2.0), 0.0)
+    _size_frac_f = (
+        _coerce_positive_float(trade.get("size_fraction_raw"))
+        or _coerce_positive_float(trade.get("size_fraction"))
+        or _coerce_positive_float(sd.get("kernel_size_fraction"))
+        or 1.0
+    )
     close_trade_record(
         trade_id, signal_exit_price=exit_price, exit_price=exit_price,
         close_reason=exit_reason, close_price_source="kernel", closed_at=_closed_at,
-        extra_signal_data={"kernel_exit_time": trade.get("exit_time"), "kernel_managed": True},
+        extra_signal_data={
+            "kernel_exit_time": trade.get("exit_time"), "kernel_managed": True,
+            **_kernel_cost_breakdown_usd(
+                equity_at_entry=equity_at_entry,
+                leverage=float(row.get("leverage") or 1.0),
+                size_fraction=_size_frac_f,
+                fee_bps=_fee_bps_f, slippage_bps=_slip_bps_f,
+                funding_gain_pct=float(trade.get("funding_cost_pct") or 0.0),
+                net_pnl_usd=pnl_usd,
+            ),
+        },
         pnl_override={
             "pnl_pct": round(pnl_pct_net, 8), "net_pnl_pct": round(pnl_pct_net, 8),
             "pnl_usd": pnl_usd, "equity_fraction": True,

--- a/forven/strategies/backtest.py
+++ b/forven/strategies/backtest.py
@@ -10453,6 +10453,11 @@ def walk_forward(
     # Resolve duration/bars
 
 
+    # A window nobody chose explicitly (no total_bars, no start/end dates) is
+    # eligible for the trade-frequency-aware floor below — explicit windows
+    # (operator UI runs, tests) are honored verbatim.
+    window_defaulted = total_bars is None and not start_date and not end_date
+
     if total_bars is None:
         # Timeframe-AWARE bar count so the WFA window matches the quick_screen
         # backtest's CALENDAR window (api_core._estimate_backtest_bars uses the same
@@ -10501,6 +10506,34 @@ def walk_forward(
         n_splits if n_splits is not None
         else settings.get("walkforward_folds", wfa_cfg.get("n_folds", 5))
     )
+
+    # Trade-frequency-aware window floor (S05925): a defaulted window must give
+    # every OOS fold a judgeable trade sample (wfa_min_fold_trades), or the fold
+    # pass rate degenerates to coin flips — the stage calendar window handed a
+    # ~3-trades/month 4h strategy folds of 1-3 OOS trades. Raise (never shrink)
+    # the defaulted window to the recommendation; explicit caller windows are
+    # untouched. The resolver caps itself at the same _WFA_MAX_BARS ceiling.
+    if window_defaulted:
+        try:
+            from forven.wfa_window import recommended_wfa_window
+
+            _rec = recommended_wfa_window(
+                strategy_id,
+                resolved_timeframe,
+                n_splits=resolved_n_splits,
+                train_ratio=resolved_in_sample_pct,
+            )
+            _rec_bars = int(_rec.get("window_bars") or 0)
+            if _rec_bars > resolved_total_bars:
+                log.info(
+                    "WFA window raised for %s: %d -> %d bars (%s, ~%.1f trades/mo, source=%s)",
+                    strategy_id, resolved_total_bars, _rec_bars, resolved_timeframe,
+                    float(_rec.get("est_trades_per_month") or 0.0),
+                    _rec.get("trade_rate_source"),
+                )
+                resolved_total_bars = _rec_bars
+        except Exception as exc:  # noqa: BLE001 — sizing must never break the run
+            log.warning("WFA window recommendation failed for %s: %s", strategy_id, exc)
 
     resolved_fee_bps = float(
         fee_bps if fee_bps is not None

--- a/forven/strategies/execution_kernel.py
+++ b/forven/strategies/execution_kernel.py
@@ -67,6 +67,50 @@ def round_trip_drag(fee_bps: float, slippage_bps: float, leverage: float) -> flo
     )
 
 
+def cost_breakdown_usd(
+    *,
+    equity_at_entry: float,
+    leverage: float,
+    size_fraction: float,
+    fee_bps: float,
+    slippage_bps: float,
+    funding_gain_pct: float = 0.0,
+    net_pnl_usd: float | None = None,
+) -> dict:
+    """Itemize, in dollars, the costs :func:`round_trip_drag` already charged inside
+    a kernel trade's net ``pnl_pct`` — for persistence into the trade's signal_data
+    so reporting can show fees/slippage/funding instead of a bare net number.
+
+    The drag is priced on the entry notional (``equity * leverage * size_fraction``)
+    at ``fee_bps`` per side. ``funding_gain_pct`` is the kernel's funding term
+    (equity fraction, positive = credit received); it is flipped to the pipeline-wide
+    cost-positive ``funding_usd`` convention. When ``net_pnl_usd`` is given,
+    ``gross_pnl_usd`` (pure price PnL before every cost) is reconstructed so that
+    net + itemized costs always sum exactly back to gross.
+    """
+    notional = (
+        max(float(equity_at_entry or 0.0), 0.0)
+        * max(float(leverage or 0.0), 0.0)
+        * max(float(size_fraction or 0.0), 0.0)
+    )
+    leg_fee = (max(float(fee_bps or 0.0), 0.0) / 10000.0) * notional
+    slippage_usd = 2.0 * (max(float(slippage_bps or 0.0), 0.0) / 10000.0) * notional
+    funding_usd = -float(funding_gain_pct or 0.0) * max(float(equity_at_entry or 0.0), 0.0)
+    breakdown = {
+        "fee_bps": max(float(fee_bps or 0.0), 0.0),
+        "entry_fee_usd": round(leg_fee, 6),
+        "exit_fee_usd": round(leg_fee, 6),
+        "total_fees_usd": round(2.0 * leg_fee, 6),
+        "slippage_usd": round(slippage_usd, 6),
+        "funding_usd": round(funding_usd, 6),
+    }
+    if net_pnl_usd is not None:
+        breakdown["gross_pnl_usd"] = round(
+            float(net_pnl_usd) + 2.0 * leg_fee + slippage_usd + funding_usd, 6
+        )
+    return breakdown
+
+
 @dataclass
 class KernelResult:
     """Output of :func:`simulate`.

--- a/forven/wfa_window.py
+++ b/forven/wfa_window.py
@@ -1,0 +1,170 @@
+"""Trade-frequency-aware walk-forward window sizing.
+
+A WFA fold can only be judged when its OOS slice contains at least
+``robustness_thresholds.wfa_min_fold_trades`` trades — below that the fold
+pass rate is a coin flip (S05925 reached paper on 2/5 positive folds of 1-3
+trades each). The right window is therefore a function of the strategy's
+measured TRADE RATE, not a fixed calendar span: 1 year of 4h bars gives a
+~3-trades/month strategy 1-3 trades per OOS fold, while a 1h scalper is fine.
+
+This module is the single sizing rule shared by:
+  * the canonical runner (``strategies.backtest.walk_forward`` raises its
+    defaulted window to this recommendation),
+  * the robustness router's recommendation endpoint,
+  * (via that endpoint) the Robustness tab's per-strategy default window.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import math
+
+log = logging.getLogger(__name__)
+
+_TF_MINUTES = {
+    "1m": 1, "3m": 3, "5m": 5, "15m": 15, "30m": 30,
+    "1h": 60, "2h": 120, "4h": 240, "6h": 360, "8h": 480, "12h": 720,
+    "1d": 1440, "1w": 10080,
+}
+
+# Keep in sync with strategies.backtest._WFA_MAX_BARS (runtime ceiling for the
+# bar-by-bar slow path).
+_WFA_MAX_BARS = 50_000
+_MIN_WINDOW_DAYS = 90
+_DAYS_PER_MONTH = 30.44
+
+# When no trade-rate measurement exists (never backtested), assume coarser
+# timeframes trade less and size the OOS fold accordingly. Days of OOS per fold.
+_FALLBACK_OOS_DAYS = {
+    "1m": 7, "3m": 7, "5m": 10, "15m": 14, "30m": 21,
+    "1h": 30, "2h": 60, "4h": 120, "6h": 150, "8h": 180, "12h": 270,
+    "1d": 365, "1w": 730,
+}
+
+
+def _timeframe_minutes(timeframe: object) -> int:
+    return _TF_MINUTES.get(str(timeframe or "").strip().lower(), 60)
+
+
+def _parse_metrics(blob: object) -> dict:
+    if isinstance(blob, dict):
+        return blob
+    if not isinstance(blob, str) or not blob.strip():
+        return {}
+    try:
+        parsed = json.loads(blob)
+    except Exception:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _rate_from_metrics(metrics: dict) -> float | None:
+    """Trades per day from a metrics blob carrying total_trades + backtest_months."""
+    try:
+        trades = float(metrics.get("total_trades") or 0)
+        months = float(metrics.get("backtest_months") or 0)
+    except (TypeError, ValueError):
+        return None
+    if trades <= 0 or months <= 0:
+        return None
+    return trades / (months * _DAYS_PER_MONTH)
+
+
+def measured_trade_rate(strategy_id: str) -> tuple[float | None, str]:
+    """(trades per day, source) for a strategy.
+
+    Prefers the strategy's canonical stored metrics; falls back to the most
+    recent completed plain backtest row. Returns (None, "none") when the
+    strategy has never produced a measurable backtest.
+    """
+    from forven.db import get_db
+
+    with get_db() as conn:
+        row = conn.execute(
+            "SELECT metrics FROM strategies WHERE id = ?", (strategy_id,)
+        ).fetchone()
+        rate = _rate_from_metrics(_parse_metrics(row["metrics"])) if row else None
+        if rate is not None:
+            return rate, "strategy_metrics"
+        result = conn.execute(
+            """
+            SELECT metrics_json FROM backtest_results
+            WHERE strategy_id = ?
+              AND LOWER(TRIM(COALESCE(result_type, 'backtest'))) = 'backtest'
+              AND (deleted_at IS NULL OR TRIM(COALESCE(deleted_at, '')) = '')
+            ORDER BY datetime(created_at) DESC
+            LIMIT 5
+            """,
+            (strategy_id,),
+        ).fetchall()
+    for r in result:
+        rate = _rate_from_metrics(_parse_metrics(r["metrics_json"]))
+        if rate is not None:
+            return rate, "latest_backtest"
+    return None, "none"
+
+
+def recommended_wfa_window(
+    strategy_id: str,
+    timeframe: str,
+    *,
+    n_splits: int | None = None,
+    train_ratio: float | None = None,
+) -> dict:
+    """Recommend a WFA window sized so every OOS fold is judgeable.
+
+    Target: ``max(2 * wfa_min_fold_trades, 10)`` expected OOS trades per fold at
+    the strategy's measured trade rate, floored by the configured min OOS days
+    and capped by the runner's bar ceiling. Deterministic and side-effect free.
+    """
+    from forven.policy import load_pipeline_config
+
+    try:
+        cfg = load_pipeline_config()
+    except Exception:
+        cfg = {}
+    rob = cfg.get("robustness_thresholds") if isinstance(cfg.get("robustness_thresholds"), dict) else {}
+    wf_cfg = cfg.get("walk_forward") if isinstance(cfg.get("walk_forward"), dict) else {}
+
+    min_fold_trades = int(rob.get("wfa_min_fold_trades", 5) or 5)
+    resolved_splits = int(n_splits or wf_cfg.get("n_folds", 5) or 5)
+    resolved_splits = max(resolved_splits, 1)
+    resolved_train = float(train_ratio or wf_cfg.get("in_sample_pct", 0.7) or 0.7)
+    resolved_train = min(max(resolved_train, 0.05), 0.95)
+    min_oos_days = float(wf_cfg.get("min_oos_days_1h", 30) or 30)
+    target_fold_trades = max(2 * min_fold_trades, 10)
+
+    tf_key = str(timeframe or "").strip().lower()
+    rate_per_day, rate_source = measured_trade_rate(strategy_id)
+    if rate_per_day and rate_per_day > 0:
+        oos_days = target_fold_trades / rate_per_day
+    else:
+        oos_days = float(_FALLBACK_OOS_DAYS.get(tf_key, 30.0))
+    oos_days = max(oos_days, min_oos_days)
+
+    window_days = math.ceil(oos_days * resolved_splits / (1.0 - resolved_train))
+    window_days = max(int(window_days), _MIN_WINDOW_DAYS)
+
+    minutes_per_bar = _timeframe_minutes(tf_key)
+    window_bars = int(window_days * 24 * 60 // minutes_per_bar)
+    capped = False
+    if window_bars > _WFA_MAX_BARS:
+        window_bars = _WFA_MAX_BARS
+        window_days = int(window_bars * minutes_per_bar // (24 * 60))
+        capped = True
+
+    return {
+        "strategy_id": strategy_id,
+        "timeframe": tf_key,
+        "n_splits": resolved_splits,
+        "train_ratio": resolved_train,
+        "window_days": int(window_days),
+        "window_bars": int(window_bars),
+        "oos_days_per_fold": round(window_days * (1.0 - resolved_train) / resolved_splits, 1),
+        "target_oos_trades_per_fold": target_fold_trades,
+        "min_fold_trades": min_fold_trades,
+        "est_trades_per_day": rate_per_day,
+        "est_trades_per_month": round(rate_per_day * _DAYS_PER_MONTH, 2) if rate_per_day else None,
+        "trade_rate_source": rate_source,
+        "capped_by_max_bars": capped,
+    }

--- a/frontend/src/lib/api/backtesting.ts
+++ b/frontend/src/lib/api/backtesting.ts
@@ -1161,6 +1161,36 @@ export interface RobustnessAnalysis {
 	regime_error?: string;
 }
 
+export interface WfaWindowRecommendation {
+	strategy_id: string;
+	timeframe: string;
+	n_splits: number;
+	train_ratio: number;
+	window_days: number;
+	window_bars: number;
+	oos_days_per_fold: number;
+	target_oos_trades_per_fold: number;
+	min_fold_trades: number;
+	est_trades_per_day: number | null;
+	est_trades_per_month: number | null;
+	trade_rate_source: 'strategy_metrics' | 'latest_backtest' | 'none';
+	capped_by_max_bars: boolean;
+	recommended_start_date: string;
+	recommended_end_date: string;
+}
+
+export async function getWalkForwardWindowRecommendation(
+	strategyId: string,
+	params: { timeframe?: string; n_splits?: number; train_ratio?: number } = {},
+): Promise<WfaWindowRecommendation> {
+	const query = new URLSearchParams();
+	if (params.timeframe) query.set('timeframe', params.timeframe);
+	if (params.n_splits != null) query.set('n_splits', String(params.n_splits));
+	if (params.train_ratio != null) query.set('train_ratio', String(params.train_ratio));
+	const qs = query.toString();
+	return fetchApi(`/robustness/walk-forward/window-recommendation/${encodeURIComponent(strategyId)}${qs ? `?${qs}` : ''}`);
+}
+
 export async function runWalkForwardRobustness(request: {
 	strategy_id: string;
 	symbol: string;

--- a/frontend/src/lib/api/paper.ts
+++ b/frontend/src/lib/api/paper.ts
@@ -57,6 +57,9 @@ export interface PaperTrade {
 	net_pnl_pct: number | null;
 	entry_fee_bps: number;
 	exit_fee_bps: number;
+	entry_fee_usd?: number | null;
+	exit_fee_usd?: number | null;
+	slippage_usd?: number | null;
 	close_reason?: string | null;
 	close_incomplete?: boolean;
 }

--- a/frontend/src/lib/components/robustness/RobustnessPanel.svelte
+++ b/frontend/src/lib/components/robustness/RobustnessPanel.svelte
@@ -4,11 +4,13 @@
 	import {
 		getResult,
 		getRobustnessResult,
+		getWalkForwardWindowRecommendation,
 		submitCostStressRobustness,
 		submitMonteCarloRobustness,
 		submitParamJitterRobustness,
 		submitRegimeSplitRobustness,
 		submitWalkForwardRobustness,
+		type WfaWindowRecommendation,
 		type CostStressRobustnessResult,
 		type CostStressSnapshot,
 		type MonteCarloRobustnessResult,
@@ -218,7 +220,91 @@
 			start_date: baselineWindowStart,
 			end_date: baselineWindowEnd,
 		};
+		autoSeededWfaWindow = { start: baselineWindowStart, end: baselineWindowEnd };
 	}
+
+	// ── Trade-frequency-aware WFA window (S05925) ──
+	// A WFA fold is only judgeable with >= min_fold_trades OOS trades, so the
+	// right window follows the strategy's measured trade rate — not a calendar
+	// preset. The backend recommendation (forven.wfa_window, the same rule that
+	// sizes the gauntlet's canonical runs) widens auto-seeded windows and drives
+	// the inline adequacy warning. Operator-edited windows are never overridden.
+	let wfaRecommendation: WfaWindowRecommendation | null = null;
+	let autoSeededWfaWindow = { start: '', end: '' };
+
+	async function loadWfaRecommendation() {
+		try {
+			wfaRecommendation = await getWalkForwardWindowRecommendation(strategyId, {
+				timeframe: (walkForwardForm.timeframe || defaultTimeframe || '').trim() || undefined,
+			});
+			applyRecommendedWindow();
+		} catch {
+			wfaRecommendation = null;
+		}
+	}
+
+	function windowDaysBetween(start: string, end: string): number | null {
+		if (!start || !end) return null;
+		const startMs = Date.parse(start);
+		const endMs = Date.parse(end);
+		if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) return null;
+		return (endMs - startMs) / 86_400_000;
+	}
+
+	function applyRecommendedWindow(force = false) {
+		if (!wfaRecommendation) return;
+		const currentDays = windowDaysBetween(walkForwardForm.start_date, walkForwardForm.end_date);
+		const untouched =
+			!walkForwardForm.start_date ||
+			(walkForwardForm.start_date === autoSeededWfaWindow.start &&
+				walkForwardForm.end_date === autoSeededWfaWindow.end);
+		// A longer window than recommended is fine — only widen, never shrink.
+		if (!force && (!untouched || (currentDays != null && currentDays >= wfaRecommendation.window_days))) {
+			return;
+		}
+		walkForwardForm = {
+			...walkForwardForm,
+			start_date: wfaRecommendation.recommended_start_date,
+			end_date: wfaRecommendation.recommended_end_date,
+		};
+		autoSeededWfaWindow = {
+			start: wfaRecommendation.recommended_start_date,
+			end: wfaRecommendation.recommended_end_date,
+		};
+	}
+
+	// Inline adequacy check: estimate the OOS trades each fold will see at the
+	// strategy's measured trade rate; below min_fold_trades the folds are not
+	// judgeable (the gate treats such runs as insufficient evidence, not verdicts).
+	$: wfaSelectedWindowDays = windowDaysBetween(walkForwardForm.start_date, walkForwardForm.end_date);
+	$: wfaEstOosTradesPerFold =
+		wfaRecommendation?.est_trades_per_day && wfaSelectedWindowDays
+			? wfaRecommendation.est_trades_per_day *
+				((wfaSelectedWindowDays *
+					(1 - Math.min(Math.max(Number(walkForwardForm.train_ratio) || 0.7, 0.05), 0.95))) /
+					Math.max(Number(walkForwardForm.n_splits) || 1, 1))
+			: null;
+	$: wfaWindowWarning = (() => {
+		if (!wfaRecommendation || !wfaSelectedWindowDays) return '';
+		if (wfaEstOosTradesPerFold != null) {
+			if (wfaEstOosTradesPerFold < wfaRecommendation.min_fold_trades) {
+				return (
+					`At ~${wfaRecommendation.est_trades_per_month} trades/month, each OOS fold will see ` +
+					`~${wfaEstOosTradesPerFold.toFixed(1)} trades — below the ${wfaRecommendation.min_fold_trades}-trade ` +
+					`minimum to judge a fold. The promotion gate treats such runs as insufficient evidence.`
+				);
+			}
+			return '';
+		}
+		if (wfaSelectedWindowDays < wfaRecommendation.window_days) {
+			return (
+				`Selected window is ${Math.round(wfaSelectedWindowDays)} days; ` +
+				`~${wfaRecommendation.window_days} days recommended for a ${wfaRecommendation.timeframe} strategy ` +
+				`so every fold has a judgeable trade sample.`
+			);
+		}
+		return '';
+	})();
 	$: if (!costStressForm.start_date && baselineWindowStart) {
 		costStressForm = {
 			...costStressForm,
@@ -260,6 +346,7 @@
 			syncTrackedProcesses(processes);
 		});
 		void rehydrateFromValidationHistory();
+		void loadWfaRecommendation();
 		return () => {
 			destroyed = true;
 			mounted = false;
@@ -1252,6 +1339,21 @@
 					accent="violet"
 				/>
 			</div>
+
+			{#if wfaWindowWarning}
+				<div class="mt-3 border border-yellow-900 bg-yellow-500/5 px-3 py-2 text-xs text-yellow-400" data-testid="wf-adequacy-warning">
+					<span>{wfaWindowWarning}</span>
+					{#if wfaRecommendation}
+						<button
+							type="button"
+							class="ml-2 underline decoration-dotted hover:text-yellow-200"
+							on:click={() => applyRecommendedWindow(true)}
+						>
+							Use recommended window (~{Math.round(wfaRecommendation.window_days / 30.44)} months)
+						</button>
+					{/if}
+				</div>
+			{/if}
 			<div class="mt-3 grid gap-4 lg:grid-cols-3">
 				<NumericInputField id="wf-splits" label="Splits" bind:value={walkForwardForm.n_splits} min="2" max="20" helpText="Number of train/test folds." />
 				<NumericInputField id="wf-train-ratio" label="Train ratio" bind:value={walkForwardForm.train_ratio} min="0.1" max="0.95" step="0.05" helpText="Fraction of each fold used for training." />

--- a/frontend/src/lib/components/trading/PaperTrades.svelte
+++ b/frontend/src/lib/components/trading/PaperTrades.svelte
@@ -335,7 +335,15 @@
 		return toTradeFill(row).key ?? index;
 	}
 
-	function legFee(feeBps: number | null | undefined, price: number | null | undefined, size: number): number | null {
+	// Prefer the exact per-leg dollars persisted at close (kernel paper trades itemize
+	// the drag they actually charged); fall back to bps x leg notional (live trades).
+	function legFee(
+		explicitUsd: number | null | undefined,
+		feeBps: number | null | undefined,
+		price: number | null | undefined,
+		size: number
+	): number | null {
+		if (typeof explicitUsd === 'number' && Number.isFinite(explicitUsd) && explicitUsd > 0) return explicitUsd;
 		if (typeof feeBps !== 'number' || feeBps <= 0) return null;
 		if (typeof price !== 'number' || !Number.isFinite(price) || price <= 0 || size <= 0) return null;
 		return (feeBps / 10000) * price * size;
@@ -345,9 +353,9 @@
 		const fills: TradeFillRow[] = [];
 		for (const trade of trades) {
 			const size = Number(trade.size) || 0;
-			const entryFee = legFee(trade.entry_fee_bps, trade.entry_price, size);
+			const entryFee = legFee(trade.entry_fee_usd, trade.entry_fee_bps, trade.entry_price, size);
 			if (trade.exit_time) {
-				const exitFee = legFee(trade.exit_fee_bps, trade.exit_price, size);
+				const exitFee = legFee(trade.exit_fee_usd, trade.exit_fee_bps, trade.exit_price, size);
 				const gross = typeof trade.gross_pnl === 'number' ? trade.gross_pnl : trade.pnl;
 				fills.push({
 					key: `${trade.id}:close`,
@@ -3662,6 +3670,12 @@
 														<span class="text-gray-500">Fees:</span>
 														<span class="text-red-400">{formatDollarPnl((trade.fees_paid ?? 0) * -1)}</span>
 													</div>
+													{#if typeof trade.slippage_usd === 'number' && trade.slippage_usd > 0}
+														<div class="flex justify-between gap-4 mb-1">
+															<span class="text-gray-500">Slippage:</span>
+															<span class="text-red-400">{formatDollarPnl(trade.slippage_usd * -1)}</span>
+														</div>
+													{/if}
 													<div class="flex justify-between gap-4 mb-1">
 														<span class="text-gray-500">Funding:</span>
 														<span class="{getPnlTone(trade.funding_pnl)}">{formatDollarPnl(trade.funding_pnl)}</span>

--- a/frontend/src/lib/components/trading/PaperTrades.svelte
+++ b/frontend/src/lib/components/trading/PaperTrades.svelte
@@ -192,6 +192,7 @@
 	// Selected session
 	let selectedSession: PaperTradingSession | null = null;
 	let sessionTrades: PaperTrade[] = [];
+	$: sessionTradeFills = buildTradeFills(sessionTrades);
 	// One-shot: a strategy id from a ?select= deep-link (e.g. the All Trades blotter)
 	// to select THAT strategy's existing session on the next session load.
 	let preselectStrategyId: string | null = null;
@@ -233,14 +234,17 @@
 	const paperStockSymbols = ['AAPL', 'MSFT', 'NVDA', 'TSLA', 'SPY', 'QQQ'];
 	const speedPresets = [0.5, 1, 2, 5, 10, 20];
 	const CHART_MARKER_TIMEOUT_MS = 5_000;
-	const tradeHistoryColumns = [
-		{ key: 'side', label: 'Side' },
-		{ key: 'entry_time', label: 'Entry Time' },
-		{ key: 'exit_time', label: 'Exit Time' },
-		{ key: 'entry_price', label: 'Entry' },
-		{ key: 'exit_price', label: 'Exit' },
-		{ key: 'pnl', label: '$ P&L', align: 'right' as const },
-		{ key: 'pnl_pct', label: 'P&L %', align: 'right' as const },
+	// Hyperliquid-style fills view: each trade renders as an Open fill row plus a
+	// Close fill row (once closed), mirroring the exchange's trade history columns.
+	const tradeFillColumns = [
+		{ key: 'time', label: 'Time' },
+		{ key: 'market', label: 'Market' },
+		{ key: 'direction', label: 'Direction' },
+		{ key: 'price', label: 'Price', align: 'right' as const },
+		{ key: 'size', label: 'Size', align: 'right' as const },
+		{ key: 'value', label: 'Trade Value', align: 'right' as const },
+		{ key: 'fee', label: 'Fee', align: 'right' as const },
+		{ key: 'closed_pnl', label: 'Closed PNL', align: 'right' as const },
 	];
 
 	let liveChartPoller: Poller | null = null;
@@ -311,13 +315,99 @@
 	// real-money warnings on the manual controls and confirm modal.
 	$: isLiveSelected = isDeployedCompatSession(selectedSession);
 
-	function toPaperTrade(row: unknown): PaperTrade {
-		return row as PaperTrade;
+	// One exchange-style fill row (a trade contributes an open fill and, once
+	// closed, a close fill — matching Hyperliquid's trade history).
+	interface TradeFillRow {
+		key: string;
+		trade: PaperTrade;
+		kind: 'open' | 'close';
+		time: string | null;
+		price: number | null;
+		fee: number | null;
+		closedPnl: number | null;
 	}
 
-	function getPaperTradeRowKey(row: unknown, index: number): string | number {
-		const trade = toPaperTrade(row);
-		return trade.id ?? index;
+	function toTradeFill(row: unknown): TradeFillRow {
+		return row as TradeFillRow;
+	}
+
+	function getTradeFillRowKey(row: unknown, index: number): string | number {
+		return toTradeFill(row).key ?? index;
+	}
+
+	function legFee(feeBps: number | null | undefined, price: number | null | undefined, size: number): number | null {
+		if (typeof feeBps !== 'number' || feeBps <= 0) return null;
+		if (typeof price !== 'number' || !Number.isFinite(price) || price <= 0 || size <= 0) return null;
+		return (feeBps / 10000) * price * size;
+	}
+
+	function buildTradeFills(trades: PaperTrade[]): TradeFillRow[] {
+		const fills: TradeFillRow[] = [];
+		for (const trade of trades) {
+			const size = Number(trade.size) || 0;
+			const entryFee = legFee(trade.entry_fee_bps, trade.entry_price, size);
+			if (trade.exit_time) {
+				const exitFee = legFee(trade.exit_fee_bps, trade.exit_price, size);
+				const gross = typeof trade.gross_pnl === 'number' ? trade.gross_pnl : trade.pnl;
+				fills.push({
+					key: `${trade.id}:close`,
+					trade,
+					kind: 'close',
+					time: trade.exit_time,
+					price: trade.exit_price,
+					fee: exitFee,
+					// Hyperliquid convention: each fill's closed PnL is net of that
+					// fill's own fee (funding lives in the hover breakdown).
+					closedPnl: typeof gross === 'number' ? gross - (exitFee ?? 0) : null,
+				});
+			}
+			fills.push({
+				key: `${trade.id}:open`,
+				trade,
+				kind: 'open',
+				time: trade.entry_time,
+				price: trade.entry_price,
+				fee: entryFee,
+				closedPnl: entryFee !== null ? -entryFee : null,
+			});
+		}
+		return fills.sort((a, b) => new Date(b.time ?? 0).getTime() - new Date(a.time ?? 0).getTime());
+	}
+
+	function fillMarket(fill: TradeFillRow): string {
+		const symbol = String(fill.trade.symbol || '').trim();
+		return symbol.split(/[/:_-]/)[0] || symbol || '--';
+	}
+
+	function fillDirectionLabel(fill: TradeFillRow): string {
+		const side = String(fill.trade.side || 'long').toUpperCase() === 'SHORT' ? 'Short' : 'Long';
+		return `${fill.kind === 'open' ? 'Open' : 'Close'} ${side}`;
+	}
+
+	function fillDirectionTone(fill: TradeFillRow): string {
+		const isShort = String(fill.trade.side || 'long').toUpperCase() === 'SHORT';
+		// Color by order side like the exchange: buys (open long / close short)
+		// green, sells (close long / open short) red.
+		const isBuy = (fill.kind === 'open') !== isShort;
+		return isBuy ? 'text-green-400' : 'text-red-400';
+	}
+
+	function fillTradeValue(fill: TradeFillRow): number | null {
+		const size = Number(fill.trade.size) || 0;
+		if (typeof fill.price !== 'number' || !Number.isFinite(fill.price) || size <= 0) return null;
+		return fill.price * size;
+	}
+
+	function formatFillTime(dateStr: string | null | undefined): string {
+		if (!dateStr) return '--';
+		const date = new Date(dateStr);
+		if (Number.isNaN(date.getTime())) return '--';
+		return `${date.toLocaleDateString()} - ${date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })}`;
+	}
+
+	function formatFee(value: number | null): string {
+		if (typeof value !== 'number' || !Number.isFinite(value)) return '—';
+		return `$${value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 	}
 
 	type LegacyTradeMarker = TradeMarker & { time?: string };
@@ -3468,8 +3558,8 @@
 					</div>
 				</div>
 
-				<!-- Row 3: Bottom Panels -->
-				<div class="border-t border-[#222] grid grid-cols-3 overflow-hidden">
+				<!-- Row 3: Bottom Panels — trades get the lion's share, signals stay compact -->
+				<div class="border-t border-[#222] grid grid-cols-[minmax(0,2fr)_minmax(0,1.2fr)_minmax(0,4.8fr)] overflow-hidden">
 					<!-- Live Indicators -->
 					<div class="border-r border-[#222] p-2 overflow-y-auto">
 						<h3 class="text-[10px] font-bold text-gray-500 uppercase tracking-wider mb-1.5">Indicators</h3>
@@ -3517,11 +3607,11 @@
 					<!-- Trade History -->
 					<div class="p-2 overflow-y-auto">
 						<h3 class="text-[10px] font-bold text-gray-500 uppercase tracking-wider mb-1.5">Trades</h3>
-						{#if sessionTrades.length > 0}
+						{#if sessionTradeFills.length > 0}
 							<DataTable
-								columns={tradeHistoryColumns}
-								rows={sessionTrades}
-								rowKey={getPaperTradeRowKey}
+								columns={tradeFillColumns}
+								rows={sessionTradeFills}
+								rowKey={getTradeFillRowKey}
 								tableClass="w-full text-[11px]"
 								headerClass="text-gray-500 border-b border-[#222]"
 								rowClass="border-b border-[#111] hover:bg-[#111]"
@@ -3529,58 +3619,62 @@
 								emptyClass="py-3 text-center text-gray-600 text-[11px]"
 							>
 								<svelte:fragment slot="cell" let:row let:column>
-									{@const trade = toPaperTrade(row)}
-									{#if column.key === 'side'}
-										<span class="font-bold {trade.side === 'long' || trade.side === 'LONG' || trade.side === 'Long' ? 'text-green-400' : 'text-red-400'}">
-											{trade.side?.toUpperCase() === 'SHORT' ? 'Short' : 'Long'}
-										</span>
-									{:else if column.key === 'entry_time'}
-										<span class="text-gray-400">{formatDateTime(trade.entry_time)}</span>
-									{:else if column.key === 'exit_time'}
-										<span class="text-gray-400">{formatDateTime(trade.exit_time)}</span>
-									{:else if column.key === 'entry_price'}
-										<span class="text-gray-400">{formatPrice(trade.entry_price)}</span>
-									{:else if column.key === 'exit_price'}
-										{@const closeBadge = getTradeCloseBadge(trade)}
-										<div class="flex flex-col items-end">
-											<span class="text-gray-400">{formatPrice(trade.exit_price)}</span>
+									{@const fill = toTradeFill(row)}
+									{@const trade = fill.trade}
+									{#if column.key === 'time'}
+										<span class="text-gray-400 whitespace-nowrap">{formatFillTime(fill.time)}</span>
+									{:else if column.key === 'market'}
+										<span class="font-bold text-gray-300">{fillMarket(fill)}</span>
+									{:else if column.key === 'direction'}
+										{@const closeBadge = fill.kind === 'close' ? getTradeCloseBadge(trade) : null}
+										<div class="flex items-center gap-1.5">
+											<span class="{fillDirectionTone(fill)}">{fillDirectionLabel(fill)}</span>
 											{#if closeBadge}
 												<span
-													class="mt-1 inline-flex rounded border px-1.5 py-0.5 text-[9px] uppercase tracking-wider {closeBadge.tone}"
+													class="inline-flex rounded border px-1.5 py-0.5 text-[9px] uppercase tracking-wider {closeBadge.tone}"
 													title={closeBadge.title}
 												>
 													{closeBadge.label}
 												</span>
 											{/if}
 										</div>
-									{:else if column.key === 'pnl'}
-										<div class="relative group cursor-default">
-											<span class="font-bold {getPnlTone(trade.pnl)}">
-												{formatDollarPnl(trade.pnl)}
-											</span>
-											<div class="absolute right-0 top-full z-10 hidden group-hover:block bg-[#111] border border-[#333] p-2 text-[10px] min-w-[140px]">
-												<div class="flex justify-between gap-4 mb-1">
-													<span class="text-gray-500">Gross:</span>
-													<span class="text-gray-300">{formatDollarPnl(trade.gross_pnl)}</span>
-												</div>
-												<div class="flex justify-between gap-4 mb-1">
-													<span class="text-gray-500">Fees:</span>
-													<span class="text-red-400">{formatDollarPnl((trade.fees_paid ?? 0) * -1)}</span>
-												</div>
-												<div class="flex justify-between gap-4 mb-1">
-													<span class="text-gray-500">Funding:</span>
-													<span class="{getPnlTone(trade.funding_pnl)}">{formatDollarPnl(trade.funding_pnl)}</span>
-												</div>
-												<div class="border-t border-[#333] pt-1 mt-1 flex justify-between gap-4 font-bold">
-													<span class="text-gray-400">Net:</span>
-													<span class="{getPnlTone(trade.net_pnl)}">{formatDollarPnl(trade.net_pnl)}</span>
+									{:else if column.key === 'price'}
+										<span class="text-gray-400">{formatPrice(fill.price)}</span>
+									{:else if column.key === 'size'}
+										<span class="text-gray-400">{formatQty(trade.size)} {fillMarket(fill)}</span>
+									{:else if column.key === 'value'}
+										{@const value = fillTradeValue(fill)}
+										<span class="text-gray-400">{value === null ? '—' : formatFee(value)}</span>
+									{:else if column.key === 'fee'}
+										<span class="text-gray-400">{formatFee(fill.fee)}</span>
+									{:else if column.key === 'closed_pnl'}
+										{#if fill.kind === 'close'}
+											<div class="relative group cursor-default">
+												<span class="font-bold {getPnlTone(fill.closedPnl)}">
+													{formatDollarPnl(fill.closedPnl)}
+												</span>
+												<div class="absolute right-0 top-full z-10 hidden group-hover:block bg-[#111] border border-[#333] p-2 text-[10px] min-w-[150px]">
+													<div class="flex justify-between gap-4 mb-1">
+														<span class="text-gray-500">Gross:</span>
+														<span class="text-gray-300">{formatDollarPnl(trade.gross_pnl)}</span>
+													</div>
+													<div class="flex justify-between gap-4 mb-1">
+														<span class="text-gray-500">Fees:</span>
+														<span class="text-red-400">{formatDollarPnl((trade.fees_paid ?? 0) * -1)}</span>
+													</div>
+													<div class="flex justify-between gap-4 mb-1">
+														<span class="text-gray-500">Funding:</span>
+														<span class="{getPnlTone(trade.funding_pnl)}">{formatDollarPnl(trade.funding_pnl)}</span>
+													</div>
+													<div class="border-t border-[#333] pt-1 mt-1 flex justify-between gap-4 font-bold">
+														<span class="text-gray-400">Net:</span>
+														<span class="{getPnlTone(trade.net_pnl)}">{formatDollarPnl(trade.net_pnl)} ({formatPercent(trade.net_pnl_pct)})</span>
+													</div>
 												</div>
 											</div>
-										</div>
-									{:else if column.key === 'pnl_pct'}
-										<span class="font-bold {getPnlTone(trade.pnl_pct)}">
-											{formatPercent(trade.pnl_pct)}
-										</span>
+										{:else}
+											<span class="{getPnlTone(fill.closedPnl)}">{fill.closedPnl === null ? '—' : formatDollarPnl(fill.closedPnl)}</span>
+										{/if}
 									{/if}
 								</svelte:fragment>
 							</DataTable>

--- a/tests/test_crucible_planner.py
+++ b/tests/test_crucible_planner.py
@@ -131,6 +131,7 @@ def _make_planner_task(
     *,
     error: str | None = None,
     durable_refine: bool = False,
+    output: dict | None = None,
 ) -> None:
     output_data = None
     if durable_refine:
@@ -147,6 +148,8 @@ def _make_planner_task(
                 ]
             }
         )
+    elif output is not None:
+        output_data = json.dumps(output)
     with get_db() as conn:
         conn.execute(
             """
@@ -723,6 +726,141 @@ def test_parked_protected_crucible_is_never_auto_archived(forven_db):
             (parked["id"],),
         ).fetchone()
     assert row["manager_state"] == "active"
+
+
+# A develop_candidate that completed WITHOUT a successful strategy-creation
+# tool call — the substrate-blocked refusal shape (LESSONS L141/L142) that used
+# to be re-dispatched every planner cycle forever.
+_REFUSAL_DEVELOP_OUTPUT = {
+    "tool_trace": [
+        {"tool_name": "read_file", "ok": False, "output_summary": "read notes"},
+        {
+            "tool_name": "write_file",
+            "ok": False,
+            "output_summary": "Appended to notes/substrate_refusal.md",
+        },
+    ],
+    "response": (
+        "=== TOOL EXECUTION LEDGER (ground truth) ===\n"
+        "  [FAILED] write_file — Appended to notes/substrate_refusal.md"
+    ),
+}
+
+_FRUITFUL_DEVELOP_OUTPUT = {
+    "tool_trace": [
+        {
+            "tool_name": "register_strategy",
+            "ok": True,
+            "output_summary": '{"ok": true, "strategy": {"id": "S-NEW"}}',
+        },
+    ],
+    "response": '=== TOOL EXECUTION LEDGER (ground truth) ===\n  [ok] register_strategy — {"ok": true}',
+}
+
+
+def test_fruitless_completed_develop_candidates_park_and_archive_crucible(forven_db):
+    """Substrate-blocked refusals complete 'successfully' but create nothing;
+    they must count toward the develop retry cap or the planner re-dispatches
+    the same crucible every cycle forever (observed at 40 dispatches/48h)."""
+    from forven.crucible_planner import plan_next_actions
+
+    parked = _make_crucible("researching")
+    for _ in range(3):
+        _make_planner_task(
+            parked["id"], "develop_candidate", "reviewed", output=_REFUSAL_DEVELOP_OUTPUT
+        )
+
+    actions = plan_next_actions(limit=3)
+
+    assert [action.action_kind for action in actions] == ["propose_crucible"]
+    with get_db() as conn:
+        row = conn.execute(
+            "SELECT manager_state, archive_reason FROM hypotheses WHERE id = ?",
+            (parked["id"],),
+        ).fetchone()
+    assert row["manager_state"] == "archived"
+    assert row["archive_reason"] == "develop_fruitless_3x"
+
+
+def test_fruitful_completed_develop_candidates_do_not_count_toward_retry_cap(forven_db):
+    from forven.crucible_planner import plan_next_actions
+
+    crucible = _make_crucible("researching")
+    for _ in range(3):
+        _make_planner_task(
+            crucible["id"], "develop_candidate", "reviewed", output=_FRUITFUL_DEVELOP_OUTPUT
+        )
+
+    actions = plan_next_actions(limit=3)
+
+    assert len(actions) == 1
+    assert actions[0].action_kind == "develop_candidate"
+    assert actions[0].crucible_id == crucible["id"]
+    with get_db() as conn:
+        row = conn.execute(
+            "SELECT manager_state FROM hypotheses WHERE id = ?",
+            (crucible["id"],),
+        ).fetchone()
+    assert row["manager_state"] == "active"
+
+
+def test_develop_completion_without_tool_evidence_is_not_counted_fruitless(forven_db):
+    """Legacy/missing traces must never park a healthy crucible."""
+    from forven.crucible_planner import plan_next_actions
+
+    crucible = _make_crucible("researching")
+    for _ in range(3):
+        _make_planner_task(crucible["id"], "develop_candidate", "reviewed")
+
+    actions = plan_next_actions(limit=3)
+
+    assert len(actions) == 1
+    assert actions[0].action_kind == "develop_candidate"
+    assert actions[0].crucible_id == crucible["id"]
+
+
+def test_mixed_failed_and_fruitless_develops_archive_with_retries_reason(forven_db):
+    """When hard failures (not refusals) push the count over the cap, keep the
+    original attributable reason."""
+    from forven.crucible_planner import plan_next_actions
+
+    parked = _make_crucible("researching")
+    _make_planner_task(parked["id"], "develop_candidate", "reviewed", output=_REFUSAL_DEVELOP_OUTPUT)
+    for _ in range(2):
+        _make_planner_task(parked["id"], "develop_candidate", "failed")
+
+    plan_next_actions(limit=3)
+
+    with get_db() as conn:
+        row = conn.execute(
+            "SELECT manager_state, archive_reason FROM hypotheses WHERE id = ?",
+            (parked["id"],),
+        ).fetchone()
+    assert row["manager_state"] == "archived"
+    assert row["archive_reason"] == "develop_retries_exhausted"
+
+
+def test_task_index_counts_fruitless_develops_with_response_ledger_fallback(forven_db):
+    from forven.crucible_planner import CrucibleTaskIndex
+
+    _make_planner_task("H-FRUITLESS", "develop_candidate", "reviewed", output=_REFUSAL_DEVELOP_OUTPUT)
+    # Trace missing, but the response ledger proves a successful creation call.
+    _make_planner_task(
+        "H-LEDGER-OK",
+        "develop_candidate",
+        "reviewed",
+        output={"response": "[ok] forven_create_strategy — persisted"},
+    )
+
+    index = CrucibleTaskIndex.build()
+
+    assert index.fruitless_develop_count("H-FRUITLESS") == 1
+    assert index.failed_action_count("develop_candidate", "H-FRUITLESS") == 1
+    assert index.successful_action_exists("develop_candidate", "H-FRUITLESS") is False
+
+    assert index.fruitless_develop_count("H-LEDGER-OK") == 0
+    assert index.failed_action_count("develop_candidate", "H-LEDGER-OK") == 0
+    assert index.successful_action_exists("develop_candidate", "H-LEDGER-OK") is True
 
 
 def test_researching_crucible_below_retry_cap_is_not_archived(forven_db):

--- a/tests/test_gauntlet_paper_bypass_fix.py
+++ b/tests/test_gauntlet_paper_bypass_fix.py
@@ -176,6 +176,33 @@ def test_robustness_floor_operator_reenforced(forven_db, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Walk-forward: zero judgeable folds = insufficient evidence, gate BLOCKS
+# (S05925: every fold below wfa_min_fold_trades used to be graded as coin
+# flips by the raw fallback — 2/5 positive 1-3-trade folds = pass_rate 0.40
+# == the configured floor, and the strategy reached paper).
+# ---------------------------------------------------------------------------
+
+def test_wfa_insufficient_fold_evidence_blocks_promotion(forven_db, monkeypatch):
+    _stub_prereqs(monkeypatch, {
+        "walk_forward": {
+            "status": "insufficient",
+            "passed": False,
+            "verdict": "INSUFFICIENT",
+            "folds": 0,
+            "pass_rate": 0.0,
+            "insufficient_fold_evidence": True,
+        },
+    })
+    cfg = _cfg(required_tests=[], min_robustness_score=0)
+    with get_db() as conn:
+        _insert_gauntlet(conn, "wfa-insufficient", _PASS_METRICS)
+    passed, msg = _evaluate_gauntlet_gate("wfa-insufficient", cfg)
+    assert not passed, msg
+    assert "window insufficient" in msg
+    assert "trade-frequency-aware" in msg
+
+
+# ---------------------------------------------------------------------------
 # Monte-Carlo tail-DD ceiling — default 0.50, operator-editable
 # ---------------------------------------------------------------------------
 

--- a/tests/test_hypothesis_promotion_loop.py
+++ b/tests/test_hypothesis_promotion_loop.py
@@ -75,6 +75,43 @@ def test_promotion_loop_respects_cooldown(forven_db):
     assert h["id"] not in result["dispatched_ids"]
 
 
+def test_promotion_loop_skips_develop_exhausted_crucible(forven_db):
+    """Mirror of the planner's develop-retry cap: a crucible with no live
+    strategies whose develop_candidate attempts all completed fruitlessly
+    (substrate-blocked refusals) must not be re-picked."""
+    from forven.hypothesis_promotion import run_promotion_loop
+    h = _hyp()
+    refusal_output = json.dumps({
+        "tool_trace": [
+            {"tool_name": "write_file", "ok": False, "output_summary": "refusal memo"},
+        ],
+    })
+    with get_db() as conn:
+        for _ in range(3):
+            conn.execute(
+                """INSERT INTO agent_tasks (agent_id, type, title, description, input_data, output_data, status)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    "strategy-developer",
+                    "develop_candidate",
+                    "t",
+                    "d",
+                    json.dumps({
+                        "origin_mode": "crucible_planner",
+                        "action_kind": "develop_candidate",
+                        "crucible_id": h["id"],
+                    }),
+                    refusal_output,
+                    "reviewed",
+                ),
+            )
+    with patch("forven.brain.assign_task") as m:
+        result = run_promotion_loop(top_k=3)
+    assert h["id"] not in result["dispatched_ids"]
+    assert result["skipped"]["develop_exhausted"] == 1
+    m.assert_not_called()
+
+
 def test_promotion_loop_respects_global_cap(forven_db):
     """When MAX_IN_FLIGHT is hit, dispatches nothing new."""
     from forven.hypothesis_promotion import run_promotion_loop

--- a/tests/test_paper_gate_inflight_and_deferral.py
+++ b/tests/test_paper_gate_inflight_and_deferral.py
@@ -308,6 +308,63 @@ def test_evolution_testing_step_defers_to_active_workflow(forven_db, monkeypatch
     assert promotion_attempts == ["s-defer"]
 
 
+def test_evolution_fast_path_blocked_by_terminally_failed_workflow(forven_db, monkeypatch):
+    """A terminally failed/cancelled v3 workflow is a VERDICT: the fast path
+    must not re-judge the same evidence through the lean gate and promote
+    (S05925: workflow failed_gate 02:47 -> fast-path promoted to paper 02:57)."""
+    import forven.evolution as evolution
+    import forven.gauntlet.store as store
+
+    candidate = {
+        "id": "s-wf-failed",
+        "stage": "gauntlet",
+        "status": "gauntlet",
+        "type": "rsi_momentum",
+        "params": {},
+        "symbol": "ETH/USDT",
+        "timeframe": "1h",
+    }
+    monkeypatch.setattr(evolution, "get_strategies", lambda: [candidate])
+    monkeypatch.setattr(evolution, "_is_pipeline_candidate_strategy", lambda s: True)
+    monkeypatch.setattr(
+        evolution, "_resolve_pipeline_execution_plan",
+        lambda n: {"drain": False, "drain_max_seconds": 60, "max_assignments": 3, "adaptive": False, "target_clear_hours": 0},
+    )
+    promotion_attempts: list[str] = []
+    monkeypatch.setattr(
+        evolution, "_attempt_stage_promotion",
+        lambda sid, **kwargs: promotion_attempts.append(sid) or (False, "stubbed"),
+    )
+    monkeypatch.setattr(
+        evolution, "_advance_gauntlet_readiness",
+        lambda **kwargs: {"action": "none"},
+    )
+    monkeypatch.setattr(store, "has_active_workflow_for_strategy", lambda sid: False)
+
+    monkeypatch.setattr(
+        store, "get_latest_workflow_for_strategy",
+        lambda sid: {"id": "gw_failed", "status": "failed_gate"},
+    )
+    outcome = evolution._run_testing_step_impl()
+    assert promotion_attempts == []
+    assert outcome.get("workflow_failed_blocked_ids") == ["s-wf-failed"]
+
+    monkeypatch.setattr(
+        store, "get_latest_workflow_for_strategy",
+        lambda sid: {"id": "gw_cancelled", "status": "cancelled"},
+    )
+    evolution._run_testing_step_impl()
+    assert promotion_attempts == []
+
+    # A PASSED terminal workflow does not block the (then no-op) fast path.
+    monkeypatch.setattr(
+        store, "get_latest_workflow_for_strategy",
+        lambda sid: {"id": "gw_passed", "status": "passed"},
+    )
+    evolution._run_testing_step_impl()
+    assert promotion_attempts == ["s-wf-failed"]
+
+
 # ---------------------------------------------------------------------------
 # 3. Best-backtest display scoped to the strategy's own market + trade floor
 # ---------------------------------------------------------------------------

--- a/tests/test_paper_trade_compat.py
+++ b/tests/test_paper_trade_compat.py
@@ -92,6 +92,71 @@ def test_build_compat_paper_trade_surfaces_real_close_costs():
     assert trade["pnl"] == 0.8738
 
 
+def test_build_compat_paper_trade_prefers_persisted_kernel_cost_breakdown():
+    # Kernel paper closes persist exact dollar costs (execution_kernel.cost_breakdown_usd)
+    # with a NET pnl_usd; the payload must surface them verbatim — not re-subtract costs
+    # from the already-net pnl, and not zero the fee fields.
+    trade = paper_domain._build_compat_paper_trade(
+        {
+            "id": "E0020",
+            "direction": "long",
+            "entry_price": 60173.01,
+            "exit_price": 62771.6,
+            "size": 0.108149,
+            "leverage": 2.0,
+            "opened_at": "2026-07-01T15:00:00+00:00",
+            "closed_at": "2026-07-05T11:01:18+00:00",
+            "pnl_usd": 266.6548,
+            "pnl_pct": 0.02666548,
+            "net_pnl_pct": 0.02666548,
+            "fees_pct": None,
+            "signal_data": {
+                "kernel_managed": True,
+                "fee_bps": 4.5,
+                "entry_fee_usd": 2.9,
+                "exit_fee_usd": 2.9,
+                "total_fees_usd": 5.8,
+                "slippage_usd": 2.58,
+                "funding_usd": 1.2,
+                "gross_pnl_usd": 276.2348,
+            },
+        },
+        strategy_name="Kernel Strategy",
+        symbol="BTC/USDT",
+    )
+
+    assert trade["gross_pnl"] == 276.2348
+    assert trade["net_pnl"] == 266.6548  # pnl is already net — no double subtraction
+    assert trade["fees_paid"] == 5.8
+    assert trade["entry_fee_bps"] == 4.5
+    assert trade["exit_fee_bps"] == 4.5
+    assert trade["entry_fee_usd"] == 2.9
+    assert trade["exit_fee_usd"] == 2.9
+    assert trade["slippage_usd"] == 2.58
+    assert trade["funding_pnl"] == -1.2
+
+
+def test_cost_breakdown_usd_reconstructs_gross_exactly():
+    from forven.strategies.execution_kernel import cost_breakdown_usd, round_trip_drag
+
+    equity, lev, size_frac, fee_bps, slip_bps = 10000.0, 2.0, 0.5, 4.5, 2.0
+    funding_gain = -0.001  # paid 0.1% of equity in funding
+    gross_return = 0.04  # price return * sign * lev, pre-drag
+    net_pct = (gross_return - round_trip_drag(fee_bps, slip_bps, lev)) * size_frac + funding_gain
+    net_usd = equity * net_pct
+
+    b = cost_breakdown_usd(
+        equity_at_entry=equity, leverage=lev, size_fraction=size_frac,
+        fee_bps=fee_bps, slippage_bps=slip_bps,
+        funding_gain_pct=funding_gain, net_pnl_usd=net_usd,
+    )
+
+    # Net + itemized costs must sum exactly back to the pure price gross.
+    assert abs(b["gross_pnl_usd"] - equity * gross_return * size_frac) < 1e-6
+    assert abs(b["total_fees_usd"] - (b["entry_fee_usd"] + b["exit_fee_usd"])) < 1e-9
+    assert abs(b["funding_usd"] - 10.0) < 1e-9  # cost-positive convention
+
+
 def test_build_compat_paper_trade_surfaces_incomplete_close_metadata():
     trade = paper_domain._build_compat_paper_trade(
         {

--- a/tests/test_paper_trade_compat.py
+++ b/tests/test_paper_trade_compat.py
@@ -57,6 +57,41 @@ def test_build_compat_paper_trade_uses_exit_fallbacks_and_computes_pnl():
     assert abs(float(trade["pnl_pct"]) - 7.5) < 1e-9
 
 
+def test_build_compat_paper_trade_surfaces_real_close_costs():
+    # Mirrors live trade E0082 (verified against Hyperliquid's fills): pnl_usd
+    # stays gross while fees_pct / net_pnl_pct / funding_usd — all recorded at
+    # close — surface as real dollar costs instead of zero-fill.
+    trade = paper_domain._build_compat_paper_trade(
+        {
+            "id": "E0082",
+            "direction": "long",
+            "entry_price": 62588.0,
+            "exit_price": 62715.0,
+            "size": 0.00688,
+            "leverage": 1.3,
+            "opened_at": "2026-07-03T22:51:21+00:00",
+            "closed_at": "2026-07-05T06:00:42+00:00",
+            "pnl_usd": 0.8738,
+            "pnl_pct": 0.002638,
+            "net_pnl_pct": 0.00094627,
+            "fees_pct": 0.00117,
+            "signal_data": {"funding_usd": 0.172777, "close_reason": "signal"},
+        },
+        strategy_name="Compat Strategy",
+        symbol="BTC/USDT",
+    )
+
+    margin = 62588.0 * 0.00688 / 1.3
+    assert abs(trade["fees_paid"] - 0.00117 * margin) < 1e-9  # ~$0.39 round trip (0.19/leg on HL)
+    assert abs(trade["entry_fee_bps"] - 4.5) < 1e-9
+    assert abs(trade["exit_fee_bps"] - 4.5) < 1e-9
+    assert abs(trade["funding_pnl"] - (-0.172777)) < 1e-9
+    assert abs(trade["net_pnl"] - (0.8738 - trade["fees_paid"] - 0.172777)) < 1e-9
+    assert abs(trade["net_pnl_pct"] - 0.094627) < 1e-9
+    assert trade["gross_pnl"] == 0.8738
+    assert trade["pnl"] == 0.8738
+
+
 def test_build_compat_paper_trade_surfaces_incomplete_close_metadata():
     trade = paper_domain._build_compat_paper_trade(
         {

--- a/tests/test_robustness_suite_bugfixes.py
+++ b/tests/test_robustness_suite_bugfixes.py
@@ -69,6 +69,40 @@ def test_wfa_falls_back_to_raw_rate_without_fold_trade_counts(forven_db):
     assert payload["folds"] == 4
 
 
+# --- 2b. walk-forward zero-judgeable folds = insufficient evidence ---------
+# S05925: every fold reported 1-3 OOS trades (all below wfa_min_fold_trades),
+# so the legacy fallback graded coin-flip folds by raw sharpe>0 and produced
+# pass_rate 0.40 == the configured floor — promoted to paper on 2 lucky folds.
+# Such runs judge NOTHING: they must read as insufficient evidence (gate
+# blocks with an actionable reason), never as a pass and never as a merit fail.
+
+
+def test_wfa_all_folds_below_trade_floor_is_insufficient_not_coinflip(forven_db):
+    # The S05925 shape: 5 folds with 3/3/2/2/1 OOS trades, 2 positive sharpes
+    # (one a 2-trade fold at the +10 clamp). Old fallback: pass_rate 0.4 -> pass.
+    metrics = _wf_metrics([(-7.9, 3), (1.09, 3), (10.0, 2), (-3.5, 2), (0.0, 1)])
+    payload = _validation_row_to_verdict_payload("walk_forward", metrics, {})
+    assert payload["insufficient_fold_evidence"] is True
+    assert payload["passed"] is False
+    assert payload["status"] == "insufficient"
+    assert payload["verdict"] == "INSUFFICIENT"
+    assert payload["folds"] == 0
+    assert payload["pass_rate"] == 0.0
+
+
+def test_wfa_insufficient_evidence_reads_as_absence_in_gauntlet_status(forven_db):
+    from forven.policy import wfa_insufficient_fold_evidence
+
+    metrics = _wf_metrics([(1.0, 2), (2.0, 1), (0.5, 3)])
+    assert wfa_insufficient_fold_evidence(metrics) is True
+    # A single judgeable fold makes the artifact gradable again.
+    metrics_ok = _wf_metrics([(1.0, 2), (2.0, 12), (0.5, 3)])
+    assert wfa_insufficient_fold_evidence(metrics_ok) is False
+    # Legacy rows without per-fold trade counts are NOT insufficient (fallback).
+    legacy = {"verdict": "PASS", "splits": [{"out_of_sample": {"sharpe": 1.0}}]}
+    assert wfa_insufficient_fold_evidence(legacy) is False
+
+
 # --- 3. param-jitter inverted floor ---------------------------------------
 
 def test_jitter_positive_baseline_requires_edge_retention():

--- a/tests/test_wfa_window.py
+++ b/tests/test_wfa_window.py
@@ -1,0 +1,89 @@
+"""Trade-frequency-aware WFA window sizing (forven.wfa_window).
+
+The window must be a function of the strategy's measured trade rate so every
+OOS fold gets a judgeable trade sample (S05925: a ~3-trades/month 4h strategy
+got 1-3 OOS trades per fold from the 1Y calendar window — coin-flip folds).
+"""
+
+import json
+
+from forven.db import get_db
+from forven.wfa_window import measured_trade_rate, recommended_wfa_window
+
+
+def _insert_strategy(conn, sid, metrics):
+    conn.execute(
+        "INSERT INTO strategies (id, name, type, status, stage, owner, metrics) "
+        "VALUES (?, ?, 'rsi_momentum', 'gauntlet', 'gauntlet', 'brain', ?)",
+        (sid, sid, json.dumps(metrics)),
+    )
+
+
+def test_measured_rate_prefers_strategy_metrics(forven_db):
+    with get_db() as conn:
+        # ~2.78 trades/month == the S05925 shape (40 trades over 14.38 months).
+        _insert_strategy(conn, "s-rate", {"total_trades": 40, "backtest_months": 14.38})
+    rate, source = measured_trade_rate("s-rate")
+    assert source == "strategy_metrics"
+    assert 0.08 < rate < 0.10  # trades per day
+
+
+def test_measured_rate_falls_back_to_latest_backtest(forven_db):
+    with get_db() as conn:
+        _insert_strategy(conn, "s-bt-rate", {})
+        conn.execute(
+            "INSERT INTO backtest_results (result_id, strategy_id, result_type, symbol, timeframe, "
+            "metrics_json, config_json, created_at) "
+            "VALUES ('bt-rate-1', 's-bt-rate', 'backtest', 'BTC', '4h', ?, '{}', datetime('now'))",
+            (json.dumps({"total_trades": 30, "backtest_months": 3.0}),),
+        )
+    rate, source = measured_trade_rate("s-bt-rate")
+    assert source == "latest_backtest"
+    assert rate > 0
+
+
+def test_low_frequency_4h_strategy_gets_multi_year_window(forven_db):
+    with get_db() as conn:
+        _insert_strategy(conn, "s-slow", {"total_trades": 40, "backtest_months": 14.38})
+    rec = recommended_wfa_window("s-slow", "4h", n_splits=5, train_ratio=0.7)
+    # ~0.0914 trades/day, target 10/fold -> ~109 OOS days/fold -> ~1824-day window.
+    assert rec["window_days"] > 1500, rec
+    assert rec["trade_rate_source"] == "strategy_metrics"
+    assert rec["target_oos_trades_per_fold"] >= 10
+    # Bars stay within the runner ceiling.
+    assert rec["window_bars"] <= 50_000
+
+
+def test_high_frequency_strategy_keeps_short_window(forven_db):
+    with get_db() as conn:
+        # ~10 trades/day: the min-OOS-days floor dominates, not the trade rate.
+        _insert_strategy(conn, "s-fast", {"total_trades": 900, "backtest_months": 3.0})
+    rec = recommended_wfa_window("s-fast", "1h", n_splits=5, train_ratio=0.7)
+    assert rec["window_days"] <= 600, rec
+
+
+def test_unmeasured_strategy_uses_timeframe_fallback(forven_db):
+    with get_db() as conn:
+        _insert_strategy(conn, "s-fresh", {})
+    rec_4h = recommended_wfa_window("s-fresh", "4h", n_splits=5, train_ratio=0.7)
+    rec_1h = recommended_wfa_window("s-fresh", "1h", n_splits=5, train_ratio=0.7)
+    assert rec_4h["trade_rate_source"] == "none"
+    # Coarser timeframe -> longer fallback window.
+    assert rec_4h["window_days"] > rec_1h["window_days"]
+
+
+def test_sub_hourly_window_capped_by_max_bars(forven_db):
+    with get_db() as conn:
+        # Very low rate on 5m bars: uncapped this would explode past 50k bars.
+        _insert_strategy(conn, "s-5m-slow", {"total_trades": 5, "backtest_months": 12.0})
+    rec = recommended_wfa_window("s-5m-slow", "5m", n_splits=5, train_ratio=0.7)
+    assert rec["capped_by_max_bars"] is True
+    assert rec["window_bars"] == 50_000
+
+
+def test_more_splits_need_a_longer_window(forven_db):
+    with get_db() as conn:
+        _insert_strategy(conn, "s-splits", {"total_trades": 40, "backtest_months": 14.38})
+    rec5 = recommended_wfa_window("s-splits", "4h", n_splits=5, train_ratio=0.7)
+    rec10 = recommended_wfa_window("s-splits", "4h", n_splits=10, train_ratio=0.7)
+    assert rec10["window_days"] > rec5["window_days"]


### PR DESCRIPTION
## Problem

Agents refusing substrate-blocked candidates (LESSONS L141/L142) complete their `develop_candidate` task as `reviewed` = success while creating nothing. The crucible planner's 3-strike retry cap counts only `failed`/`cancelled` statuses, so refusal loops never park: the planner re-dispatched the same crucible every ~5-minute cycle forever.

Measured impact: **585 develop_candidate dispatches in 48h** (451 planner, 134 promotion loop). H01543 burned 40 identical refusal cycles; H01552 hit 17 in one day; H01553 was at 12 and still climbing when this fix was written. Each dispatch is a full strategy-developer LLM run plus a redundant refusal memo.

Brain approvals #441/#442 proposed LLM-cron routines to work around this; #442's `dispatch_suppressed` flag is read by nothing in the codebase. This PR is the deterministic guard at the actual gap; both approvals should be denied.

## Fix

- **`_develop_task_spawned_strategy()`** (crucible_planner.py): a success-status `develop_candidate` whose tool evidence (runner ground-truth `tool_trace` / response ledger) shows no successful `register_strategy` / `forven_create_strategy` / `create_strategy` / `forven_register_strategy_file` call now counts toward `failed_action_counts` — mirroring the existing `_refine_task_has_durable_update` idiom. Missing/unreadable evidence counts as fruitful, so a legacy trace can never park a healthy crucible.
- **Attributable archive reason**: new `fruitless_develop_counts` tracker; pure refusal loops archive as `develop_fruitless_3x`, hard-failure loops keep `develop_retries_exhausted`. Archiving stays reversible via the Hypothesis Manager, and protected/contested theses remain exempt.
- **Promotion loop mirror** (hypothesis_promotion.py): picks skip crucibles with zero live strategies whose develop attempts are exhausted (`skipped.develop_exhausted`), so neither dispatcher burns an agent run on a known refusal.

## Verification

- 6 new tests: refusal shape, fruitful shape, missing-evidence safety, mixed failed+fruitless reason attribution, response-ledger fallback, promotion-loop skip.
- `test_crucible_planner.py` + `test_hypothesis_promotion_loop.py`: 41/41 pass. Related crucible/hypothesis suites: 159/160 (the one `test_pipeline_hardening.py` failure reproduces on clean main; pre-existing).
- Read-only preview against the live DB: of 19 active crucibles, the guard's first cycle archives exactly the two current loopers (H01553 fruitless=12, H01511 fruitless=8) and touches nothing else.

## Rollout

Backend restart required for the scheduler to pick up the new planner code. Deny approvals #441/#442 in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also in this branch

Committed on this branch alongside the planner fix:

- **531e0943 fix(gauntlet)**: unjudgeable WFA folds now block promotion instead of silently passing; fold windows are sized by observed trade rate so sparse strategies get judgeable folds.
- **bc89b079 feat(paper)**: real close costs in the compat trade payload + per-trade cost breakdown in the trades table.
- **fc5edbfe feat(paper)**: itemize the fees/slippage/funding the kernel already charges in the trade payload.
- Merged `main` in (includes the PR #28 OAuth fix) — no conflicts.
