### PR TITLE
fix(auth): OAuth completion never marked provider connected; false "could not open browser"

### DIFF
--- a/forven/api_core.py
+++ b/forven/api_core.py
@@ -3882,6 +3882,19 @@ def _build_minimax_oauth_start() -> dict[str, str]:
     }
 
 
+def _mark_provider_connected_after_oauth(provider: str) -> None:
+    """A finished OAuth flow is an explicit operator connection. Record it so
+    the fail-closed spend gate (provider_is_connected) goes green, exactly like
+    the manual key-save path — otherwise the tokens land in the auth file but
+    the provider keeps showing NOT CONNECTED / "env key only"."""
+    try:
+        from forven.model_selection import mark_provider_connected
+
+        mark_provider_connected(provider)
+    except Exception:
+        log.exception("failed to mark %s connected after oauth", provider)
+
+
 def _complete_openai_oauth(state: str, code: str, code_verifier: str | None) -> None:
     from forven.auth import openai as openai_auth
 
@@ -3955,6 +3968,7 @@ def _complete_openai_oauth(state: str, code: str, code_verifier: str | None) -> 
         profile["accountId"] = account_id
 
     upsert_profile("openai", profile)
+    _mark_provider_connected_after_oauth("openai")
     _consume_oauth_session("openai", state)
 
 
@@ -4099,6 +4113,7 @@ def _poll_minimax_once(state: str, session: dict) -> dict:
                 "expires": int(expires) if isinstance(expires, (int, float)) else None,
             }
             upsert_profile("minimax", profile)
+            _mark_provider_connected_after_oauth("minimax")
             _consume_oauth_session("minimax", state)
             return {"status": "complete"}
         status = _minimax_status_from_error(_oauth_error_code(payload), state, session)

--- a/frontend/src/lib/components/settings/sections/SettingsAgents.svelte
+++ b/frontend/src/lib/components/settings/sections/SettingsAgents.svelte
@@ -25,6 +25,7 @@
 		type ForvenAuthProviderOAuthStartResponse,
 	} from '$lib/api';
 	import { openExternal } from '$lib/external-open';
+	import { copyTextToClipboard } from '$lib/utils/clipboard';
 	import { msToMinutes, minutesToMs, formatIntervalMs } from '$lib/utils/schedule';
 
 	export let settings: Record<string, unknown> = {};
@@ -86,9 +87,25 @@
 	let providerBaseUrlInput: Record<string, string> = {};
 	let providerOAuthState: Record<
 		string,
-		(ForvenAuthProviderOAuthStartResponse & { code: string }) | null
+		(ForvenAuthProviderOAuthStartResponse & { code: string; openFailed?: boolean }) | null
 	> = {};
 	let providerOAuthStatus: Record<string, string> = {};
+	let providerLinkCopied: Record<string, boolean> = {};
+
+	async function copySignInLink(provider: string) {
+		const flow = providerOAuthState[provider];
+		const url = flow?.authorize_url ?? flow?.verification_url;
+		if (!url) return;
+		const ok = await copyTextToClipboard(url);
+		providerLinkCopied = { ...providerLinkCopied, [provider]: ok };
+		if (ok) {
+			setTimeout(() => {
+				providerLinkCopied = { ...providerLinkCopied, [provider]: false };
+			}, 2000);
+		} else {
+			setProviderError(provider, `Copy failed — select and copy the link manually: ${url}`);
+		}
+	}
 
 	function draftFromAgent(a: ForvenAgent) {
 		return {
@@ -396,6 +413,7 @@
 						stopPolling(provider);
 						setOAuthStatus(provider, 'complete');
 						providerOAuthState = { ...providerOAuthState, [provider]: null };
+						setProviderError(provider, null);
 						setProviderMessage(provider, 'Connected');
 						await loadAuthProviders();
 						return;
@@ -432,28 +450,6 @@
 		try {
 			const res = await startForvenAuthProviderOAuth(provider);
 			providerOAuthState = { ...providerOAuthState, [provider]: { ...res, code: '' } };
-			// Hand the authorize URL to the OS browser. In the packaged Tauri
-			// shell, window.open(_blank) is a silent no-op — the OAuth tab
-			// never loads and the user sees "Waiting for sign-in..." forever.
-			// openExternal() invokes the tauri-plugin-opener command; in a
-			// plain browser it falls back to window.open.
-			if (res.authorize_url) {
-				const ok = await openExternal(res.authorize_url);
-				if (!ok) {
-					setProviderError(
-						provider,
-						`Could not open browser. Copy this URL manually: ${res.authorize_url}`,
-					);
-				}
-			} else if (res.verification_url) {
-				const ok = await openExternal(res.verification_url);
-				if (!ok) {
-					setProviderError(
-						provider,
-						`Could not open browser. Copy this URL manually: ${res.verification_url}`,
-					);
-				}
-			}
 
 			const needsManualOnly = res.flow === 'authorization_code' && res.auto_callback === false;
 			if (needsManualOnly) {
@@ -461,6 +457,24 @@
 			} else {
 				setOAuthStatus(provider, 'awaiting_user');
 				schedulePoll(provider, res.state, res.interval ?? 2);
+			}
+
+			// Hand the authorize URL to the OS browser. In the packaged Tauri
+			// shell, window.open(_blank) is a silent no-op — openExternal()
+			// invokes the tauri-plugin-opener command; in a plain browser it
+			// falls back to window.open. A failure here is recoverable from
+			// inside the flow panel (open link + copy button), so flag it on
+			// the flow state instead of aborting with an error.
+			const target = res.authorize_url ?? res.verification_url;
+			if (target) {
+				const opened = await openExternal(target);
+				const flow = providerOAuthState[provider];
+				if (!opened && flow) {
+					providerOAuthState = {
+						...providerOAuthState,
+						[provider]: { ...flow, openFailed: true },
+					};
+				}
 			}
 		} catch (e) {
 			setProviderError(provider, e instanceof Error ? e.message : 'Failed to start OAuth');
@@ -660,20 +674,38 @@
 								<p class="text-xs text-[#888]">
 									{oauth.flow === 'device_code' ? 'Device code flow' : 'Authorization code flow'}
 								</p>
+								{#if oauth.openFailed}
+									<p class="text-xs text-yellow-400">
+										Your browser didn't open automatically — use the sign-in link below.
+									</p>
+								{/if}
 								{#if oauth.verification_url && oauth.user_code}
 									<p class="text-xs text-[#888]">
 										Go to <a
 											href={oauth.verification_url}
+											target="_blank"
+											rel="noopener noreferrer"
 											on:click|preventDefault={() => openExternal(oauth.verification_url!)}
 											class="text-white underline cursor-pointer">{oauth.verification_url}</a>
 										and enter code <span class="font-mono text-white">{oauth.user_code}</span>
 									</p>
 								{:else if oauth.authorize_url}
 									<p class="text-xs text-[#888]">
-										A new tab opened to <a
-											href={oauth.authorize_url}
-											on:click|preventDefault={() => openExternal(oauth.authorize_url!)}
-											class="text-white underline cursor-pointer">authorize</a>.
+										{#if oauth.openFailed}
+											<a
+												href={oauth.authorize_url}
+												target="_blank"
+												rel="noopener noreferrer"
+												class="text-white underline cursor-pointer">Open the sign-in page</a>
+											or copy the link, then finish signing in there.
+										{:else}
+											A new tab opened to <a
+												href={oauth.authorize_url}
+												target="_blank"
+												rel="noopener noreferrer"
+												on:click|preventDefault={() => openExternal(oauth.authorize_url!)}
+												class="text-white underline cursor-pointer">authorize</a>.
+										{/if}
 										{#if isManualPaste}
 											Paste the code returned by the provider:
 										{:else if isAuthorizationCode}
@@ -710,6 +742,15 @@
 											class="terminal-button-primary text-xs"
 										>
 											{busy ? 'Completing…' : 'Use pasted code'}
+										</button>
+									{/if}
+									{#if oauth.authorize_url || oauth.verification_url}
+										<button
+											type="button"
+											on:click={() => copySignInLink(key)}
+											class="terminal-button text-xs"
+										>
+											{providerLinkCopied[key] ? 'Copied ✓' : 'Copy sign-in link'}
 										</button>
 									{/if}
 									<button

--- a/frontend/src/lib/external-open.ts
+++ b/frontend/src/lib/external-open.ts
@@ -84,8 +84,18 @@ export async function openExternal(url: string): Promise<boolean> {
 		}
 	}
 	try {
-		const win = window.open(url, '_blank', 'noopener,noreferrer');
-		return win !== null;
+		// Do NOT pass 'noopener' in the features string: per spec window.open()
+		// then returns null even when the tab opened fine, which misreported a
+		// working browser handoff as "could not open". Open plainly (null now
+		// really means blocked) and sever the opener link ourselves.
+		const win = window.open(url, '_blank');
+		if (!win) return false;
+		try {
+			win.opener = null;
+		} catch {
+			/* cross-origin — opener access denied, already isolated */
+		}
+		return true;
 	} catch {
 		return false;
 	}

--- a/frontend/src/lib/utils/clipboard.ts
+++ b/frontend/src/lib/utils/clipboard.ts
@@ -1,0 +1,29 @@
+/**
+ * Copy text to the clipboard. Returns true on success so callers can show
+ * "Copied" feedback. Falls back to the hidden-textarea trick for contexts
+ * where the async clipboard API is unavailable (mirrors strategyPortability).
+ */
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+	try {
+		if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+			await navigator.clipboard.writeText(text);
+			return true;
+		}
+	} catch {
+		/* fall through to the textarea fallback */
+	}
+	try {
+		const textarea = document.createElement('textarea');
+		textarea.value = text;
+		textarea.setAttribute('readonly', 'true');
+		textarea.style.position = 'fixed';
+		textarea.style.left = '-9999px';
+		document.body.appendChild(textarea);
+		textarea.select();
+		const ok = document.execCommand('copy');
+		textarea.remove();
+		return ok;
+	} catch {
+		return false;
+	}
+}

--- a/frontend/src/routes/agents/components/tabs/ProvidersTab.svelte
+++ b/frontend/src/routes/agents/components/tabs/ProvidersTab.svelte
@@ -23,6 +23,7 @@
 	} from '$lib/api';
 	import { onDestroy } from 'svelte';
 	import { openExternal } from '$lib/external-open';
+	import { copyTextToClipboard } from '$lib/utils/clipboard';
 	import { agentsConfig, isProviderConnected } from '../agentsConfigStore';
 
 	$: providers = $agentsConfig.providers;
@@ -37,9 +38,25 @@
 	let providerBaseUrlInput: Record<string, string> = {};
 	let providerOAuthState: Record<
 		string,
-		(ForvenAuthProviderOAuthStartResponse & { code: string }) | null
+		(ForvenAuthProviderOAuthStartResponse & { code: string; openFailed?: boolean }) | null
 	> = {};
 	let providerOAuthStatus: Record<string, string> = {};
+	let providerLinkCopied: Record<string, boolean> = {};
+
+	async function copySignInLink(provider: string) {
+		const flow = providerOAuthState[provider];
+		const url = flow?.authorize_url ?? flow?.verification_url;
+		if (!url) return;
+		const ok = await copyTextToClipboard(url);
+		providerLinkCopied = { ...providerLinkCopied, [provider]: ok };
+		if (ok) {
+			setTimeout(() => {
+				providerLinkCopied = { ...providerLinkCopied, [provider]: false };
+			}, 2000);
+		} else {
+			setProviderError(provider, `Copy failed — select and copy the link manually: ${url}`);
+		}
+	}
 
 	/**
 	 * Where to sign up / get an API key per provider. Rendered as a plain "get a
@@ -166,6 +183,7 @@
 						stopPolling(provider);
 						setOAuthStatus(provider, 'complete');
 						providerOAuthState = { ...providerOAuthState, [provider]: null };
+						setProviderError(provider, null);
 						setProviderMessage(provider, 'Connected');
 						await reload();
 						return;
@@ -201,23 +219,6 @@
 		try {
 			const res = await startForvenAuthProviderOAuth(provider);
 			providerOAuthState = { ...providerOAuthState, [provider]: { ...res, code: '' } };
-			if (res.authorize_url) {
-				const ok = await openExternal(res.authorize_url);
-				if (!ok) {
-					setProviderError(
-						provider,
-						`Could not open browser. Copy this URL manually: ${res.authorize_url}`,
-					);
-				}
-			} else if (res.verification_url) {
-				const ok = await openExternal(res.verification_url);
-				if (!ok) {
-					setProviderError(
-						provider,
-						`Could not open browser. Copy this URL manually: ${res.verification_url}`,
-					);
-				}
-			}
 
 			const needsManualOnly = res.flow === 'authorization_code' && res.auto_callback === false;
 			if (needsManualOnly) {
@@ -225,6 +226,21 @@
 			} else {
 				setOAuthStatus(provider, 'awaiting_user');
 				schedulePoll(provider, res.state, res.interval ?? 2);
+			}
+
+			// Hand the URL to the OS browser. A failure here is recoverable from
+			// inside the flow panel (open link + copy button), so flag it on the
+			// flow state instead of aborting with an error.
+			const target = res.authorize_url ?? res.verification_url;
+			if (target) {
+				const opened = await openExternal(target);
+				const flow = providerOAuthState[provider];
+				if (!opened && flow) {
+					providerOAuthState = {
+						...providerOAuthState,
+						[provider]: { ...flow, openFailed: true },
+					};
+				}
 			}
 		} catch (e) {
 			setProviderError(provider, e instanceof Error ? e.message : 'Failed to start OAuth');
@@ -423,20 +439,38 @@
 							<p class="text-xs text-[#888]">
 								{oauth.flow === 'device_code' ? 'Device code flow' : 'Authorization code flow'}
 							</p>
+							{#if oauth.openFailed}
+								<p class="text-xs text-yellow-400">
+									Your browser didn't open automatically — use the sign-in link below.
+								</p>
+							{/if}
 							{#if oauth.verification_url && oauth.user_code}
 								<p class="text-xs text-[#888]">
 									Go to <a
 										href={oauth.verification_url}
+										target="_blank"
+										rel="noopener noreferrer"
 										on:click|preventDefault={() => openExternal(oauth.verification_url!)}
 										class="text-white underline cursor-pointer">{oauth.verification_url}</a>
 									and enter code <span class="font-mono text-white">{oauth.user_code}</span>
 								</p>
 							{:else if oauth.authorize_url}
 								<p class="text-xs text-[#888]">
-									A new tab opened to <a
-										href={oauth.authorize_url}
-										on:click|preventDefault={() => openExternal(oauth.authorize_url!)}
-										class="text-white underline cursor-pointer">authorize</a>.
+									{#if oauth.openFailed}
+										<a
+											href={oauth.authorize_url}
+											target="_blank"
+											rel="noopener noreferrer"
+											class="text-white underline cursor-pointer">Open the sign-in page</a>
+										or copy the link, then finish signing in there.
+									{:else}
+										A new tab opened to <a
+											href={oauth.authorize_url}
+											target="_blank"
+											rel="noopener noreferrer"
+											on:click|preventDefault={() => openExternal(oauth.authorize_url!)}
+											class="text-white underline cursor-pointer">authorize</a>.
+									{/if}
 									{#if isManualPaste}
 										Paste the code returned by the provider:
 									{:else if isAuthorizationCode}
@@ -471,6 +505,15 @@
 										class="terminal-button-primary text-xs px-3 py-1 disabled:opacity-60"
 									>
 										{busy ? 'Completing…' : 'Use pasted code'}
+									</button>
+								{/if}
+								{#if oauth.authorize_url || oauth.verification_url}
+									<button
+										type="button"
+										on:click={() => copySignInLink(key)}
+										class="terminal-button text-xs px-3 py-1"
+									>
+										{providerLinkCopied[key] ? 'Copied ✓' : 'Copy sign-in link'}
 									</button>
 								{/if}
 								<button


### PR DESCRIPTION
## Emergency fix — provider OAuth flow

**Bug 1 (the real damage):** completing OAuth (OpenAI/MiniMax) stored tokens via `upsert_profile` but never called `mark_provider_connected` — only the manual key-save path did. A fully successful sign-in left the provider **NOT CONNECTED / "env key only"** with valid tokens in the auth file, unable to authorize spend. Both completion paths now record the connection via a shared `_mark_provider_connected_after_oauth` helper (all three OpenAI completion routes funnel through `_complete_openai_oauth`; MiniMax through `_poll_minimax_once`).

**Bug 2 (the scary-but-fake error):** `openExternal()`'s browser fallback passed `noopener` to `window.open`, which per spec returns `null` even on success — so a working browser hand-off surfaced as *"Could not open browser. Copy this URL manually: …"*. Now opens plainly (`null` genuinely means popup-blocked) and severs `win.opener` manually for the same tabnabbing protection.

**UX:** raw-URL red error dump replaced by an in-panel notice with an "Open the sign-in page" anchor + "Copy sign-in link" button (new `$lib/utils/clipboard` helper); stale errors cleared on successful completion. Applied to both `ProvidersTab.svelte` and `SettingsAgents.svelte`.

## Verification
- `tests/test_oauth_ux_rework.py` — 27 passed
- `svelte-check` — 0 errors (2 pre-existing warnings)
- `settingsAgentsSection.test.ts` — 4 passed

**Post-merge:** restart the backend, then hit **Re-authenticate** once — previously-minted tokens are valid but the connected flag was never recorded under the old code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)