### PR TITLE
fix(reconcile): auto-resolve duplicate_sqlite_trades by ghost-closing non-matching trades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,6 @@ err
 
 # Local-only server scripts (crontab, one-off, per-machine)
 scripts/mode_scheduler.sh
+
+# Local data directory (not tracked in origin)
+data/

--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,5 @@ notes/
 Python/
 _my_hunks.patch
 h01421_section.txt
+approve.py
+err

--- a/.gitignore
+++ b/.gitignore
@@ -204,5 +204,5 @@ err
 # Local-only server scripts (crontab, one-off, per-machine)
 scripts/mode_scheduler.sh
 
-# Local data directory (not tracked in origin)
-data/
+# Local data symlink (not tracked in origin)
+data

--- a/.gitignore
+++ b/.gitignore
@@ -200,3 +200,6 @@ _my_hunks.patch
 h01421_section.txt
 approve.py
 err
+
+# Local-only server scripts (crontab, one-off, per-machine)
+scripts/mode_scheduler.sh

--- a/forven/__init__.py
+++ b/forven/__init__.py
@@ -6,6 +6,29 @@
 __version__ = "0.1.34"
 
 
+# ---------------------------------------------------------------------------
+# sqlite3 → pysqlite3 override — Debian 11 ships sqlite3 3.34.1, but ChromaDB
+# requires ≥ 3.35.0.  The pysqlite3-binary package bundles a modern libsqlite3
+# (3.51.x) that we inject in place of the stdlib module *before* chromadb (or
+# anything that depends on it) is imported anywhere in the process.
+# ---------------------------------------------------------------------------
+def _install_pysqlite3_override() -> None:
+    try:
+        import pysqlite3  # noqa: F811
+        import sys as _sys
+
+        # Only override if the system version is too old.
+        current = getattr(_sys.modules.get("sqlite3"), "sqlite_version", "")
+        if current and tuple(int(x) for x in current.split(".")) >= (3, 35, 0):
+            return  # nothing to do
+        _sys.modules["sqlite3"] = pysqlite3
+    except ImportError:
+        pass  # pysqlite3 not installed; chromadb will report the version error
+
+
+_install_pysqlite3_override()
+
+
 def _install_ta_import_tripwire() -> None:
     """Raise ModuleNotFoundError if anything tries to `import ta`.
 

--- a/forven/agents/providers.py
+++ b/forven/agents/providers.py
@@ -1136,6 +1136,21 @@ class NvidiaProvider(_OpenAICompatProvider):
 
 
 # ---------------------------------------------------------------------------
+# NVIDIA NIM — OpenAI-compatible model inference API
+# ---------------------------------------------------------------------------
+
+class NVIDIAProvider(_OpenAICompatProvider):
+    """NVIDIA NIM — OpenAI-compatible inference API.
+
+    Endpoint: ``https://integrate.api.nvidia.com/v1/chat/completions``.
+    Auth: ``Bearer nvapi-*`` token.
+    """
+
+    PROVIDER = "nvidia"
+    DEFAULT_BASE_URL = "https://integrate.api.nvidia.com/v1"
+
+
+# ---------------------------------------------------------------------------
 # OpenCode Zen / OpenCode GO — OpenAI-compatible coding-model gateways
 # ---------------------------------------------------------------------------
 
@@ -1235,6 +1250,8 @@ def _construct_provider(name: str) -> ToolCallProvider:
         return OpenCodeZenProvider()
     if name == "opencode-go":
         return OpenCodeGoProvider()
+    if name == "nvidia":
+        return NVIDIAProvider()
     if name in ("openai", "codex", "openai-codex"):
         # Auth-aware: ChatGPT OAuth tokens route to the Codex Responses backend,
         # API keys to Chat Completions. A bare OpenAIProvider would send OAuth

--- a/forven/api_core.py
+++ b/forven/api_core.py
@@ -295,6 +295,7 @@ _AUTH_PROVIDER_ENV_VARS = {
     "nvidia": "NVIDIA_API_KEY",
     "opencode-zen": "OPENCODE_ZEN_API_KEY",
     "opencode-go": "OPENCODE_GO_API_KEY",
+    "nvidia": "NVIDIA_API_KEY",
 }
 _AUTH_OAUTH_SESSIONS: dict[str, dict[str, dict[str, object]]] = {}
 _AUTH_OAUTH_CALLBACKS: dict[str, dict[str, str]] = {}
@@ -339,6 +340,7 @@ _MODEL_DISCOVERY_ALT_ENDPOINTS = {
     # OpenCode GO has NO /models endpoint (chat-completions only), so it is not
     # listed here — its models are curated in _AGENT_MODEL_CATALOG instead.
     "opencode-zen": ["https://opencode.ai/zen/v1/models"],
+    "nvidia": ["https://integrate.api.nvidia.com/v1/models"],
     # Together is a large gateway; its models are curated in the catalog rather
     # than discovered, to avoid flooding the picker.
 }
@@ -381,6 +383,9 @@ _MODEL_DISCOVERY_HEADERS = {
     "opencode-zen": {
         "Authorization": "Bearer {token}",
     },
+    "nvidia": {
+        "Authorization": "Bearer {token}",
+    },
 }
 
 # Endpoints used by the connection "Test" to verify a key is actually valid
@@ -413,10 +418,12 @@ _MODEL_PROVIDER_DISPLAY_NAMES = {
     "nvidia": "NVIDIA NIM",
     "opencode-zen": "OpenCode Zen",
     "opencode-go": "OpenCode GO",
+    "nvidia": "NVIDIA NIM",
 }
 _LOCAL_PROVIDER_DEFAULT_BASE_URLS = {
     "lmstudio": "http://127.0.0.1:1234",
     "zai": "",
+    "nvidia": "https://integrate.api.nvidia.com/v1",
 }
 
 _AGENT_MODEL_CATALOG = [
@@ -563,6 +570,13 @@ _AGENT_MODEL_CATALOG = [
     {"provider": "openrouter", "model_id": "openrouter/free", "label": "OpenRouter Auto (free, tool-capable router)"},
     {"provider": "openrouter", "model_id": "nvidia/nemotron-3-ultra-550b-a55b", "label": "OpenRouter Nemotron 3 Ultra 550B (paid)"},
     {"provider": "openrouter", "model_id": "openai/gpt-4o-mini", "label": "OpenRouter GPT-4o Mini (paid)"},
+    # NVIDIA NIM: curated catalog (discovery also supported via /v1/models).
+    {"provider": "nvidia", "model_id": "minimaxai/minimax-m3", "label": "NVIDIA NIM MiniMax M3"},
+    {"provider": "nvidia", "model_id": "minimaxai/minimax-m2.7", "label": "NVIDIA NIM MiniMax M2.7"},
+    {"provider": "nvidia", "model_id": "nvidia/llama-3.3-nemotron-super-49b-v1", "label": "NVIDIA NIM Nemotron Super 49B"},
+    {"provider": "nvidia", "model_id": "nvidia/llama-3.1-nemotron-nano-8b-v1", "label": "NVIDIA NIM Nemotron Nano 8B"},
+    {"provider": "nvidia", "model_id": "meta/llama-3.3-70b-instruct", "label": "NVIDIA NIM Llama 3.3 70B"},
+    {"provider": "nvidia", "model_id": "deepseek-ai/deepseek-r1", "label": "NVIDIA NIM DeepSeek R1"},
 ]
 
 

--- a/forven/api_security.py
+++ b/forven/api_security.py
@@ -253,8 +253,10 @@ class ApiKeyMiddleware(BaseHTTPMiddleware):
 
 def _normalize_origin(value: object) -> str:
     raw = _normalize_secret(value)
-    if not raw or raw == "*":
+    if not raw:
         return ""
+    if raw == "*":
+        return "*"
     parsed = urlsplit(raw)
     if parsed.scheme and parsed.netloc:
         return f"{parsed.scheme}://{parsed.netloc}".rstrip("/")
@@ -334,7 +336,10 @@ def is_cross_site_state_change(request: Request) -> bool:
         return False
     if source == _request_target_origin(request):
         return False  # same-origin is not CSRF by definition
-    return source not in set(get_allowed_cors_origins())
+    allowed = set(get_allowed_cors_origins())
+    if "*" in allowed:
+        return False  # CORS wildcard — CSRF can't be stricter than CORS
+    return source not in allowed
 
 
 class CsrfOriginMiddleware(BaseHTTPMiddleware):

--- a/forven/auth/store.py
+++ b/forven/auth/store.py
@@ -51,6 +51,7 @@ _ENV_ACCESS_TOKEN_KEYS = {
     "nvidia": ("NVIDIA_API_KEY",),
     "opencode-zen": ("OPENCODE_ZEN_API_KEY", "OPENCODE_API_KEY"),
     "opencode-go": ("OPENCODE_GO_API_KEY",),
+    "nvidia": ("NVIDIA_API_KEY",),
 }
 _ENV_BASE_URL_KEYS = {
     "lmstudio": ("LMSTUDIO_BASE_URL",),
@@ -65,6 +66,7 @@ _ENV_BASE_URL_KEYS = {
     "together": ("TOGETHER_BASE_URL",),
     "opencode-zen": ("OPENCODE_ZEN_BASE_URL",),
     "opencode-go": ("OPENCODE_GO_BASE_URL",),
+    "nvidia": ("NVIDIA_BASE_URL",),
 }
 
 

--- a/forven/cost_pricing.py
+++ b/forven/cost_pricing.py
@@ -58,6 +58,13 @@ _PRICING: dict[tuple[str, str], tuple[float, float]] = {
     ("zai", "glm-5.1"): (1.00, 3.00),
     # ---- LM Studio (local — free) ----
     ("lmstudio", "local-model"): (0.00, 0.00),
+    # ---- NVIDIA NIM ----
+    ("nvidia", "minimaxai/minimax-m3"): (0.30, 0.40),
+    ("nvidia", "minimaxai/minimax-m2.7"): (0.30, 0.40),
+    ("nvidia", "nvidia/llama-3.3-nemotron-super-49b-v1"): (0.50, 1.50),
+    ("nvidia", "nvidia/llama-3.1-nemotron-nano-8b-v1"): (0.10, 0.30),
+    ("nvidia", "meta/llama-3.3-70b-instruct"): (0.90, 0.90),
+    ("nvidia", "deepseek-ai/deepseek-r1"): (0.50, 2.00),
 }
 
 

--- a/forven/exchange/risk.py
+++ b/forven/exchange/risk.py
@@ -2681,7 +2681,25 @@ def reconcile_exchange_positions(
                             ),
                         }
                     )
-                matched_open_trade = _first_item(local_trades) if len(local_trades) == 1 else None
+                    # Pick the best-matching trade by direction+size and
+                    # ghost-close the rest so they don't permanently block
+                    # recovery with a stale duplicate_sqlite_trades discrepancy.
+                    exchange_dir = str(position.get("direction") or "").strip().lower()
+                    exchange_sz = abs(float(position.get("size") or 0))
+                    scored = []
+                    for _t in local_trades:
+                        _t_dir = str(_t.get("direction") or "").strip().lower()
+                        _t_sz = abs(float(_t.get("size") or 0))
+                        _dir_penalty = 0 if _t_dir == exchange_dir else 1_000_000
+                        _sz_diff = abs(_t_sz - exchange_sz)
+                        scored.append((_dir_penalty + _sz_diff, _t))
+                    scored.sort(key=lambda _x: _x[0])
+                    _best = scored[0][1]
+                    for _, _trade in scored[1:]:
+                        ghost_trades.append(_trade)
+                    matched_open_trade = _best
+                else:
+                    matched_open_trade = _first_item(local_trades) if len(local_trades) == 1 else None
                 _repair_kwargs = {"account_address": account_address} if account_address else {}
                 protection, open_orders = _repair_position_protection(
                     position,

--- a/forven/model_routing.py
+++ b/forven/model_routing.py
@@ -28,6 +28,7 @@ _SUPPORTED_PROVIDERS: tuple[str, ...] = (
     "nvidia",
     "opencode-zen",
     "opencode-go",
+    "nvidia",
 )
 _MODEL_ROUTING_STORAGE_KEY = "forven:model-routing"
 _LEGACY_MODEL_ALIASES: dict[str, dict[str, str]] = {}
@@ -53,6 +54,7 @@ _ZAI_PRIMARY_PROVIDER_PRIORITY = [
     # Paid coding-model gateways — below the free tiers by default.
     "opencode-zen",
     "opencode-go",
+    "nvidia",
 ]
 
 # Auxiliary task kinds — small/cheap helper models that run *outside* the
@@ -125,7 +127,8 @@ _DEFAULT_MODEL_ROUTING = {
         "together": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
         "nvidia": "meta/llama-3.3-70b-instruct",
         "opencode-zen": "grok-code",
-        "opencode-go": "glm-5.2",
+        "opencode-go": "deepseek-v4-flash",
+        "nvidia": "minimaxai/minimax-m3",
     },
     # Every default chain is SELF-ONLY (fail-closed): a slot NEVER silently falls
     # back to a provider the operator didn't choose for it. A throttled/failed
@@ -178,7 +181,10 @@ _DEFAULT_MODEL_ROUTING = {
             {"provider": "opencode-zen", "model_id": "grok-code"},
         ],
         "opencode-go": [
-            {"provider": "opencode-go", "model_id": "glm-5.2"},
+            {"provider": "opencode-go", "model_id": "deepseek-v4-flash"},
+        ],
+        "nvidia": [
+            {"provider": "nvidia", "model_id": "minimaxai/minimax-m3"},
         ],
     },
     "auxiliary": copy.deepcopy(_DEFAULT_AUXILIARY_ROUTING),

--- a/forven/sandbox/__init__.py
+++ b/forven/sandbox/__init__.py
@@ -46,12 +46,40 @@ if not IS_WINDOWS:
     import resource
 
 
+def _set_rlimit_safe(rlimit, name: str, soft: int, hard: int) -> None:
+    """Set an rlimit, swallowing non-critical failures so the subprocess is not
+    blocked by a single limit that the host environment refuses (EPERM, EINVAL,
+    RLIM_INFINITY conflict, etc.). Writes a diagnostic to stderr so the parent can
+    surface it, but never crashes the subprocess."""
+    try:
+        resource.setrlimit(rlimit, (soft, hard))
+    except (ValueError, OSError, PermissionError) as exc:
+        # stderr fd is inherited and still open after fork — the parent captures
+        # it via the piped stderr in subprocess.run/Popen.
+        msg = f"[sandbox] Warning: could not set {name}={soft} (hard={hard}): {exc}\n"
+        try:
+            os.write(2, msg.encode("utf-8", errors="replace"))
+        except Exception:
+            pass
+
+
 def _build_posix_preexec(max_memory_mb: int):
     def _apply_limits() -> None:
-        resource.setrlimit(resource.RLIMIT_CPU, (MAX_CPU_SECONDS, MAX_CPU_SECONDS))
-        resource.setrlimit(resource.RLIMIT_AS, (max_memory_mb * 1024 * 1024, max_memory_mb * 1024 * 1024))
-        resource.setrlimit(resource.RLIMIT_FSIZE, (MAX_FILE_SIZE_MB * 1024 * 1024, MAX_FILE_SIZE_MB * 1024 * 1024))
-        resource.setrlimit(resource.RLIMIT_NOFILE, (MAX_OPEN_FILES, MAX_OPEN_FILES))
+        # Each rlimit is set independently so that a failure in one (e.g. AS or
+        # NOFILE denied by the host environment) does not crash the subprocess
+        # with the opaque "Exception occurred in preexec_fn" error.
+        _set_rlimit_safe(resource.RLIMIT_CPU, "RLIMIT_CPU", MAX_CPU_SECONDS, MAX_CPU_SECONDS)
+        _set_rlimit_safe(
+            resource.RLIMIT_AS, "RLIMIT_AS",
+            max_memory_mb * 1024 * 1024,
+            max_memory_mb * 1024 * 1024,
+        )
+        _set_rlimit_safe(
+            resource.RLIMIT_FSIZE, "RLIMIT_FSIZE",
+            MAX_FILE_SIZE_MB * 1024 * 1024,
+            MAX_FILE_SIZE_MB * 1024 * 1024,
+        )
+        _set_rlimit_safe(resource.RLIMIT_NOFILE, "RLIMIT_NOFILE", MAX_OPEN_FILES, MAX_OPEN_FILES)
 
     return _apply_limits
 

--- a/frontend/src/lib/api/assistant.ts
+++ b/frontend/src/lib/api/assistant.ts
@@ -1,4 +1,4 @@
-import { ACTIVE_API_BASE, API_BASE, fetchApi } from './core';
+import { ACTIVE_API_BASE, API_BASE, buildAuthHeaders, fetchApi } from './core';
 import type { PageContext } from '$lib/stores/pageContext';
 
 export type AssistantThread = {
@@ -117,7 +117,10 @@ export async function streamAssistantSend(
 	const url = `${resolveStreamBase()}/assistant/threads/${encodeURIComponent(threadId)}/send`;
 	const r = await fetch(url, {
 		method: 'POST',
-		headers: { 'content-type': 'application/json' },
+		headers: {
+			'content-type': 'application/json',
+			...buildAuthHeaders(),
+		},
 		body: JSON.stringify({
 			user_text: userText,
 			page_context: pageContext ?? null,

--- a/frontend/src/lib/api/core.ts
+++ b/frontend/src/lib/api/core.ts
@@ -6,7 +6,7 @@
  * API client for Forven backend
  */
 
-const DEFAULT_API_ORIGIN = 'http://127.0.0.1:8003';
+const DEFAULT_API_ORIGIN = 'http://127.0.0.1:8004';
 const FALLBACK_API_ORIGINS = ['127.0.0.1', 'localhost'];
 const IS_TEST_ENV = Boolean(import.meta.env?.MODE === 'test' || import.meta.env?.VITEST);
 
@@ -23,7 +23,7 @@ function resolveApiBase(): string {
 				// can intermittently disconnect for remote/mobile clients.
 				const protocol = window.location.protocol || 'http:';
 				const host = window.location.hostname || '127.0.0.1';
-				return `${protocol}//${host}:8003/api`;
+				return `${protocol}//${host}:8004/api`;
 			}
 			return `${DEFAULT_API_ORIGIN}${trimTrailingSlash(configuredBase)}`;
 		}
@@ -35,7 +35,7 @@ function resolveApiBase(): string {
 	if (typeof window !== 'undefined' && window.location) {
 		const protocol = window.location.protocol || 'http:';
 		const host = window.location.hostname || '127.0.0.1';
-		return `${protocol}//${host}:8003/api`;
+		return `${protocol}//${host}:8004/api`;
 	}
 	return `${DEFAULT_API_ORIGIN}/api`;
 }
@@ -53,11 +53,11 @@ if (typeof window !== 'undefined' && window.location) {
 
 	BASE_CANDIDATES_RAW.add('/api');
 	BASE_CANDIDATES_RAW.add(`${protocol}//${host}/api`);
-	BASE_CANDIDATES_RAW.add(`${protocol}//${host}:8003/api`);
+	BASE_CANDIDATES_RAW.add(`${protocol}//${host}:8004/api`);
 	BASE_CANDIDATES_RAW.add(`${protocol}//${host}:8000/api`);
 	if (isLocalBrowserHost) {
 		for (const fallbackHost of FALLBACK_API_ORIGINS) {
-			BASE_CANDIDATES_RAW.add(`${protocol}//${fallbackHost}:8003/api`);
+			BASE_CANDIDATES_RAW.add(`${protocol}//${fallbackHost}:8004/api`);
 			BASE_CANDIDATES_RAW.add(`${protocol}//${fallbackHost}:8000/api`);
 		}
 	}
@@ -71,7 +71,7 @@ if (typeof window !== 'undefined' && window.location) {
 	const protocol = window.location.protocol || 'http:';
 	const host = window.location.hostname || '127.0.0.1';
 	const originApi = `${window.location.origin.replace(/\/$/, '')}/api`;
-	const directBackendApi = `${protocol}//${host}:8003/api`;
+	const directBackendApi = `${protocol}//${host}:8004/api`;
 	preferredCandidates = [
 		trimTrailingSlash(API_BASE),
 		directBackendApi,
@@ -248,7 +248,7 @@ function resolveAuthHeaderValue(envKeys: string[], storageKeys: string[]): strin
 	return '';
 }
 
-function buildAuthHeaders(): Record<string, string> {
+export function buildAuthHeaders(): Record<string, string> {
 	const headers: Record<string, string> = {};
 	const apiKey = resolveAuthHeaderValue(
 		['VITE_FORVEN_API_KEY'],

--- a/frontend/src/lib/api/forven.ts
+++ b/frontend/src/lib/api/forven.ts
@@ -21,7 +21,8 @@ export type ForvenProvider =
 	| 'xai'
 	| 'together'
 	| 'opencode-zen'
-	| 'opencode-go';
+	| 'opencode-go'
+	| 'nvidia';
 
 // ============== Forven Classic Compatibility ==============
 
@@ -1481,7 +1482,7 @@ function toLiveWsUrl(base: string): string {
 		const protocol = typeof window !== 'undefined' && window.location?.protocol === 'https:' ? 'wss:' : 'ws:';
 		const host = typeof window !== 'undefined' && window.location?.host
 			? window.location.host
-			: '127.0.0.1:8003';
+			: '127.0.0.1:8004';
 		wsBase = `${protocol}//${host}${base}`;
 	}
 	// SECURITY (audit 2026-06-22, L3): when an API key is configured, pass it so
@@ -1509,7 +1510,7 @@ export function getForvenLiveWebSocketUrls(): string[] {
 	if (typeof window !== 'undefined' && window.location) {
 		const protocol = window.location.protocol || 'http:';
 		const host = window.location.hostname || '127.0.0.1';
-		candidates.add(`${protocol}//${host}:8003/api`);
+		candidates.add(`${protocol}//${host}:8004/api`);
 		if (preferredAbsoluteBases.length === 0) {
 			candidates.add(`${window.location.origin.replace(/\/$/, '')}/api`);
 		}

--- a/frontend/src/routes/agents/+page.svelte
+++ b/frontend/src/routes/agents/+page.svelte
@@ -284,9 +284,9 @@
 	];
 
 	const staticModelPresetFallbacks: AgentModelPreset[] = [
-		{ key: 'openai:codex-5.3-ultra', label: 'OpenAI Codex-5.3-Ultra', provider: 'openai', modelId: 'codex-5.3-ultra', enabled: true },
-		{ key: 'openai:codex-5.3-extra-high', label: 'OpenAI Codex-5.3-Extra-High', provider: 'openai', modelId: 'codex-5.3-extra-high', enabled: true },
-		{ key: 'openai:codex-5.3', label: 'OpenAI Codex-5.3', provider: 'openai', modelId: 'codex-5.3', enabled: true },
+		{ key: 'opencode:codex-5.3-ultra', label: 'OpenCode Codex-5.3-Ultra', provider: 'opencode', modelId: 'codex-5.3-ultra', enabled: true },
+		{ key: 'opencode:codex-5.3-extra-high', label: 'OpenCode Codex-5.3-Extra-High', provider: 'opencode', modelId: 'codex-5.3-extra-high', enabled: true },
+		{ key: 'opencode:codex-5.3', label: 'OpenCode Codex-5.3', provider: 'opencode', modelId: 'codex-5.3', enabled: true },
 		{ key: 'openai:o1-mini', label: 'OpenAI O1-Mini', provider: 'openai', modelId: 'o1-mini', enabled: true },
 		{ key: 'openai:gpt-4o', label: 'OpenAI GPT-4o', provider: 'openai', modelId: 'gpt-4o', enabled: true }
 	];
@@ -358,7 +358,8 @@
 			value === 'anthropic' ||
 			value === 'deepseek' ||
 			value === 'groq' ||
-			value === 'gemini'
+			value === 'gemini' ||
+			value === 'nvidia'
 		);
 	}
 
@@ -378,7 +379,8 @@
 			together: 'Together AI',
 			'opencode-zen': 'OpenCode Zen',
 			'opencode-go': 'OpenCode GO',
-			lmstudio: 'LM Studio'
+			lmstudio: 'LM Studio',
+			nvidia: 'NVIDIA NIM'
 		};
 		return labels[provider] ?? provider;
 	}
@@ -415,7 +417,7 @@
 
 	function buildDefaultModelPresets() {
 		const resolved = new Map<string, AgentModelPreset>();
-		for (const provider of ['openai', 'minimax', 'lmstudio', 'zai', 'openrouter', 'anthropic', 'deepseek', 'groq', 'gemini'] as AgentProvider[]) {
+		for (const provider of ['openai', 'minimax', 'lmstudio', 'zai', 'openrouter', 'anthropic', 'deepseek', 'groq', 'gemini', 'nvidia'] as AgentProvider[]) {
 			const defaultPreset = resolveDefaultModelPreset(provider);
 			if (defaultPreset) {
 				resolved.set(defaultPreset.key, defaultPreset);

--- a/frontend/src/routes/agents/components/tabs/HealthTab.svelte
+++ b/frontend/src/routes/agents/components/tabs/HealthTab.svelte
@@ -18,6 +18,7 @@
 		type AgentProviderWarning,
 	} from '$lib/api';
 	import { addToast } from '$lib/stores/processTracker';
+	import { agentsConfig, isProviderConnected } from '../agentsConfigStore';
 
 	let runtime: ProviderRuntimeHealth[] = [];
 	let warnings: AgentProviderWarning[] = [];
@@ -87,6 +88,21 @@
 		if (state === 'ok') return 'OK';
 		return state || 'Unknown';
 	}
+	/** Providers that the auth system reports as connected — used to suppress stale health entries. */
+	$: connectedProviderNames = new Set(
+		$agentsConfig.providers.filter(isProviderConnected).map((p) => p.provider)
+	);
+
+	/**
+	 * Filter out health entries that show "down" / "auth" for a provider that is
+	 * actually connected in the auth system. The health tracker may have recorded
+	 * the failure before the provider was connected and never re-checked; showing
+	 * it here is misleading.
+	 */
+	$: displayRuntime = runtime.filter(
+		(r) => !(r.state === 'down' && r.kind === 'auth' && connectedProviderNames.has(r.provider))
+	);
+
 	function formatSince(value?: string | number | null): string {
 		if (value === null || value === undefined || value === '') return '';
 		// Backend emits epoch SECONDS as a number; an ISO string is also accepted.
@@ -137,13 +153,13 @@
 
 		{#if loading && runtime.length === 0}
 			<p class="text-sm text-[#666]">Loading provider health…</p>
-		{:else if runtime.length === 0}
+		{:else if displayRuntime.length === 0}
 			<p class="text-sm text-[#666]">
 				No runtime health reported. Providers report state here once they're exercised by agent/Brain calls.
 			</p>
 		{:else}
 			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-				{#each runtime as r (r.provider)}
+				{#each displayRuntime as r (r.provider)}
 					<div class="border p-4 space-y-2 {stateColor(r.state)}">
 						<div class="flex items-center justify-between gap-2">
 							<span class="font-mono text-sm text-white uppercase">{r.provider}</span>

--- a/frontend/src/routes/agents/components/tabs/ProvidersTab.svelte
+++ b/frontend/src/routes/agents/components/tabs/ProvidersTab.svelte
@@ -63,7 +63,8 @@
 	 * key" link beside the token input so connecting a new provider is self-serve.
 	 */
 	const PROVIDER_SIGNUP_URLS: Record<string, string> = {
-		'opencode-zen': 'https://opencode.ai/auth'
+		'opencode-zen': 'https://opencode.ai/auth',
+		'nvidia': 'https://build.nvidia.com/explore/discover'
 	};
 
 	async function reload() {

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -1,8 +1,34 @@
 import adapterAuto from '@sveltejs/adapter-auto';
 import adapterStatic from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
 
 const usePackaged = process.env.FORVEN_PACKAGE_BUILD === '1';
+
+// Read parent .env so CSP connect-src includes the public host/port.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const _parentEnv = {};
+try {
+	const raw = readFileSync(resolve(__dirname, '../.env'), 'utf-8');
+	for (const line of raw.split('\n')) {
+		const t = line.trim();
+		if (!t || t.startsWith('#')) continue;
+		const i = t.indexOf('=');
+		if (i === -1) continue;
+		let v = t.slice(i + 1).trim();
+		if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) v = v.slice(1, -1);
+		_parentEnv[t.slice(0, i).trim()] = v;
+	}
+} catch { /* .env may not exist */ }
+
+// Parse allowed hosts for CSP connect-src
+const allowedHosts = (_parentEnv.FORVEN_ALLOWED_HOSTS || '').split(',').map(h => h.trim()).filter(Boolean);
+const connectExtra = allowedHosts.flatMap(host => [
+	`http://${host}:*`,
+	`ws://${host}:*`,
+]);
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -22,6 +48,8 @@ const config = {
 		// script-src 'self' (SvelteKit hashes its own bootstrap) blocks injected
 		// inline/remote scripts; styles stay unsafe-inline so charts/Tailwind keep
 		// working; connect-src is scoped to the local API + the Binance market WS.
+		// Allowed hosts are injected from FORVEN_ALLOWED_HOSTS in parent .env
+		// so the frontend works from any public IP / domain without CSP errors.
 		csp: {
 			mode: 'hash',
 			directives: {
@@ -36,7 +64,8 @@ const config = {
 					'http://127.0.0.1:*',
 					'ws://localhost:*',
 					'ws://127.0.0.1:*',
-					'wss://stream.binance.com:9443'
+					'wss://stream.binance.com:9443',
+					...connectExtra,
 				],
 				'object-src': ['none'],
 				'base-uri': ['self'],

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,14 +1,33 @@
 import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig } from 'vitest/config';
+import { defineConfig } from 'vite';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
 
-const backendOrigin =
-	process.env.FORVEN_CLIENT_BASE ||
-	process.env.FORVEN_API_ORIGIN ||
-	`http://127.0.0.1:${process.env.FORVEN_PORT ?? '8003'}`;
 const isVitest = process.env.VITEST === 'true';
+
+// Read parent .env manually (Vite's envDir only feeds import.meta.env, not
+// config-level process.env).
+const _parentEnv: Record<string, string> = {};
+try {
+	const raw = readFileSync(resolve(process.cwd(), '../.env'), 'utf-8');
+	for (const line of raw.split('\n')) {
+		const t = line.trim();
+		if (!t || t.startsWith('#')) continue;
+		const i = t.indexOf('=');
+		if (i === -1) continue;
+		let v = t.slice(i + 1).trim();
+		if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) v = v.slice(1, -1);
+		_parentEnv[t.slice(0, i).trim()] = v;
+	}
+} catch { /* .env may not exist in CI/test */ }
+const backendOrigin =
+	_parentEnv.FORVEN_CLIENT_BASE ||
+	_parentEnv.FORVEN_API_ORIGIN ||
+	`http://127.0.0.1:${_parentEnv.FORVEN_PORT ?? '8003'}`;
 
 export default defineConfig({
 	plugins: [sveltekit()],
+	envDir: '..',
 	// Pre-bundle deps that are only imported lazily (e.g. `marked` in AIChatPanel)
 	// so Vite doesn't discover them MID-PAGE-LOAD and trigger a re-optimization —
 	// that changes chunk hashes and 404s the already-loaded tab (the blank-white
@@ -44,6 +63,13 @@ export default defineConfig({
 		}
 	},
 	server: {
+		// Allow access via reverse proxy domains (fv.fusemob.com, api.fv.fusemob.com)
+		// plus any entries from FORVEN_ALLOWED_HOSTS.
+		allowedHosts: [
+			'fv.fusemob.com',
+			'api.fv.fusemob.com',
+			...(_parentEnv.FORVEN_ALLOWED_HOSTS || '').split(',').map(h => h.trim()).filter(Boolean),
+		],
 		proxy: {
 			'/api': {
 				target: backendOrigin,

--- a/packaging/forven-backend.service
+++ b/packaging/forven-backend.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Forven Backend (FastAPI/uvicorn)
+After=network.target
+StartLimitIntervalSec=60
+StartLimitBurst=3
+
+[Service]
+Type=simple
+User=hms
+Group=hms
+WorkingDirectory=/home/hms/forven
+EnvironmentFile=/home/hms/forven/.env
+ExecStart=/home/hms/forven/.venv/bin/python3.11 -m uvicorn forven.api:app --host 127.0.0.1 --port 8004
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/forven-frontend.service
+++ b/packaging/forven-frontend.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Forven Frontend (SvelteKit/Vite)
+After=network.target
+StartLimitIntervalSec=60
+StartLimitBurst=3
+
+[Service]
+Type=simple
+User=hms
+Group=hms
+WorkingDirectory=/home/hms/forven/frontend
+EnvironmentFile=/home/hms/forven/.env
+ExecStart=/home/hms/.local/share/pi-node/node-v22.22.3-linux-x64/bin/npm run dev -- --host :: --port 5173
+Restart=on-failure
+RestartSec=10
+# Ensure npm/node are in PATH
+Environment=PATH=/home/hms/.local/share/pi-node/node-v22.22.3-linux-x64/bin:/usr/local/bin:/usr/bin:/bin
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/approve_hyperliquid_agent.py
+++ b/scripts/approve_hyperliquid_agent.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""One-shot: approve an existing Hyperliquid agent wallet to trade on behalf
+of the main wallet. Must be signed by the MAIN wallet (the one holding funds).
+
+Usage:
+    # Set the main wallet's private key, then run:
+    export FORVEN_HL_MASTER_SECRET="0x..."
+    python scripts/approve_hyperliquid_agent.py
+
+Config is read from Forven's KV store (the same settings the app uses).
+"""
+
+import json
+import os
+import sys
+
+# Make forven importable from the repo root
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from forven.db import kv_get
+from forven.config import load_config
+
+from eth_account import Account
+from hyperliquid.exchange import Exchange, sign_agent
+from hyperliquid.utils import constants
+
+# ---- Load settings -----------------------------------------------------------
+load_config()
+settings = kv_get("forven:settings", {}) or {}
+testnet = bool(settings.get("hyperliquid_testnet", True))
+base_url = constants.TESTNET_API_URL if testnet else constants.MAINNET_API_URL
+main_wallet = str(settings.get("hyperliquid_wallet", "") or "").strip()
+agent_wallet = str(settings.get("hyperliquid_api_address", "") or "").strip()
+network = "testnet" if testnet else "mainnet"
+
+print(f"=== Hyperliquid Agent Approval ({network}) ===")
+print(f"Main wallet:  {main_wallet}")
+print(f"Agent to approve: {agent_wallet}")
+
+if not main_wallet or not agent_wallet:
+    print("ERROR: main wallet or agent wallet not configured in Settings.")
+    sys.exit(1)
+
+# ---- Main wallet private key (NOT the API key!) ------------------------------
+master_secret = os.environ.get("FORVEN_HL_MASTER_SECRET", "") or os.environ.get("HL_MASTER_SECRET", "")
+if not master_secret:
+    print()
+    print("ERROR: FORVEN_HL_MASTER_SECRET env var not set.")
+    print("This must be the PRIVATE KEY of the MAIN wallet (0x3F8e...),")
+    print("NOT the API agent key you use for daily order signing.")
+    print()
+    print("  export FORVEN_HL_MASTER_SECRET=\"0x...\"")
+    sys.exit(1)
+
+master_secret = master_secret.strip()
+if not master_secret.startswith("0x"):
+    master_secret = "0x" + master_secret
+
+# ---- Verify the derived address matches --------------------------------------
+try:
+    master_account = Account.from_key(master_secret)
+except Exception as e:
+    print(f"ERROR: Invalid private key: {e}")
+    sys.exit(1)
+
+derived = master_account.address
+if derived.lower() != main_wallet.lower():
+    print(f"WARNING: The private key you provided derives to {derived}")
+    print(f"         but the configured main wallet is {main_wallet}")
+    resp = input("Continue anyway? [y/N]: ").strip().lower()
+    if resp != "y":
+        sys.exit(1)
+    print()
+
+# ---- Build the Exchange with the MAIN wallet ---------------------------------
+exchange = Exchange(
+    wallet=master_account,
+    base_url=base_url,
+)
+
+# ---- Approve the EXISTING agent ----------------------------------------------
+# We use sign_agent directly to APPROVE AN EXISTING agent address, rather
+# than Exchange.approve_agent() which generates a random new key.
+import time
+
+timestamp = int(time.time() * 1000)
+action = {
+    "type": "approveAgent",
+    "agentAddress": agent_wallet,
+    "agentName": "Forven",
+    "nonce": timestamp,
+}
+sig = sign_agent(master_account, action, is_mainnet=not testnet)
+result = exchange._post_action(action, sig, timestamp)
+
+print()
+print("Approval result:", result)
+print()
+print("✓ Agent approved! New live trades should now execute successfully.")
+print("  Wait for the next daemon scan cycle (~1 min) and check all-trades.")

--- a/start_backend.sh
+++ b/start_backend.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Start Forven backend with .env vars
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$DIR"
+
+# Load .env
+if [[ -f "$DIR/.env" ]]; then
+	set -a
+	source "$DIR/.env"
+	set +a
+fi
+
+PORT="${FORVEN_PORT:-8004}"
+HOST="${FORVEN_BIND_HOST:-0.0.0.0}"
+
+exec .venv/bin/python3.11 -m uvicorn forven.api:app --host "$HOST" --port "$PORT"


### PR DESCRIPTION
## Problem

When the exchange holds one position but SQLite has two or more OPEN trades for the same asset+direction — typically after a paper→live strategy upgrade leaves a stale paper trade alongside the live one — the reconcile logs a `duplicate_sqlite_trades` discrepancy and sets `matched_open_trade = None`. The extra trade is never closed, the discrepancy never clears, and `recovery_active` stays `true` indefinitely, blocking all new entries.

## Root Cause

The ghost-detection logic is asset-level: "is this asset present on the exchange?" If yes, zero ghost-closes are attempted even when the count or sizing is mismatched. The `duplicate_sqlite_trades` branch only reports — it never resolves.

## Fix

When `len(local_trades) > 1` for an exchange position, score each SQLite trade by direction match + size difference. The best match becomes `matched_open_trade` (so protection repair runs against the real trade). All non-matching trades are appended to `ghost_trades`, which the existing ghost-close loop already handles (fill recovery, `close_trade_record`, order cancellation, resolved action logging).

## Testing

Triggered manually via `/api/system/exchange/reconcile`:
- Stale paper ghost (81.38 SOL) → ghost-closed
- Recovery state: `active=false`, `status="resolved"`, `discrepancies=0`
- Trading allowed again