### PR TITLE
Data Manager: lake-scan performance, Kraken deep history, maintenance-tab overhaul

### DIFF
--- a/forven/agents/tools_core.py
+++ b/forven/agents/tools_core.py
@@ -464,7 +464,7 @@ def _tool_fetch_exchange_data(params: dict) -> str:
             exchange_id=exchange,
             limit=bars,
         )
-        return json.dumps({
+        payload = {
             "status": "success",
             "symbol": result.get("symbol", symbol),
             "timeframe": result.get("timeframe", timeframe),
@@ -473,7 +473,12 @@ def _tool_fetch_exchange_data(params: dict) -> str:
             "bars_fetched": result.get("bars_fetched", 0),
             "bars_new": result.get("bars_new", 0),
             "date_range": f"{result.get('start_ts', '?')} to {result.get('end_ts', '?')}",
-        }, indent=2)
+        }
+        if result.get("warning"):
+            # e.g. Kraken only serves the most-recent ~720 candles — tell the
+            # agent so it doesn't assume it got full history.
+            payload["warning"] = result.get("warning")
+        return json.dumps(payload, indent=2)
     except RuntimeError as e:
         if "ccxt is not installed" in str(e):
             return "Error: ccxt library is not installed. Install with: pip install ccxt"

--- a/forven/data.py
+++ b/forven/data.py
@@ -1632,6 +1632,123 @@ def _venue_ohlcv_max_bars(exchange_id: str) -> int | None:
     return _VENUE_OHLCV_MAX_BARS.get(str(exchange_id or "").strip().lower())
 
 
+# Capped venues that ALSO expose a full-history public Trades feed we can
+# aggregate into candles, bypassing the OHLC per-request cap. Kraken's Trades
+# endpoint pages forward through the entire history from `since` (unlike its
+# 720-capped OHLC endpoint), so trade reconstruction is the only way to backfill
+# deep Kraken history.
+_VENUE_TRADES_OHLCV: set[str] = {"kraken"}
+TRADES_PAGE_LIMIT = 1000
+_TRADES_CHECKPOINT_PAGES = 100  # flush finalized bars every ~100k trades
+
+
+def _venue_builds_ohlcv_from_trades(exchange_id: str) -> bool:
+    return str(exchange_id or "").strip().lower() in _VENUE_TRADES_OHLCV
+
+
+def _fetch_trades_once(exchange, symbol: str, since: int | None, limit: int) -> list[dict[str, Any]]:
+    retryable = _retryable_ccxt_errors()
+    last_exc: Exception | None = None
+    for attempt in range(5):
+        try:
+            return exchange.fetch_trades(symbol, since=since, limit=limit)
+        except retryable as exc:  # type: ignore[misc]
+            last_exc = exc
+            time.sleep(min(60, 2 ** attempt))
+        except Exception as exc:
+            last_exc = exc
+            break
+    if last_exc:
+        raise last_exc
+    return []
+
+
+def _bars_dict_to_frame(bars: dict[int, list[float]]) -> pd.DataFrame:
+    if not bars:
+        return _normalize_ohlcv_frame(pd.DataFrame())
+    rows = [
+        {
+            "timestamp": pd.to_datetime(open_ms, unit="ms", utc=True),
+            "open": o, "high": h, "low": l, "close": c, "volume": v,
+        }
+        for open_ms, (o, h, l, c, v) in sorted(bars.items())
+    ]
+    return _normalize_ohlcv_frame(pd.DataFrame(rows))
+
+
+def _build_ohlcv_from_trades(
+    exchange,
+    ccxt_symbol: str,
+    timeframe: str,
+    start_ms: int,
+    end_ms: int,
+    progress_callback=None,
+    checkpoint=None,
+) -> pd.DataFrame:
+    """Reconstruct OHLCV bars from a venue's paginated public Trades feed.
+
+    Kraken's Trades endpoint pages forward through the FULL history from `since`
+    (unlike its 720-capped OHLC endpoint), so aggregating trades into candles is
+    the only way to backfill deep Kraken history. Trades arrive in time order, so
+    aggregation streams into per-bucket accumulators; when a ``checkpoint`` is
+    given, buckets before the currently-forming bar are finalized, flushed to it,
+    and dropped — bounding memory and persisting progress on a multi-hour build.
+    """
+    tf_ms = _timeframe_to_ms(timeframe)
+    cursor = max(0, int(start_ms))
+    bound = int(end_ms)
+    bars: dict[int, list[float]] = {}
+    pages = 0
+
+    while cursor <= bound:
+        batch = _fetch_trades_once(exchange, ccxt_symbol, cursor, TRADES_PAGE_LIMIT)
+        if not batch:
+            break
+        for trade in batch:
+            ts = int(trade.get("timestamp") or 0)
+            if ts <= 0 or ts > bound:
+                continue
+            price = trade.get("price")
+            if price is None:
+                continue
+            price = float(price)
+            amount = float(trade.get("amount") or 0.0)
+            bucket = (ts // tf_ms) * tf_ms
+            acc = bars.get(bucket)
+            if acc is None:
+                bars[bucket] = [price, price, price, price, amount]
+            else:
+                if price > acc[1]:
+                    acc[1] = price
+                if price < acc[2]:
+                    acc[2] = price
+                acc[3] = price
+                acc[4] += amount
+
+        last_ts = int(batch[-1].get("timestamp") or cursor)
+        pages += 1
+        if progress_callback is not None:
+            progress_callback(min(last_ts, bound), bound, len(batch))
+
+        if checkpoint is not None and pages % _TRADES_CHECKPOINT_PAGES == 0:
+            forming = (last_ts // tf_ms) * tf_ms
+            done = {k: v for k, v in bars.items() if k < forming}
+            if done:
+                checkpoint(_bars_dict_to_frame(done))
+                for k in done:
+                    bars.pop(k, None)
+
+        if len(batch) < TRADES_PAGE_LIMIT:
+            break  # partial page => reached the tail of available trades
+        # Trades are returned with ts >= cursor, so last_ts+1 always advances.
+        cursor = last_ts + 1
+        rate_limit = float(getattr(exchange, "rateLimit", 0) or 0)
+        if rate_limit > 0:
+            time.sleep(rate_limit / 1000.0)
+
+    return _bars_dict_to_frame(bars)
+
+
 _ingestion_runs = {}
 _ingestion_runs_lock = threading.Lock()
 
@@ -1768,43 +1885,90 @@ def fetch_ohlcv_chunked(
     # "all available" checkbox and a default/large bar-count are not shortfalls.
     capped_note: str | None = None
     venue_cap = _venue_ohlcv_max_bars(exchange_id)
-    if venue_cap is not None:
+    trades_venue = _venue_builds_ohlcv_from_trades(exchange_id)
+
+    # Trades-venues (Kraken) get FULL history: a deep request is served by
+    # reconstructing candles from the uncapped Trades feed instead of the
+    # 720-capped OHLC endpoint. "Deep" = all_available, an explicit start older
+    # than the OHLC window, or a bar-count beyond the cap. Recent/small requests
+    # still take the fast OHLC path (much cheaper than replaying trades).
+    use_trades = False
+    if trades_venue and venue_cap is not None:
+        reachable_start = now_ms - venue_cap * tf_ms
+        if all_available:
+            use_trades = True
+        elif since_ms is not None and int(since_ms) < reachable_start:
+            use_trades = True
+        elif since_ms is None and limit is not None and int(limit) > venue_cap:
+            use_trades = True
+
+    if venue_cap is not None and not trades_venue:
+        # Capped venue with NO trades fallback: collapse an unservable request to
+        # the recent window (never send the since=0 that 400s) and MERGE, warning
+        # only when the user explicitly picked a start older than the window.
         reachable_start = now_ms - venue_cap * tf_ms
         explicit_since_too_old = (
             not all_available
             and since_ms is not None
             and int(since_ms) < reachable_start
         )
-        # The bar-count `limit` only governs the fetch when neither all_available
-        # nor since_ms is set (that's the branch that reads it) — and only there
-        # can a huge limit on a long timeframe synthesize the crashing since=0.
-        # Guarding on it while since_ms is present would wrongly null a valid
-        # in-window date (limit defaults to 1000 > cap).
         limit_branch_overshoots = (
             not all_available
             and since_ms is None
             and limit is not None
             and int(limit) > venue_cap
         )
-        reaches_back = all_available or explicit_since_too_old or limit_branch_overshoots
-        if reaches_back:
+        if all_available or explicit_since_too_old or limit_branch_overshoots:
             if explicit_since_too_old:
                 capped_note = (
                     f"{exchange_id}'s history API returns at most ~{venue_cap} "
                     f"{timeframe} candles per request, so the earlier part of the "
                     f"requested range wasn't available — the most recent window was "
-                    f"downloaded and merged. Use Binance, OKX or Bybit for deeper history."
+                    f"downloaded and merged."
                 )
-            # Collapse to the recent window Kraken accepts (since=None → its latest
-            # bars), routed through the limit branch (not the since/append
-            # fast-path) so the fetched window MERGES with — never replaces — the
-            # already-accumulated dataset.
             all_available = False
             since_ms = None
             limit = venue_cap
 
+    def _trades_checkpoint(partial: pd.DataFrame) -> None:
+        # Persist finalized bars mid-build so a long full-history run is durable
+        # and its progress is visible in the lake. Runs before the final merge
+        # below acquires the same lock (sequential, no nesting).
+        if partial is None or partial.empty:
+            return
+        cp_lock = _get_dataset_lock(fs_symbol, timeframe)
+        with cp_lock:
+            try:
+                cp_current = load_parquet(fs_symbol, timeframe)
+            except Exception:
+                cp_current = None
+            cp_merged = _drop_unclosed_bars(merge_and_dedup(cp_current, partial), tf_ms, now_ms)
+            if not cp_merged.empty:
+                save_parquet(cp_merged, fs_symbol, timeframe, source=exchange_id)
+
+    def _trades_window(start: int, end: int) -> pd.DataFrame:
+        return _build_ohlcv_from_trades(
+            exchange, ccxt_symbol, timeframe, start, end,
+            progress_callback=progress_callback, checkpoint=_trades_checkpoint,
+        )
+
     try:
-        if all_available:
+        if use_trades:
+            if all_available and snapshot is not None and not snapshot.empty:
+                # Fill only the gaps around what's already accumulated.
+                earliest = _to_ms(snapshot["timestamp"].iloc[0])
+                latest = _to_ms(snapshot["timestamp"].iloc[-1])
+                if latest + tf_ms <= end_ms_to_use:
+                    fetched_blocks.append(_trades_window(latest + tf_ms, end_ms_to_use))
+                if earliest - tf_ms > 0:
+                    fetched_blocks.append(_trades_window(0, earliest - tf_ms))
+            elif all_available:
+                fetched_blocks.append(_trades_window(0, end_ms_to_use))
+            elif since_ms is not None:
+                fetched_blocks.append(_trades_window(int(since_ms), end_ms_to_use))
+            else:  # bar-count beyond the cap
+                fetched_blocks.append(_trades_window(now_ms - int(limit) * tf_ms, end_ms_to_use))
+        elif all_available:
             if snapshot is not None and not snapshot.empty:
                 earliest = _to_ms(snapshot["timestamp"].iloc[0])
                 latest = _to_ms(snapshot["timestamp"].iloc[-1])
@@ -1846,7 +2010,10 @@ def fetch_ohlcv_chunked(
         # the full merge path on first-time fetch, overlap (possible
         # restatement — the revision log must see the prior values), or any
         # bounds problem.
-        if since_ms is not None and fetched.empty and (
+        # A trades-built deep backfill spans old→now and MUST take the full merge
+        # path — the tail-append fast-path below would keep only strictly-newer
+        # bars and silently drop everything it backfilled.
+        if since_ms is not None and not use_trades and fetched.empty and (
             parquet_path(fs_symbol, timeframe).exists() or tail_path(fs_symbol, timeframe).exists()
         ):
             # Incremental fetch found nothing new: do NOT pay a full
@@ -1856,7 +2023,7 @@ def fetch_ohlcv_chunked(
             record["bars_new"] = 0
             return record
 
-        if since_ms is not None and not fetched.empty:
+        if since_ms is not None and not use_trades and not fetched.empty:
             appended = _append_bars_locked(fs_symbol, timeframe, fetched, source=exchange_id)
             if appended is not None:
                 record = _footer_dataset_record(fs_symbol, timeframe, exchange_id)
@@ -2509,6 +2676,77 @@ def _decode_csv_content(content: bytes) -> str:
     return content.decode("utf-8", errors="ignore")
 
 
+def _cell_is_numeric(value: Any) -> bool:
+    text = str(value).strip().replace(",", "")
+    if not text:
+        return False
+    try:
+        float(text)
+        return True
+    except ValueError:
+        return False
+
+
+# Positional layouts for headerless exchange dumps (no column names). Keyed by
+# column count. Kraken's downloadable OHLCVT export is the 7-column shape
+# (timestamp, O, H, L, C, volume, trades); some variants insert a vwap column
+# (8). Only the OHLCV columns are consumed downstream; extras are ignored.
+_HEADERLESS_OHLCV_LAYOUTS: dict[int, list[str]] = {
+    6: ["timestamp", "open", "high", "low", "close", "volume"],
+    7: ["timestamp", "open", "high", "low", "close", "volume", "trades"],
+    8: ["timestamp", "open", "high", "low", "close", "vwap", "volume", "trades"],
+}
+
+
+def _read_uploaded_csv(text: str) -> pd.DataFrame:
+    """Parse an uploaded CSV, transparently handling headerless exchange dumps.
+
+    A file whose first row is entirely numeric (e.g. Kraken's OHLCVT export) has
+    no header — pandas would otherwise consume that first data row as column
+    names. We detect that and re-read positionally, assigning canonical OHLCV
+    names by column count so the normal mapping/parse path just works.
+    """
+    frame = pd.read_csv(io.StringIO(text))
+    frame.columns = [str(c).strip() for c in frame.columns]
+    if frame.columns.size and all(_cell_is_numeric(c) for c in frame.columns):
+        frame = pd.read_csv(io.StringIO(text), header=None)
+        ncols = int(frame.shape[1])
+        layout = _HEADERLESS_OHLCV_LAYOUTS.get(ncols)
+        if layout is None:
+            raise ValueError(
+                f"CSV has no header row and an unrecognized {ncols}-column layout. "
+                f"Add a header line such as 'timestamp,open,high,low,close,volume'."
+            )
+        frame.columns = layout
+    return frame
+
+
+def _parse_timestamp_series(series: pd.Series, date_format: str | None = None) -> pd.Series:
+    """Timestamps → tz-aware UTC, auto-detecting epoch (s/ms/us/ns) columns.
+
+    Exchange dumps ship raw epoch integers (Kraken uses seconds); parsing those
+    as datetime strings silently yields 1970. When an explicit ``date_format`` is
+    given we honour it; otherwise a mostly-numeric column is treated as epoch and
+    the unit is inferred from magnitude, and anything else is parsed as a datetime
+    string.
+    """
+    if date_format:
+        return pd.to_datetime(series, format=date_format, utc=True, errors="coerce")
+    numeric = pd.to_numeric(series, errors="coerce")
+    if len(numeric) and numeric.notna().mean() >= 0.9:
+        magnitude = float(numeric.dropna().abs().median() or 0.0)
+        if magnitude >= 1e17:
+            unit = "ns"
+        elif magnitude >= 1e14:
+            unit = "us"
+        elif magnitude >= 1e11:
+            unit = "ms"
+        else:
+            unit = "s"
+        return pd.to_datetime(numeric, unit=unit, utc=True, errors="coerce")
+    return pd.to_datetime(series, utc=True, errors="coerce")
+
+
 def _suggest_csv_mapping(columns: list[str]) -> tuple[str | None, dict[str, str], dict[str, bool]]:
     lower_map = {c.lower(): c for c in columns}
     timestamp_candidates = ["timestamp", "time", "datetime", "date", "ts"]
@@ -2531,7 +2769,7 @@ def _suggest_csv_mapping(columns: list[str]) -> tuple[str | None, dict[str, str]
 
 def preview_csv(content: bytes) -> dict[str, Any]:
     text = _decode_csv_content(content)
-    frame = pd.read_csv(io.StringIO(text))
+    frame = _read_uploaded_csv(text)
     columns = [str(c) for c in list(frame.columns)]
     ts_col, mapping, required = _suggest_csv_mapping(columns)
     sample = frame.head(5).where(pd.notnull(frame.head(5)), None).to_dict("records")
@@ -2554,8 +2792,7 @@ def process_csv_upload(
     date_format: str | None = None,
 ) -> dict[str, Any]:
     text = _decode_csv_content(content)
-    frame = pd.read_csv(io.StringIO(text))
-    frame.columns = [str(c).strip() for c in frame.columns]
+    frame = _read_uploaded_csv(text)
 
     inferred_ts, mapping, required = _suggest_csv_mapping(list(frame.columns))
     timestamp_column = ts_col or inferred_ts
@@ -2566,12 +2803,7 @@ def process_csv_upload(
         raise ValueError(f"CSV missing required OHLCV columns: {', '.join(missing)}")
 
     ohlcv = pd.DataFrame()
-    ohlcv["timestamp"] = pd.to_datetime(
-        frame[timestamp_column],
-        format=(date_format or None),
-        utc=True,
-        errors="coerce",
-    )
+    ohlcv["timestamp"] = _parse_timestamp_series(frame[timestamp_column], date_format)
     for col in ("open", "high", "low", "close", "volume"):
         ohlcv[col] = pd.to_numeric(frame[mapping[col]], errors="coerce")
     ohlcv = _normalize_ohlcv_frame(ohlcv)

--- a/forven/data.py
+++ b/forven/data.py
@@ -1752,32 +1752,53 @@ def fetch_ohlcv_chunked(
 
     end_ms_to_use = until_ms if until_ms is not None else (now_ms + tf_ms)
 
-    # Kraken-class venues can only serve the most-recent N candles and error on
-    # an out-of-window `since` (that's the EGeneral:Invalid arguments the user
-    # sees on an "all available" download). When the request reaches past that
-    # window, rewrite it to the single recent window the venue CAN return and
-    # remember we clamped, so the caller is told the span is capped instead of
-    # silently believing it got full history.
+    # Kraken's REST OHLC endpoint returns at most ~N candles per request as the
+    # window [since, now], and — the actual crash — rejects `since=0`/tiny values
+    # with EGeneral:Invalid arguments (an input-validation quirk, NOT a "too far
+    # back" limit: a valid old timestamp returns the recent window fine). Since
+    # every request ends at now, deeper history than ~N bars back can't be paged
+    # in one shot; larger local datasets are built by ACCUMULATION (each fetch
+    # merges its recent window into the lake, so repeated/keep-alive downloads
+    # grow it forward over time — which is why >N bars can already exist on disk).
+    #
+    # So: never send the since=0 that crashes, collapse an unservable request to
+    # the recent window the venue CAN return, and MERGE (never truncate — the
+    # merge below preserves everything already accumulated). Warn only when the
+    # user EXPLICITLY picked a start date older than the reachable window; an
+    # "all available" checkbox and a default/large bar-count are not shortfalls.
     capped_note: str | None = None
     venue_cap = _venue_ohlcv_max_bars(exchange_id)
     if venue_cap is not None:
         reachable_start = now_ms - venue_cap * tf_ms
-        wanted_start: int | None = None
-        if all_available:
-            wanted_start = 0
-        elif since_ms is not None:
-            wanted_start = int(since_ms)
-        elif limit is not None and int(limit) > venue_cap:
-            wanted_start = _estimate_limit_window_start(int(limit), timeframe)
-        if wanted_start is not None and wanted_start < reachable_start:
-            capped_note = (
-                f"{exchange_id} serves only the most recent ~{venue_cap} {timeframe} "
-                f"candles; older history is unavailable from this venue. Use Binance, "
-                f"OKX or Bybit for a full backfill."
-            )
-            # Collapse to the recent window Kraken accepts: since=None makes it
-            # return its latest bars, and routing through the limit branch (not
-            # the since/append fast-path) merges them into the lake correctly.
+        explicit_since_too_old = (
+            not all_available
+            and since_ms is not None
+            and int(since_ms) < reachable_start
+        )
+        # The bar-count `limit` only governs the fetch when neither all_available
+        # nor since_ms is set (that's the branch that reads it) — and only there
+        # can a huge limit on a long timeframe synthesize the crashing since=0.
+        # Guarding on it while since_ms is present would wrongly null a valid
+        # in-window date (limit defaults to 1000 > cap).
+        limit_branch_overshoots = (
+            not all_available
+            and since_ms is None
+            and limit is not None
+            and int(limit) > venue_cap
+        )
+        reaches_back = all_available or explicit_since_too_old or limit_branch_overshoots
+        if reaches_back:
+            if explicit_since_too_old:
+                capped_note = (
+                    f"{exchange_id}'s history API returns at most ~{venue_cap} "
+                    f"{timeframe} candles per request, so the earlier part of the "
+                    f"requested range wasn't available — the most recent window was "
+                    f"downloaded and merged. Use Binance, OKX or Bybit for deeper history."
+                )
+            # Collapse to the recent window Kraken accepts (since=None → its latest
+            # bars), routed through the limit branch (not the since/append
+            # fast-path) so the fetched window MERGES with — never replaces — the
+            # already-accumulated dataset.
             all_available = False
             since_ms = None
             limit = venue_cap

--- a/forven/data.py
+++ b/forven/data.py
@@ -1749,6 +1749,36 @@ def _build_ohlcv_from_trades(
     return _bars_dict_to_frame(bars)
 
 
+def _forward_fill_ohlcv(frame: pd.DataFrame, tf_ms: int) -> pd.DataFrame:
+    """Fill no-trade gaps with flat bars (O=H=L=C = prior close, volume 0).
+
+    Candles reconstructed from a trades feed only exist for buckets that had
+    trades, so thin/early history is riddled with holes that fail the gauntlet's
+    gap gate. Exchange OHLC endpoints instead forward-fill empty periods with a
+    flat bar; this makes a trade-built series follow that same convention
+    (continuous, gap-free) — and heals an already-stored gappy series on merge.
+    """
+    if frame is None or frame.empty or len(frame) < 2:
+        return frame
+    frame = _normalize_ohlcv_frame(frame)
+    start = _to_ms(frame["timestamp"].iloc[0])
+    end = _to_ms(frame["timestamp"].iloc[-1])
+    expected = (end - start) // tf_ms + 1
+    if expected <= len(frame):
+        return frame  # already continuous — nothing to fill
+    full = pd.DatetimeIndex(
+        pd.to_datetime(range(start, end + tf_ms, tf_ms), unit="ms", utc=True),
+        name="timestamp",
+    )
+    filled = frame.set_index("timestamp").reindex(full)
+    was_missing = filled["open"].isna()
+    ff_close = filled["close"].ffill()
+    for col in ("open", "high", "low", "close"):
+        filled.loc[was_missing, col] = ff_close[was_missing]
+    filled.loc[was_missing, "volume"] = 0.0
+    return _normalize_ohlcv_frame(filled.reset_index())
+
+
 _ingestion_runs = {}
 _ingestion_runs_lock = threading.Lock()
 
@@ -2037,6 +2067,12 @@ def fetch_ohlcv_chunked(
             log.debug("Ignoring unreadable OHLCV snapshot for %s %s while merging remote fetch: %s", fs_symbol, timeframe, exc)
             current = None
         merged = merge_and_dedup(current, fetched)
+        # Trade-reconstructed candles skip no-trade buckets; forward-fill them to
+        # a continuous series (exchange-OHLC convention) so thin history doesn't
+        # fail the gap gate. Applied to the whole merged series, so re-running
+        # "all available" also heals an already-stored gappy trade-built dataset.
+        if use_trades:
+            merged = _forward_fill_ohlcv(merged, tf_ms)
         # Never persist the in-progress bar: a fetch reaches now+tf, so the last
         # row is typically the forming candle. Drop any unclosed bar (and clean a
         # previously-persisted one) before writing the lake.

--- a/forven/data.py
+++ b/forven/data.py
@@ -1619,6 +1619,19 @@ def _estimate_limit_window_start(limit: int, timeframe: str) -> int:
     return max(0, now_ms - int(bars * tf_ms * 1.2))
 
 
+# Venues whose public OHLC endpoint only ever serves the most-recent N candles.
+# Kraken returns at most ~720 of the LATEST bars regardless of `since`, and — the
+# part that actually crashes downloads — rejects any `since` older than that
+# window outright with {"error":["EGeneral:Invalid arguments"]}. Every other
+# venue pages backward from since=0, so this map is deliberately sparse: absence
+# means "no cap, normal deep-history paging".
+_VENUE_OHLCV_MAX_BARS: dict[str, int] = {"kraken": 720}
+
+
+def _venue_ohlcv_max_bars(exchange_id: str) -> int | None:
+    return _VENUE_OHLCV_MAX_BARS.get(str(exchange_id or "").strip().lower())
+
+
 _ingestion_runs = {}
 _ingestion_runs_lock = threading.Lock()
 
@@ -1739,6 +1752,36 @@ def fetch_ohlcv_chunked(
 
     end_ms_to_use = until_ms if until_ms is not None else (now_ms + tf_ms)
 
+    # Kraken-class venues can only serve the most-recent N candles and error on
+    # an out-of-window `since` (that's the EGeneral:Invalid arguments the user
+    # sees on an "all available" download). When the request reaches past that
+    # window, rewrite it to the single recent window the venue CAN return and
+    # remember we clamped, so the caller is told the span is capped instead of
+    # silently believing it got full history.
+    capped_note: str | None = None
+    venue_cap = _venue_ohlcv_max_bars(exchange_id)
+    if venue_cap is not None:
+        reachable_start = now_ms - venue_cap * tf_ms
+        wanted_start: int | None = None
+        if all_available:
+            wanted_start = 0
+        elif since_ms is not None:
+            wanted_start = int(since_ms)
+        elif limit is not None and int(limit) > venue_cap:
+            wanted_start = _estimate_limit_window_start(int(limit), timeframe)
+        if wanted_start is not None and wanted_start < reachable_start:
+            capped_note = (
+                f"{exchange_id} serves only the most recent ~{venue_cap} {timeframe} "
+                f"candles; older history is unavailable from this venue. Use Binance, "
+                f"OKX or Bybit for a full backfill."
+            )
+            # Collapse to the recent window Kraken accepts: since=None makes it
+            # return its latest bars, and routing through the limit branch (not
+            # the since/append fast-path) merges them into the lake correctly.
+            all_available = False
+            since_ms = None
+            limit = venue_cap
+
     try:
         if all_available:
             if snapshot is not None and not snapshot.empty:
@@ -1817,6 +1860,9 @@ def fetch_ohlcv_chunked(
     base = _build_dataset_record(fs_symbol, timeframe, exchange_id, merged)
     base["bars_fetched"] = int(len(fetched))
     base["bars_new"] = int(max(0, len(merged) - (len(current) if current is not None else 0)))
+    if capped_note is not None:
+        base["capped"] = True
+        base["warning"] = capped_note
     return base
 
 # Ingestion runs survive a backend restart via a compact KV snapshot: runs
@@ -1958,6 +2004,12 @@ def submit_ingestion(
                 _ingestion_runs[run_id]["status"] = "completed"
                 _ingestion_runs[run_id]["bars_fetched"] = res.get("bars_fetched", 0)
                 _ingestion_runs[run_id]["bars_new"] = res.get("bars_new", 0)
+                # Carry a venue-cap warning (e.g. Kraken's recent-720 ceiling) so
+                # the background path surfaces it instead of silently reporting a
+                # full-history success. Absent on uncapped fetches.
+                if res.get("warning"):
+                    _ingestion_runs[run_id]["warning"] = res.get("warning")
+                    _ingestion_runs[run_id]["capped"] = bool(res.get("capped"))
                 _ingestion_runs[run_id]["completed_at"] = datetime.now(timezone.utc).isoformat()
                 _persist_ingestion_runs_locked()
         except Exception as e:

--- a/forven/dataeng/catalog.py
+++ b/forven/dataeng/catalog.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import timezone
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 import duckdb
 import pandas as pd
@@ -115,10 +115,14 @@ class Catalog:
                     start_ts TIMESTAMPTZ,
                     end_ts TIMESTAMPTZ,
                     row_count BIGINT NOT NULL,
+                    fingerprint VARCHAR,
                     updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
                     PRIMARY KEY (source, market, symbol, timeframe, stream)
                 )
                 """
+            )
+            con.execute(
+                "ALTER TABLE series_coverage ADD COLUMN IF NOT EXISTS fingerprint VARCHAR"
             )
             con.execute(
                 """
@@ -195,6 +199,9 @@ class Catalog:
             )
 
     def upsert_series_coverage(self, row: CoverageRow) -> None:
+        # Leaves `fingerprint` NULL (INSERT OR REPLACE resets unlisted columns),
+        # so the next scan_lake re-reads the file instead of trusting a stale
+        # cached-bounds entry.
         with self.connect() as con:
             con.execute(
                 """
@@ -240,9 +247,95 @@ class Catalog:
     def scan_lake(self, data_root: str | Path | None = None) -> list[CoverageRow]:
         root = Path(data_root) if data_root is not None else default_data_root()
         ohlcv_root = root if root.name == "ohlcv" else root / "ohlcv"
-        rows = list(_scan_ohlcv_files(ohlcv_root))
-        for row in rows:
-            self.upsert_series_coverage(row)
+        if not ohlcv_root.exists():
+            return []
+
+        # Incremental: a file whose size+mtime fingerprint matches the stored
+        # coverage row keeps its persisted bounds. Re-aggregating every parquet
+        # made this scan O(lake) per call — 30s+ once the research universe
+        # seeded — and it runs from the catch-up job and plan endpoints.
+        cached: dict[str, tuple[str | None, CoverageRow]] = {}
+        with self.connect() as con:
+            stored = con.execute(
+                """
+                SELECT source, market, symbol, timeframe, stream, path,
+                       start_ts, end_ts, row_count, fingerprint
+                FROM series_coverage
+                WHERE stream = 'candles'
+                """
+            ).fetchall()
+        for values in stored:
+            row = CoverageRow(
+                source=values[0],
+                market=values[1],
+                symbol=values[2],
+                timeframe=values[3],
+                stream=values[4],
+                path=values[5],
+                start_ts=_utc_iso(values[6]),
+                end_ts=_utc_iso(values[7]),
+                row_count=int(values[8] or 0),
+            )
+            cached[row.path] = (values[9], row)
+
+        rows: list[CoverageRow] = []
+        changed: list[tuple[CoverageRow, str]] = []
+        for path in sorted(ohlcv_root.rglob("*.parquet")):
+            parsed = _parse_ohlcv_path(ohlcv_root, path)
+            if parsed is None:
+                continue
+            ref, timeframe = parsed
+            fingerprint = _file_fingerprint(path)
+            prior = cached.get(str(path))
+            if prior is not None and prior[0] is not None and prior[0] == fingerprint:
+                rows.append(prior[1])
+                continue
+            try:
+                start_ts, end_ts, row_count = _read_parquet_bounds(path)
+            except Exception:
+                continue
+            row = CoverageRow(
+                source=ref.source,
+                market=ref.market,
+                symbol=ref.to_fs(),
+                timeframe=timeframe,
+                stream="candles",
+                path=str(path),
+                start_ts=start_ts,
+                end_ts=end_ts,
+                row_count=row_count,
+            )
+            rows.append(row)
+            changed.append((row, fingerprint))
+
+        if changed:
+            # One connection for the whole batch — per-row connects serialized
+            # every row behind the catalog lock (364 open/close cycles per scan).
+            with self.connect() as con:
+                con.executemany(
+                    """
+                    INSERT OR REPLACE INTO series_coverage (
+                        source, market, symbol, timeframe, stream, path,
+                        start_ts, end_ts, row_count, fingerprint, updated_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, now())
+                    """,
+                    [
+                        [
+                            row.source,
+                            row.market,
+                            row.symbol,
+                            row.timeframe,
+                            row.stream,
+                            row.path,
+                            row.start_ts,
+                            row.end_ts,
+                            row.row_count,
+                            fingerprint,
+                        ]
+                        for row, fingerprint in changed
+                    ],
+                )
         return rows
 
     def upsert_symbol_registry(
@@ -311,34 +404,17 @@ def _read_parquet_bounds(path: Path) -> tuple[str | None, str | None, int]:
     return _utc_iso(row[0]), _utc_iso(row[1]), int(row[2] or 0)
 
 
-def _scan_ohlcv_files(ohlcv_root: Path) -> Iterable[CoverageRow]:
-    if not ohlcv_root.exists():
-        return []
-
-    rows: list[CoverageRow] = []
-    for path in sorted(ohlcv_root.rglob("*.parquet")):
-        parsed = _parse_ohlcv_path(ohlcv_root, path)
-        if parsed is None:
-            continue
-        ref, timeframe = parsed
+def _file_fingerprint(path: Path) -> str:
+    # Covers the cold file AND its tail sidecar — recent appends land in the
+    # tail until compaction, so either changing must invalidate cached bounds.
+    def stamp(target: Path) -> str:
         try:
-            start_ts, end_ts, row_count = _read_parquet_bounds(path)
-        except Exception:
-            continue
-        rows.append(
-            CoverageRow(
-                source=ref.source,
-                market=ref.market,
-                symbol=ref.to_fs(),
-                timeframe=timeframe,
-                stream="candles",
-                path=str(path),
-                start_ts=start_ts,
-                end_ts=end_ts,
-                row_count=row_count,
-            )
-        )
-    return rows
+            st = target.stat()
+        except OSError:
+            return "absent"
+        return f"{st.st_size}:{st.st_mtime_ns}"
+
+    return f"{stamp(path)}|{stamp(Path(str(path) + '.tail'))}"
 
 
 def _parse_ohlcv_path(ohlcv_root: Path, path: Path) -> tuple[SymbolRef, str] | None:

--- a/forven/dataeng/hub.py
+++ b/forven/dataeng/hub.py
@@ -146,15 +146,12 @@ class DataHub:
 
         coverage: list[dict[str, object]]
         try:
-            catalog = Catalog()
-            # The engine is opt-in / default-off. A full lake rescan opens a fresh
-            # DuckDB connection per parquet, so only pay for it when the engine is
-            # actually enabled; otherwise serve the last-persisted coverage. This
-            # endpoint runs on EVERY Data-page load, so an unconditional scan piled
-            # onto the load that was starving the event loop and dropping the WS.
-            if engine_enabled:
-                catalog.scan_lake()
-            coverage = catalog.list_coverage()
+            # Never rescan the lake here — this endpoint runs on EVERY Data-page
+            # load, and even a gated scan held page loads hostage for 30s+ once
+            # the research universe seeded the lake. Serve the last-persisted
+            # coverage; the catch-up job and the backfill-plan endpoint scan_lake()
+            # before planning, which keeps this snapshot fresh.
+            coverage = Catalog().list_coverage()
         except Exception:
             coverage = []
 

--- a/frontend/src/lib/api/data.ts
+++ b/frontend/src/lib/api/data.ts
@@ -784,7 +784,10 @@ function toQualityReport(ds: Dataset, q: DataQualityExtended, idx: number): Qual
 }
 
 export async function getDataEngineStatus(): Promise<DataEngineStatus> {
-	return fetchApi('/data/engine/status');
+	// Hard total budget via signal (not timeoutMs): fetchApi retries non-HTTP
+	// failures across every API base candidate, so a per-attempt timeout would
+	// multiply by the candidate count while the Data page waits on this call.
+	return fetchApi('/data/engine/status', { signal: AbortSignal.timeout(15_000) });
 }
 
 export async function planDataEngineBackfill(): Promise<DataEngineBackfillPlan> {

--- a/frontend/src/lib/api/data.ts
+++ b/frontend/src/lib/api/data.ts
@@ -168,7 +168,14 @@ export async function fetchData(
 					message: `Finalizing ${symbol} ${timeframe}...`,
 					run,
 				});
-				return getDatasetDetail(symbol, timeframe, signal);
+				const detail = await getDatasetDetail(symbol, timeframe, signal);
+				// getDatasetDetail re-reads the lake and so drops any venue-cap
+				// warning the fetch attached — carry it over from the run.
+				if (run.warning) {
+					detail.warning = run.warning;
+					detail.capped = run.capped ?? true;
+				}
+				return detail;
 			}
 
 			const statusLabel = run.status === 'pending' ? 'Queued' : 'Downloading';
@@ -614,6 +621,10 @@ export interface IngestionRun {
 	bars_fetched: number;
 	bars_new: number;
 	bars_updated: number;
+	// Venue-cap warning (e.g. Kraken's recent-720 ceiling) stamped on completion
+	// when the request reached past what the venue could serve.
+	capped?: boolean;
+	warning?: string | null;
 	error: string | null;
 	prior_version_id: string | null;
 	new_version_id: string | null;

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -35,6 +35,11 @@ export interface Dataset {
 	// Venue identity stamped by the write path (forven_market parquet metadata):
 	// 'perp' | 'spot' | 'unknown' | 'unstamped' (legacy pre-stamping file).
 	market?: string;
+	// Set when the venue could only serve a bounded recent window (e.g. Kraken's
+	// most-recent-~720-candles ceiling) and the request asked for more. `warning`
+	// is a human-readable explanation to show the user.
+	capped?: boolean;
+	warning?: string;
 }
 
 export interface Job {

--- a/frontend/src/lib/components/research/CoverageMatrix.svelte
+++ b/frontend/src/lib/components/research/CoverageMatrix.svelte
@@ -227,13 +227,15 @@
 	{:else if timeframes.length === 0}
 		<div class="text-xs text-gray-500">No {STREAM_LABEL[stream]} series stored yet.</div>
 	{:else}
-		<div class="overflow-x-auto">
+		<!-- Own scroll container: the research universe puts 50+ symbols in this
+		     matrix, so cap the height instead of letting it swallow the page. -->
+		<div class="max-h-[480px] overflow-auto">
 			<table class="w-full border-separate border-spacing-1 text-xs">
 				<thead>
 					<tr>
-						<th class="w-px whitespace-nowrap px-2 py-1 text-left font-medium text-gray-400">symbol</th>
+						<th class="sticky top-0 z-10 w-px whitespace-nowrap bg-[#050505] px-2 py-1 text-left font-medium text-gray-400">symbol</th>
 						{#each timeframes as tf}
-							<th class="px-2 py-1 text-center font-medium text-gray-400">{tf}</th>
+							<th class="sticky top-0 z-10 bg-[#050505] px-2 py-1 text-center font-medium text-gray-400">{tf}</th>
 						{/each}
 					</tr>
 				</thead>

--- a/frontend/src/lib/components/research/DataInspector.svelte
+++ b/frontend/src/lib/components/research/DataInspector.svelte
@@ -309,7 +309,10 @@
 							(progress) => updateDataFetchProgress(progress.message)
 						);
 					}
-					completeDataFetchSuccess(`Finished ${symbol} — ${tfs.length} timeframe${tfs.length > 1 ? 's' : ''}`);
+					completeDataFetchSuccess(
+						`Finished ${symbol} — ${tfs.length} timeframe${tfs.length > 1 ? 's' : ''}`,
+						lastResult?.warning ?? null
+					);
 					dispatch('refresh');
 					if (lastResult) dispatch('fetched', { dataset: lastResult });
 					mode = 'details';

--- a/frontend/src/lib/components/research/StorageMaintenance.svelte
+++ b/frontend/src/lib/components/research/StorageMaintenance.svelte
@@ -61,7 +61,7 @@
 		try {
 			orphans = await scanOrphans();
 			const total = orphans.orphans.length + orphans.cataloged_missing.length;
-			notice = total === 0 ? 'No storage drift — catalog and parquet are in sync. ✓' : null;
+			notice = total === 0 ? 'All clean — no leftover or missing files. ✓' : null;
 		} catch (e) {
 			error = e instanceof Error ? e.message : 'Orphan scan failed';
 		} finally {
@@ -94,12 +94,13 @@
 </script>
 
 <div class="border border-[#222] bg-[#050505] p-4">
-	<div class="mb-3 flex items-center justify-between">
-		<h2 class="text-xs font-bold uppercase tracking-widest text-white">Storage &amp; maintenance</h2>
+	<div class="mb-1 flex items-center justify-between">
+		<h2 class="text-xs font-bold uppercase tracking-widest text-white">Data health</h2>
 		<button class="border border-[#333] px-2 py-0.5 text-[11px] text-[#888] hover:bg-[#111] hover:text-white transition-colors" on:click={load} disabled={loading}>
 			{loading ? '…' : 'Refresh'}
 		</button>
 	</div>
+	<p class="mb-3 text-[11px] text-[#555]">How much is stored, whether storage and catalog agree, and what was written recently.</p>
 
 	{#if error}
 		<div class="mb-2 border border-red-900 bg-red-500/5 p-2 text-xs text-red-400">{error}</div>
@@ -136,16 +137,16 @@
 				</div>
 			</div>
 			<div>
-				<div class="text-[#666]">Last ingestion</div>
+				<div class="text-[#666]">Last download</div>
 				<div class="font-mono text-[#888]">{ago(health.last_ingestion_at)}</div>
 			</div>
 		</div>
 
 		<!-- Orphan scan -->
 		<div class="mb-4 border-t border-[#1a1a1a] pt-3">
-			<div class="mb-2 flex items-center justify-between">
+			<div class="mb-1 flex items-center justify-between">
 				<span class="text-xs font-medium text-[#888]">
-					Storage drift
+					Storage check
 					{#if health.orphan_count > 0}
 						<span class="ml-1 border border-yellow-900 px-1.5 py-0.5 text-yellow-400">{health.orphan_count} flagged</span>
 					{/if}
@@ -157,25 +158,28 @@
 						</button>
 					{/if}
 					<button class="border border-[#333] px-2 py-0.5 text-[11px] text-[#888] hover:bg-[#111] hover:text-white transition-colors disabled:opacity-50" on:click={doScan} disabled={scanning || cleaning}>
-						{scanning ? 'scanning…' : 'Scan orphans'}
+						{scanning ? 'scanning…' : 'Scan'}
 					</button>
 				</div>
 			</div>
+			<p class="mb-2 text-[11px] text-[#555]">
+				Finds temp files and half-written data left behind by interrupted downloads. Read-only until you clean up.
+			</p>
 			{#if orphans}
 				{#if orphans.orphans.length === 0 && orphans.cataloged_missing.length === 0}
-					<div class="text-xs text-[#666]">In sync — no orphaned files or missing parquet.</div>
+					<div class="text-xs text-[#666]">All clean — storage and catalog agree.</div>
 				{:else}
 					<div class="space-y-1 text-xs">
 						{#each orphans.orphans as o}
 							<div class="flex items-center justify-between {o.safe_delete ? 'text-yellow-400' : 'text-[#888]'}">
 								<span class="font-mono">{o.symbol}/{o.timeframe}</span>
-								<span class="text-[#666]">{o.reason ?? 'orphan'} · {fmtBytes(o.size_bytes)}{o.safe_delete ? '' : ' · kept'}</span>
+								<span class="text-[#666]">{o.reason ?? 'orphan'} · {fmtBytes(o.size_bytes)}{o.safe_delete ? '' : ' · kept for review'}</span>
 							</div>
 						{/each}
 						{#each orphans.cataloged_missing as m}
 							<div class="flex items-center justify-between text-red-400">
 								<span class="font-mono">{m.symbol}/{m.timeframe}</span>
-								<span class="text-[#666]">cataloged but file missing</span>
+								<span class="text-[#666]">in catalog but file missing</span>
 							</div>
 						{/each}
 					</div>
@@ -185,9 +189,9 @@
 
 		<!-- Recent versions audit trail -->
 		<div class="border-t border-[#1a1a1a] pt-3">
-			<div class="mb-2 text-xs font-medium text-[#888]">Recent ingestion versions</div>
+			<div class="mb-2 text-xs font-medium text-[#888]">Recent data writes</div>
 			{#if versions.length === 0}
-				<div class="text-xs text-[#666]">No version history yet.</div>
+				<div class="text-xs text-[#666]">No writes recorded yet.</div>
 			{:else}
 				<div class="overflow-x-auto">
 					<table class="w-full text-xs">

--- a/frontend/src/lib/stores/dataFetch.ts
+++ b/frontend/src/lib/stores/dataFetch.ts
@@ -7,6 +7,9 @@ export interface DataFetchState {
 	taskId: string | null;
 	label: string;
 	message: string | null;
+	// Non-fatal completion note (e.g. a venue-cap warning: Kraken only serves the
+	// most recent ~720 candles). Shown alongside a success message.
+	warning: string | null;
 	progress: string;
 	startedAt: number | null;
 	finishedAt: number | null;
@@ -18,6 +21,7 @@ const initialState: DataFetchState = {
 	taskId: null,
 	label: '',
 	message: null,
+	warning: null,
 	progress: '',
 	startedAt: null,
 	finishedAt: null,
@@ -44,6 +48,7 @@ export function startDataFetchTask(label: string, options?: { taskId?: string; i
 		taskId,
 		label,
 		message: null,
+		warning: null,
 		progress: '',
 		startedAt: Date.now(),
 		finishedAt: null,
@@ -62,12 +67,13 @@ export function updateDataFetchProgress(progress: string) {
 	});
 }
 
-export function completeDataFetchSuccess(message: string) {
+export function completeDataFetchSuccess(message: string, warning: string | null = null) {
 	activeAbortController = null;
 	dataFetchState.update((state) => ({
 		...state,
 		status: 'success',
 		message,
+		warning,
 		progress: '',
 		finishedAt: Date.now()
 	}));

--- a/frontend/src/routes/data/+page.svelte
+++ b/frontend/src/routes/data/+page.svelte
@@ -183,9 +183,20 @@
 
 	async function loadData(preferred?: { symbol: string; timeframe: string }): Promise<void> {
 		const failures: string[] = [];
+		const datasetsPromise = getDatasets();
+		// Show the dataset list as soon as its own request answers — the tab must
+		// not sit on "Loading..." because one of the six status calls below is slow.
+		void datasetsPromise
+			.then((rows) => {
+				if (Array.isArray(rows)) {
+					datasets = rows;
+					loading = false;
+				}
+			})
+			.catch(() => {});
 		const [settingsResult, datasetsResult, runsResult, dataEngineResult, healthResult, lakeResult, universeResult] = await Promise.allSettled([
 			getSettings(),
-			getDatasets(),
+			datasetsPromise,
 			getIngestionRuns({ limit: 500 }),
 			getDataEngineStatus(),
 			getCollectionHealth(),

--- a/frontend/src/routes/data/+page.svelte
+++ b/frontend/src/routes/data/+page.svelte
@@ -955,12 +955,17 @@
 			</div>
 		</div>
 	{:else if $dataFetchState.status === 'success' && $dataFetchState.message}
-		<div class="flex items-start justify-between gap-3 border border-green-800 bg-green-950/30 text-green-200 text-xs px-3 py-2 rounded">
-			<div class="min-w-0 font-mono break-words">{$dataFetchState.message}</div>
+		<div class="flex items-start justify-between gap-3 border {$dataFetchState.warning ? 'border-amber-800 bg-amber-950/30 text-amber-200' : 'border-green-800 bg-green-950/30 text-green-200'} text-xs px-3 py-2 rounded">
+			<div class="min-w-0">
+				<div class="font-mono break-words">{$dataFetchState.message}</div>
+				{#if $dataFetchState.warning}
+					<div class="mt-1 break-words text-amber-300">⚠ {$dataFetchState.warning}</div>
+				{/if}
+			</div>
 			<button
 				type="button"
 				on:click={clearDataFetchTask}
-				class="shrink-0 text-green-400 hover:text-white transition-colors"
+				class="shrink-0 {$dataFetchState.warning ? 'text-amber-400' : 'text-green-400'} hover:text-white transition-colors"
 				aria-label="Dismiss download status"
 			>
 				Dismiss

--- a/frontend/src/routes/data/+page.svelte
+++ b/frontend/src/routes/data/+page.svelte
@@ -594,6 +594,14 @@
 	$: dataEngineLiveCount = (dataEngineStatus?.streams ?? []).filter((stream) => stream.status === 'connected').length;
 	$: dataEngineSourceCount = dataEngineStatus?.sources?.length ?? 0;
 
+	// Source status comes from a circuit breaker, where "closed" = healthy and
+	// "open" = failing — exactly backwards for a casual reader, so translate.
+	const SOURCE_STATUS_LABEL: Record<string, string> = {
+		closed: 'healthy',
+		open: 'failing',
+		'half-open': 'recovering',
+	};
+
 	onMount(() => {
 		let isDestroyed = false;
 		async function initialLoad() {
@@ -758,174 +766,246 @@
 	{/if}
 
 	{#if activeTab === 'maintenance'}
-	<StorageMaintenance />
-
+	<!-- All three download mechanisms live in ONE card, ordered from broadest
+	     (add markets) to most surgical (fill gaps) — each row says plainly when
+	     to use it, so users don't have to decode seed/backfill/catch-up jargon. -->
 	<section class="border border-[#222] rounded bg-[#0a0a0a] overflow-hidden">
 		<div class="px-3 py-2 border-b border-[#1a1a1a]">
-			<div class="text-[11px] uppercase tracking-wider text-gray-400">Research Universe &amp; Deep History</div>
+			<div class="text-[11px] uppercase tracking-wider text-gray-400">Downloads &amp; Coverage</div>
 			<div class="text-[11px] text-gray-500 mt-0.5">
-				Deep perp history for strategy discovery — more assets and more years means more evidence per hypothesis.
+				Three ways to get data: track more markets, extend their history further back, or fill small recent gaps.
 			</div>
 		</div>
-		<div class="grid grid-cols-1 lg:grid-cols-2">
-			<div class="p-3 border-b lg:border-b-0 lg:border-r border-[#171717]">
-				<div class="flex items-center justify-between gap-2 mb-2">
-					<div class="text-[10px] uppercase tracking-wider text-gray-500">Research Universe</div>
-					<div class="flex gap-2">
-						<button
-							type="button"
-							on:click={handleRefreshRegistry}
-							disabled={universeBusy || universeSeedRunning}
-							class="px-2 py-1 text-[11px] rounded border border-[#2b2b2b] hover:border-cyan-500 hover:text-cyan-100 transition-colors disabled:opacity-50"
-						>Refresh Registry</button>
-						{#if universeSeedRunning}
-							<button
-								type="button"
-								on:click={handleCancelSeed}
-								class="px-2 py-1 text-[11px] rounded border border-red-900 text-red-300 hover:border-red-500 transition-colors"
-							>Cancel Seed</button>
-						{:else}
-							<button
-								type="button"
-								on:click={handleSeedUniverse}
-								disabled={universeBusy}
-								class="px-2 py-1 text-[11px] rounded border border-cyan-700 text-cyan-300 hover:text-white hover:border-cyan-400 transition-colors disabled:opacity-50"
-							>Seed Universe</button>
-						{/if}
-					</div>
-				</div>
-				{#if universeError}
-					<div class="text-[11px] text-red-300 mb-2">{universeError}</div>
-				{/if}
-				{#if universe}
-					<div class="grid grid-cols-3 gap-2 text-center mb-2">
-						<div class="rounded border border-[#1c1c1c] p-2">
-							<div class="text-sm font-semibold text-gray-100">{universe.active.toLocaleString()}</div>
-							<div class="text-[10px] text-gray-500 uppercase">active perps</div>
-						</div>
-						<div class="rounded border border-[#1c1c1c] p-2">
-							<div class="text-sm font-semibold text-gray-100">{universe.plan.length.toLocaleString()}</div>
-							<div class="text-[10px] text-gray-500 uppercase">in plan ({universeMinuteTier} w/ 1m)</div>
-						</div>
-						<div class="rounded border border-[#1c1c1c] p-2">
-							<div class="text-sm font-semibold text-gray-100">{universe.delisted.toLocaleString()}</div>
-							<div class="text-[10px] text-gray-500 uppercase">delisted kept</div>
-						</div>
-					</div>
 
-					<!-- Universe sizing: presets are premades, the number stays editable;
-					     seeding is always manual, so nothing downloads until Seed is clicked. -->
-					<div class="flex flex-wrap items-center gap-2 mb-2 text-[11px]">
-						<span class="text-gray-500 uppercase text-[10px] tracking-wider">Size</span>
-						{#each UNIVERSE_PRESETS as preset}
-							<button
-								type="button"
-								disabled={universeConfigBusy || universeSeedRunning}
-								on:click={() => void applyUniverseSize(preset.size)}
-								class="px-2 py-0.5 rounded border transition-colors disabled:opacity-50 {universeSize === preset.size
-									? 'border-cyan-600 text-cyan-200'
-									: 'border-[#2b2b2b] text-gray-400 hover:border-cyan-700 hover:text-gray-200'}"
-								title={`${preset.size} most liquid perps`}
-							>{preset.label} ({preset.size})</button>
-						{/each}
-						<input
-							type="number"
-							min="1"
-							max="500"
-							class="w-16 bg-[#111] border border-[#2b2b2b] rounded px-1.5 py-0.5 text-gray-200"
-							value={universeSize}
-							disabled={universeConfigBusy || universeSeedRunning}
-							on:change={(e) => {
-								const v = Number(e.currentTarget.value);
-								if (Number.isFinite(v) && v >= 1 && v <= 500) void applyUniverseSize(Math.round(v));
-							}}
-							title="Custom universe size (1-500 most liquid perps)"
-						/>
-						<span class="text-gray-500" title="Rough full-seed footprint at this size (perp history + derivatives)">
-							est. {universeEstimate}
-						</span>
+		<!-- 1 · Track more markets (research universe) -->
+		<div class="p-3 border-b border-[#171717]">
+			<div class="flex flex-wrap items-center justify-between gap-2 mb-1">
+				<div class="text-xs font-semibold text-gray-200">1 · Track more markets</div>
+				<div class="flex gap-2">
+					<button
+						type="button"
+						on:click={handleRefreshRegistry}
+						disabled={universeBusy || universeSeedRunning}
+						title="Re-read the exchange's list of tradable perpetuals"
+						class="px-2 py-1 text-[11px] rounded border border-[#2b2b2b] hover:border-cyan-500 hover:text-cyan-100 transition-colors disabled:opacity-50"
+					>Refresh symbol list</button>
+					{#if universeSeedRunning}
+						<button
+							type="button"
+							on:click={handleCancelSeed}
+							class="px-2 py-1 text-[11px] rounded border border-red-900 text-red-300 hover:border-red-500 transition-colors"
+						>Cancel</button>
+					{:else}
+						<button
+							type="button"
+							on:click={handleSeedUniverse}
+							disabled={universeBusy}
+							class="px-2 py-1 text-[11px] rounded border border-cyan-700 text-cyan-300 hover:text-white hover:border-cyan-400 transition-colors disabled:opacity-50"
+						>Download history</button>
+					{/if}
+				</div>
+			</div>
+			<div class="text-[11px] text-gray-500 mb-2 leading-snug max-w-3xl">
+				The research universe is the set of most-liquid perpetuals the system studies for strategy discovery.
+				Pick a size, then <span class="text-gray-300">Download history</span> to fetch each one's complete past
+				(price, funding, open interest, basis). Nothing downloads until you click; safe to cancel — everything
+				already saved is kept, and the next run resumes where it stopped.
+			</div>
+			{#if universeError}
+				<div class="text-[11px] text-red-300 mb-2">{universeError}</div>
+			{/if}
+			{#if universe}
+				<div class="grid grid-cols-3 gap-2 text-center mb-2 max-w-md">
+					<div class="rounded border border-[#1c1c1c] p-2" title="Perpetuals currently tradable on the exchange">
+						<div class="text-sm font-semibold text-gray-100">{universe.active.toLocaleString()}</div>
+						<div class="text-[10px] text-gray-500 uppercase">on exchange</div>
+					</div>
+					<div class="rounded border border-[#1c1c1c] p-2" title="Symbols selected for the research universe at the current size ({universeMinuteTier} also get 1-minute bars)">
+						<div class="text-sm font-semibold text-gray-100">{universe.plan.length.toLocaleString()}</div>
+						<div class="text-[10px] text-gray-500 uppercase">selected ({universeMinuteTier} w/ 1m)</div>
+					</div>
+					<div class="rounded border border-[#1c1c1c] p-2" title="Delisted symbols whose history is kept, so research isn't biased toward survivors">
+						<div class="text-sm font-semibold text-gray-100">{universe.delisted.toLocaleString()}</div>
+						<div class="text-[10px] text-gray-500 uppercase">delisted kept</div>
+					</div>
+				</div>
+
+				<!-- Universe sizing: presets are premades, the number stays editable;
+				     seeding is always manual, so nothing downloads until the click. -->
+				<div class="flex flex-wrap items-center gap-2 mb-2 text-[11px]">
+					<span class="text-gray-500 uppercase text-[10px] tracking-wider">Size</span>
+					{#each UNIVERSE_PRESETS as preset}
 						<button
 							type="button"
 							disabled={universeConfigBusy || universeSeedRunning}
-							on:click={toggleUniverseEnabled}
-							class="ml-auto px-2 py-0.5 rounded border transition-colors disabled:opacity-50 {universe.config?.enabled === false
-								? 'border-[#2b2b2b] text-gray-500 hover:text-gray-300'
-								: 'border-green-900 text-green-300'}"
-							title="When off, the research universe is not planned or seeded — only your traded symbols keep collecting."
-						>{universe.config?.enabled === false ? 'Universe OFF' : 'Universe ON'}</button>
-					</div>
-					{#if universe.config?.enabled === false}
-						<div class="text-[11px] text-amber-200/80 mb-2">
-							Research universe disabled — no bulk downloads will be planned. Your traded symbols keep collecting normally.
-						</div>
-					{/if}
-					{#if universeSeedRunning && universe.seed.progress}
-						<div class="text-[11px] text-gray-300 mb-1">
-							Seeding {universe.seed.progress.current_symbol} — {universe.seed.progress.done}/{universe.seed.progress.total}
-						</div>
-						<div class="h-1.5 rounded bg-[#161616] overflow-hidden">
-							<div class="h-full bg-cyan-600 transition-all" style={`width:${jobPct(universe.seed.progress)}%`}></div>
-						</div>
-					{:else if universe.seed.last_error}
-						<div class="text-[11px] text-red-300">Last seed failed: {universe.seed.last_error}</div>
-					{:else if universe.seed.last_result}
-						<div class="text-[11px] text-green-400">
-							Last seed: {String((universe.seed.last_result as Record<string, unknown>).series_seeded ?? 0)} series seeded,
-							{String((universe.seed.last_result as Record<string, unknown>).series_current ?? 0)} already current
-						</div>
-					{:else}
-						<div class="text-[11px] text-gray-500">
-							Seed downloads full Binance-Vision perp history + a live tail for each planned series. Resumable and cancellable.
-						</div>
-					{/if}
-				{:else if !universeError}
-					<div class="text-xs text-gray-500">Loading…</div>
-				{/if}
-			</div>
-			<div class="p-3">
-				<div class="flex items-center justify-between gap-2 mb-2">
-					<div class="text-[10px] uppercase tracking-wider text-gray-500">Deep History Backfill (Binance Vision)</div>
-					<div class="flex gap-2">
-						{#if bvStatus?.running}
-							<button
-								type="button"
-								on:click={handleCancelBv}
-								class="px-2 py-1 text-[11px] rounded border border-red-900 text-red-300 hover:border-red-500 transition-colors"
-							>{bvStatus?.cancel_requested ? 'Cancelling…' : 'Cancel'}</button>
-						{:else}
-							<button
-								type="button"
-								on:click={handleTriggerBv}
-								disabled={bvBusy}
-								class="px-2 py-1 text-[11px] rounded border border-cyan-700 text-cyan-300 hover:text-white hover:border-cyan-400 transition-colors disabled:opacity-50"
-							>Backfill All</button>
-						{/if}
-					</div>
+							on:click={() => void applyUniverseSize(preset.size)}
+							class="px-2 py-0.5 rounded border transition-colors disabled:opacity-50 {universeSize === preset.size
+								? 'border-cyan-600 text-cyan-200'
+								: 'border-[#2b2b2b] text-gray-400 hover:border-cyan-700 hover:text-gray-200'}"
+							title={`${preset.size} most liquid perps`}
+						>{preset.label} ({preset.size})</button>
+					{/each}
+					<input
+						type="number"
+						min="1"
+						max="500"
+						class="w-16 bg-[#111] border border-[#2b2b2b] rounded px-1.5 py-0.5 text-gray-200"
+						value={universeSize}
+						disabled={universeConfigBusy || universeSeedRunning}
+						on:change={(e) => {
+							const v = Number(e.currentTarget.value);
+							if (Number.isFinite(v) && v >= 1 && v <= 500) void applyUniverseSize(Math.round(v));
+						}}
+						title="Custom universe size (1-500 most liquid perps)"
+					/>
+					<span class="text-gray-500" title="Rough full-download footprint at this size (perp history + derivatives)">
+						est. {universeEstimate}
+					</span>
+					<button
+						type="button"
+						disabled={universeConfigBusy || universeSeedRunning}
+						on:click={toggleUniverseEnabled}
+						class="ml-auto px-2 py-0.5 rounded border transition-colors disabled:opacity-50 {universe.config?.enabled === false
+							? 'border-[#2b2b2b] text-gray-500 hover:text-gray-300'
+							: 'border-green-900 text-green-300'}"
+						title="When off, the research universe is not planned or downloaded — only your traded symbols keep collecting."
+					>{universe.config?.enabled === false ? 'Universe OFF' : 'Universe ON'}</button>
 				</div>
-				{#if bvError}
-					<div class="text-[11px] text-red-300 mb-2">{bvError}</div>
+				{#if universe.config?.enabled === false}
+					<div class="text-[11px] text-amber-200/80 mb-2">
+						Research universe disabled — no bulk downloads will be planned. Your traded symbols keep collecting normally.
+					</div>
 				{/if}
-				{#if bvStatus?.running && bvStatus.progress}
+				{#if universeSeedRunning && universe.seed.progress}
 					<div class="text-[11px] text-gray-300 mb-1">
-						Backfilling {bvStatus.progress.current_symbol} — {bvStatus.progress.done}/{bvStatus.progress.total} symbols
+						Downloading {universe.seed.progress.current_symbol} — {universe.seed.progress.done}/{universe.seed.progress.total}
 					</div>
 					<div class="h-1.5 rounded bg-[#161616] overflow-hidden">
-						<div class="h-full bg-cyan-600 transition-all" style={`width:${jobPct(bvStatus.progress)}%`}></div>
+						<div class="h-full bg-cyan-600 transition-all" style={`width:${jobPct(universe.seed.progress)}%`}></div>
 					</div>
-				{:else if bvStatus?.running}
-					<div class="text-[11px] text-gray-300">Backfill running…</div>
-				{:else if bvStatus?.last_error}
-					<div class="text-[11px] text-red-300">Last backfill failed: {bvStatus.last_error}</div>
-				{:else if bvStatus?.last_started_at}
-					<div class="text-[11px] text-green-400">Last backfill: {formatTimestamp(bvStatus.last_started_at)} ✓</div>
-				{:else}
-					<div class="text-[11px] text-gray-500">
-						Fills pre-history (OHLCV / funding / OI / basis) for every stored symbol from Binance Vision archives. Survives restarts; cancellable between symbols.
+				{:else if universe.seed.last_error}
+					<div class="text-[11px] text-red-300">Last run failed: {universe.seed.last_error}</div>
+				{:else if universe.seed.last_result}
+					<div class="text-[11px] text-green-400">
+						Last run: {String((universe.seed.last_result as Record<string, unknown>).series_seeded ?? 0)} series downloaded,
+						{String((universe.seed.last_result as Record<string, unknown>).series_current ?? 0)} already current
 					</div>
 				{/if}
+			{:else if !universeError}
+				<div class="text-xs text-gray-500">Loading…</div>
+			{/if}
+		</div>
+
+		<!-- 2 · Extend history further back (deep-history backfill) -->
+		<div class="p-3 border-b border-[#171717]">
+			<div class="flex flex-wrap items-center justify-between gap-2 mb-1">
+				<div class="text-xs font-semibold text-gray-200">2 · Extend history further back</div>
+				<div class="flex gap-2">
+					{#if bvStatus?.running}
+						<button
+							type="button"
+							on:click={handleCancelBv}
+							class="px-2 py-1 text-[11px] rounded border border-red-900 text-red-300 hover:border-red-500 transition-colors"
+						>{bvStatus?.cancel_requested ? 'Cancelling…' : 'Cancel'}</button>
+					{:else}
+						<button
+							type="button"
+							on:click={handleTriggerBv}
+							disabled={bvBusy}
+							class="px-2 py-1 text-[11px] rounded border border-cyan-700 text-cyan-300 hover:text-white hover:border-cyan-400 transition-colors disabled:opacity-50"
+						>Extend all symbols</button>
+					{/if}
+				</div>
 			</div>
+			<div class="text-[11px] text-gray-500 mb-2 leading-snug max-w-3xl">
+				Symbols downloaded mid-history stop at their first stored bar. This walks every stored symbol back to
+				its first day on the exchange (price, funding, open interest, basis) using Binance's public archive.
+				Survives restarts; cancelling takes effect between symbols.
+			</div>
+			{#if bvError}
+				<div class="text-[11px] text-red-300 mb-2">{bvError}</div>
+			{/if}
+			{#if bvStatus?.running && bvStatus.progress}
+				<div class="text-[11px] text-gray-300 mb-1">
+					Extending {bvStatus.progress.current_symbol} — {bvStatus.progress.done}/{bvStatus.progress.total} symbols
+				</div>
+				<div class="h-1.5 rounded bg-[#161616] overflow-hidden">
+					<div class="h-full bg-cyan-600 transition-all" style={`width:${jobPct(bvStatus.progress)}%`}></div>
+				</div>
+			{:else if bvStatus?.running}
+				<div class="text-[11px] text-gray-300">Extending history…</div>
+			{:else if bvStatus?.last_error}
+				<div class="text-[11px] text-red-300">Last run failed: {bvStatus.last_error}</div>
+			{:else if bvStatus?.last_started_at}
+				<div class="text-[11px] text-green-400">Last run: {formatTimestamp(bvStatus.last_started_at)} ✓</div>
+			{/if}
+		</div>
+
+		<!-- 3 · Fill recent gaps (data-engine catch-up) -->
+		<div class="p-3">
+			<div class="flex flex-wrap items-center justify-between gap-2 mb-1">
+				<div class="text-xs font-semibold text-gray-200">3 · Fill recent gaps</div>
+				<button
+					type="button"
+					on:click={handlePlanBackfill}
+					disabled={dataEngineLoading}
+					class="px-2 py-1 text-[11px] rounded border border-[#2b2b2b] hover:border-cyan-500 hover:text-cyan-100 transition-colors disabled:opacity-50"
+				>
+					{dataEngineLoading ? 'Checking…' : 'Check for gaps'}
+				</button>
+			</div>
+			<div class="text-[11px] text-gray-500 mb-2 leading-snug max-w-3xl">
+				Tops up bars missed while the app was off and small holes inside stored series. Runs automatically every
+				~10&nbsp;minutes when the Data Engine is on; checking here forces a pass right now.
+			</div>
+			{#if dataEngineStatus && dataEngineStatus.enabled === false}
+				<div class="text-[11px] text-amber-200/80 mb-2">
+					Automatic catch-up is paused — the Data Engine is off. Manual gap-fills here still work; enable it in
+					<a href="/settings#data" class="underline hover:text-amber-100">Settings → Data</a> for hands-free catch-up.
+				</div>
+			{/if}
+			{#if dataEngineError}
+				<div class="text-[11px] text-red-300 mb-2">{dataEngineError}</div>
+			{/if}
+			{#if dataEnginePlan}
+				{#if dataEnginePlan.task_count === 0}
+					<div class="text-xs text-green-400">Everything is current — no gaps found. ✓</div>
+				{:else}
+					<div class="text-xs text-gray-200">
+						{dataEnginePlan.task_count.toLocaleString()} gap{dataEnginePlan.task_count === 1 ? '' : 's'} to fill
+					</div>
+					{#if dataEnginePlan.tasks.length > 0}
+						<div class="mt-2 max-h-24 overflow-auto space-y-1">
+							{#each dataEnginePlan.tasks.slice(0, 6) as task}
+								<div class="font-mono text-[11px] text-gray-400">
+									{task.symbol} {task.timeframe} {task.start_ts} → {task.end_ts}
+								</div>
+							{/each}
+						</div>
+						<button
+							type="button"
+							on:click={handleExecuteBackfill}
+							disabled={dataEngineExecuting}
+							class="mt-2 px-3 py-1.5 text-[11px] rounded border border-cyan-700 text-cyan-300 hover:text-white hover:border-cyan-400 transition-colors disabled:opacity-50"
+						>
+							{dataEngineExecuting
+								? 'Filling…'
+								: dataEngineExecResult
+									? `Fill ${dataEngineCandleRemaining} more`
+									: 'Fill gaps now'}
+						</button>
+					{/if}
+				{/if}
+				{#if dataEngineExecResult}
+					<div class="mt-2 text-[11px] {dataEngineExecResult.failed > 0 ? 'text-yellow-400' : dataEngineExecResult.rows_added > 0 ? 'text-green-400' : 'text-gray-400'}">
+						✓ filled {dataEngineExecResult.executed}, +{dataEngineExecResult.rows_added.toLocaleString()} bars{#if dataEngineExecResult.failed > 0}, {dataEngineExecResult.failed} failed{/if}{#if dataEngineCandleRemaining === 0}, all caught up{/if}
+					</div>
+				{/if}
+			{/if}
 		</div>
 	</section>
+
+	<StorageMaintenance />
 	{/if}
 
 	{#if drillSeries}
@@ -999,56 +1079,47 @@
 	{/if}
 
 	{#if activeTab === 'maintenance'}
+	<!-- Status-only card: the catch-up ACTIONS live in "Fill recent gaps" above,
+	     so this stays a read-only glance at the collection machinery. -->
 	<section class="border border-[#222] rounded bg-[#0a0a0a] overflow-hidden">
-		<div class="px-3 py-2 border-b border-[#1a1a1a] flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-			<div>
-				<div class="text-[11px] uppercase tracking-wider text-gray-400">Data Engine</div>
-				<div class="text-[11px] text-gray-500 mt-0.5">
-					{dataEngineCoverageCount.toLocaleString()} catalog series • {dataEngineLiveCount.toLocaleString()} live streams • {dataEngineSourceCount.toLocaleString()} sources
-				</div>
+		<div class="px-3 py-2 border-b border-[#1a1a1a]">
+			<div class="text-[11px] uppercase tracking-wider text-gray-400">Data Engine Status</div>
+			<div class="text-[11px] text-gray-500 mt-0.5">
+				The machinery behind automatic collection — {dataEngineCoverageCount.toLocaleString()} tracked series • {dataEngineLiveCount.toLocaleString()} live streams • {dataEngineSourceCount.toLocaleString()} sources
 			</div>
-			<button
-				type="button"
-				on:click={handlePlanBackfill}
-				disabled={dataEngineLoading}
-				class="px-3 py-2 text-xs rounded border border-[#2b2b2b] hover:border-cyan-500 hover:text-cyan-100 transition-colors disabled:opacity-50"
-			>
-				{dataEngineLoading ? 'Planning...' : 'Backfill Plan'}
-			</button>
 		</div>
-		{#if dataEngineError}
-			<div class="px-3 py-2 text-xs text-red-300 border-b border-red-900/40 bg-red-950/20">{dataEngineError}</div>
-		{/if}
 		{#if dataEngineStatus && dataEngineStatus.enabled === false}
 			<div class="px-3 py-2 text-[11px] text-amber-200/90 border-b border-amber-900/40 bg-amber-950/20">
 				The Data Engine is <span class="font-semibold">disabled</span> (this is optional). The standard local data path works without it — enable it in
-				<a href="/settings#data" class="underline hover:text-amber-100">Settings → Data</a> to use catalog streaming and automatic catch-up. The counts below stay at zero until it's on.
+				<a href="/settings#data" class="underline hover:text-amber-100">Settings → Data</a> to use catalog streaming and automatic catch-up. The counts here stay at zero until it's on.
 			</div>
 		{/if}
-		<div class="grid grid-cols-1 lg:grid-cols-3">
+		<div class="grid grid-cols-1 lg:grid-cols-2">
 			<div class="p-3 border-b lg:border-b-0 lg:border-r border-[#171717]">
-				<div class="text-[10px] uppercase tracking-wider text-gray-500 mb-2">Source Health</div>
+				<div class="text-[10px] uppercase tracking-wider text-gray-500 mb-2">Exchange connections</div>
 				{#if dataEngineStatus?.sources?.length}
 					<div class="space-y-2">
 						{#each dataEngineStatus.sources as source}
 							<div class="flex items-center justify-between gap-3 text-xs">
 								<span class="font-mono text-gray-200">{source.source}</span>
-								<span class={`rounded border px-2 py-0.5 text-[10px] uppercase ${
-									source.status === 'closed'
-										? 'border-green-800 text-green-300'
-										: source.status === 'open'
-											? 'border-red-800 text-red-300'
-											: 'border-yellow-800 text-yellow-300'
-								}`}>{source.status}</span>
+								<span
+									title={`circuit ${source.status}`}
+									class={`rounded border px-2 py-0.5 text-[10px] uppercase ${
+										source.status === 'closed'
+											? 'border-green-800 text-green-300'
+											: source.status === 'open'
+												? 'border-red-800 text-red-300'
+												: 'border-yellow-800 text-yellow-300'
+									}`}>{SOURCE_STATUS_LABEL[source.status] ?? source.status}</span>
 							</div>
 						{/each}
 					</div>
 				{:else}
-					<div class="text-xs text-gray-500">No source health rows yet.</div>
+					<div class="text-xs text-gray-500">No connection history yet.</div>
 				{/if}
 			</div>
-			<div class="p-3 border-b lg:border-b-0 lg:border-r border-[#171717]">
-				<div class="text-[10px] uppercase tracking-wider text-gray-500 mb-2">Live Streams</div>
+			<div class="p-3">
+				<div class="text-[10px] uppercase tracking-wider text-gray-500 mb-2">Live streams</div>
 				{#if dataEngineStatus?.streams?.length}
 					<div class="space-y-2">
 						{#each dataEngineStatus.streams.slice(0, 5) as stream}
@@ -1059,46 +1130,7 @@
 						{/each}
 					</div>
 				{:else}
-					<div class="text-xs text-gray-500">No live stream buffers are active.</div>
-				{/if}
-			</div>
-			<div class="p-3">
-				<div class="text-[10px] uppercase tracking-wider text-gray-500 mb-2">Backfill</div>
-				<div class="text-[11px] text-gray-500 mb-2 leading-snug">
-					Auto catch-up drains this plan every ~10&nbsp;min (toggle in Settings → Data). The button forces a batch now.
-				</div>
-				{#if dataEnginePlan}
-					<div class="text-xs text-gray-200">
-						{dataEnginePlan.task_count.toLocaleString()} planned task{dataEnginePlan.task_count === 1 ? '' : 's'}
-					</div>
-					{#if dataEnginePlan.tasks.length > 0}
-						<div class="mt-2 max-h-24 overflow-auto space-y-1">
-							{#each dataEnginePlan.tasks.slice(0, 6) as task}
-								<div class="font-mono text-[11px] text-gray-400">
-									{task.symbol} {task.timeframe} {task.start_ts} → {task.end_ts}
-								</div>
-							{/each}
-						</div>
-						<button
-							type="button"
-							on:click={handleExecuteBackfill}
-							disabled={dataEngineExecuting}
-							class="mt-2 px-3 py-1.5 text-[11px] rounded border border-[#2b2b2b] hover:border-cyan-500 hover:text-cyan-100 transition-colors disabled:opacity-50"
-						>
-							{dataEngineExecuting
-								? 'Running…'
-								: dataEngineExecResult
-									? `Catch up ${dataEngineCandleRemaining} more`
-									: 'Catch up now'}
-						</button>
-					{/if}
-					{#if dataEngineExecResult}
-						<div class="mt-2 text-[11px] {dataEngineExecResult.failed > 0 ? 'text-yellow-400' : dataEngineExecResult.rows_added > 0 ? 'text-green-400' : 'text-gray-400'}">
-							✓ ran {dataEngineExecResult.executed}, +{dataEngineExecResult.rows_added.toLocaleString()} bars{#if dataEngineExecResult.failed > 0}, {dataEngineExecResult.failed} failed{/if}{#if dataEngineCandleRemaining === 0}, plan drained{/if}
-						</div>
-					{/if}
-				{:else}
-					<div class="text-xs text-gray-500">No backfill plan has been requested this session.</div>
+					<div class="text-xs text-gray-500">No live streams buffering right now.</div>
 				{/if}
 			</div>
 		</div>

--- a/tests/test_data_remaining_phases.py
+++ b/tests/test_data_remaining_phases.py
@@ -110,18 +110,20 @@ class TestPerpResolution:
 
 
 # ---------------------------------------------------------------------------
-# Venue OHLC ceiling (Kraken). Kraken's REST OHLC returns at most ~720 candles
-# per request and 400s a since=0 (EGeneral:Invalid arguments). A download must
-# NEVER hard-fail on that: an unservable request is collapsed to the recent
-# window and MERGED (accumulated history is preserved, not truncated). A warning
-# is attached ONLY when the user explicitly picked a start date older than the
-# reachable window — not for the "all available" checkbox or a default limit.
+# Capped venue WITHOUT a trades fallback: an unservable request (all_available,
+# far-past since, big limit) must NEVER hard-fail — it collapses to the recent
+# window and MERGES (accumulation preserved), warning ONLY when the user picked
+# an explicit start older than the reachable window. Tested against a synthetic
+# capped venue since Kraken (the only real capped venue) now uses trades.
 # ---------------------------------------------------------------------------
 
 
 class TestVenueOhlcvCap:
+    CAP_VENUE = "capfake"
+
     @pytest.fixture(autouse=True)
-    def _reset_breakers(self):
+    def _register_capped_venue(self, monkeypatch):
+        monkeypatch.setitem(data_mod._VENUE_OHLCV_MAX_BARS, self.CAP_VENUE, 720)
         with data_mod._candle_breakers_lock:
             data_mod._candle_breakers.clear()
         yield
@@ -129,8 +131,6 @@ class TestVenueOhlcvCap:
             data_mod._candle_breakers.clear()
 
     def _wire(self, monkeypatch, seen: dict):
-        # Kraken returns its recent window; capture the `since` / `start_ms`
-        # each fetch path was actually handed so we can assert it was never 0.
         recent = _bars(_closed_start(30), 10)
 
         def _once(exchange, symbol, timeframe, since, limit):
@@ -150,80 +150,239 @@ class TestVenueOhlcvCap:
         monkeypatch.setattr(data_mod, "get_exchange", lambda ex: object())
         monkeypatch.setattr(data_mod, "_cached_markets", lambda ex: {})
 
-    def test_all_available_kraken_downloads_without_warning(self, lake, monkeypatch):
+    def test_all_available_downloads_without_warning(self, lake, monkeypatch):
         seen: dict = {}
         self._wire(monkeypatch, seen)
-
-        rec = data_mod.fetch_ohlcv_chunked(SYMBOL, TF, exchange_id="kraken", all_available=True)
-
-        # Downloads (never sends the since=0 that Kraken rejects) and, because
-        # "all available" got everything obtainable, does NOT flag a shortfall.
+        rec = data_mod.fetch_ohlcv_chunked(SYMBOL, TF, exchange_id=self.CAP_VENUE, all_available=True)
         assert seen.get("once_called") is True
-        assert seen.get("once_since") is None
-        assert seen.get("range_start") is None  # the since=0 range path is skipped
+        assert seen.get("once_since") is None  # never the since=0 that 400s
         assert not rec.get("capped")
         assert not rec.get("warning")
 
-    def test_all_available_kraken_preserves_accumulated_history(self, lake, monkeypatch):
-        # A dataset already grown past the recent window (via prior accumulation)
-        # must not be truncated to the ~720 window when "all available" re-runs.
-        old = _bars(_closed_start(5000), 4000)  # far older than the recent fetch
-        data_mod.save_parquet(old, SYMBOL, TF, source="kraken")
-        before = len(data_mod.load_parquet(SYMBOL, TF))
-        assert before == 4000
-
+    def test_far_past_since_clamps_and_warns(self, lake, monkeypatch):
         seen: dict = {}
         self._wire(monkeypatch, seen)
-        data_mod.fetch_ohlcv_chunked(SYMBOL, TF, exchange_id="kraken", all_available=True)
-
-        after = len(data_mod.load_parquet(SYMBOL, TF))
-        assert after >= before  # merged forward, nothing dropped
-
-    def test_far_past_since_kraken_clamps_and_warns(self, lake, monkeypatch):
-        seen: dict = {}
-        self._wire(monkeypatch, seen)
-
         old = int(datetime(2021, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
-        rec = data_mod.fetch_ohlcv_chunked(SYMBOL, TF, exchange_id="kraken", since_ms=old)
-
+        rec = data_mod.fetch_ohlcv_chunked(SYMBOL, TF, exchange_id=self.CAP_VENUE, since_ms=old)
         assert seen.get("once_since") is None  # collapsed to recent-window fetch
         assert rec["capped"] is True
         assert rec.get("warning")
 
-    def test_in_window_since_kraken_not_clamped(self, lake, monkeypatch):
+    def test_in_window_since_not_clamped(self, lake, monkeypatch):
         seen: dict = {}
         self._wire(monkeypatch, seen)
-
         recent_since = int(datetime.now(timezone.utc).timestamp() * 1000) - 50 * 3600 * 1000
-        rec = data_mod.fetch_ohlcv_chunked(SYMBOL, TF, exchange_id="kraken", since_ms=recent_since)
-
-        # A satisfiable request is honoured as-is, no cap flag.
+        rec = data_mod.fetch_ohlcv_chunked(SYMBOL, TF, exchange_id=self.CAP_VENUE, since_ms=recent_since)
         assert seen.get("range_start") == recent_since
-        assert not rec.get("capped")
-        assert not rec.get("warning")
-
-    def test_large_limit_kraken_clamps_without_warning(self, lake, monkeypatch):
-        seen: dict = {}
-        self._wire(monkeypatch, seen)
-
-        # A bar-count request beyond the cap downloads what's available; a
-        # count is not a date selection, so no warning is raised.
-        rec = data_mod.fetch_ohlcv_chunked(SYMBOL, TF, exchange_id="kraken", limit=5000)
-
-        assert seen.get("once_since") is None  # never the crashing since=0
         assert not rec.get("capped")
         assert not rec.get("warning")
 
     def test_binance_all_available_unaffected(self, lake, monkeypatch):
         seen: dict = {}
         self._wire(monkeypatch, seen)
-
         rec = data_mod.fetch_ohlcv_chunked(SYMBOL, TF, exchange_id="binance", all_available=True)
-
-        # Deep-history paging from 0 is preserved for uncapped venues.
-        assert seen.get("range_start") == 0
+        assert seen.get("range_start") == 0  # deep paging from 0 preserved
         assert not rec.get("capped")
         assert not rec.get("warning")
+
+
+# ---------------------------------------------------------------------------
+# Kraken full history via the Trades feed. Deep requests (all_available,
+# far-past since, big limit) reconstruct candles from the uncapped Trades
+# endpoint; recent/small requests keep the fast OHLC path.
+# ---------------------------------------------------------------------------
+
+
+class TestKrakenTradesHistory:
+    @pytest.fixture(autouse=True)
+    def _reset_breakers(self):
+        with data_mod._candle_breakers_lock:
+            data_mod._candle_breakers.clear()
+        yield
+        with data_mod._candle_breakers_lock:
+            data_mod._candle_breakers.clear()
+
+    def _wire(self, monkeypatch, seen: dict, bars=None):
+        recent = bars if bars is not None else _bars(_closed_start(30), 10)
+
+        def _build(exchange, sym, tf, start, end, progress_callback=None, checkpoint=None):
+            seen.setdefault("trades_windows", []).append((start, end))
+            return data_mod._normalize_ohlcv_frame(recent)
+
+        def _range(exchange, sym, tf, start_ms, end_ms, *a, **k):
+            seen["range_start"] = start_ms
+            return data_mod._normalize_ohlcv_frame(recent)
+
+        def _once(exchange, symbol, timeframe, since, limit):
+            seen["once_since"] = since
+            return [
+                [data_mod._to_ms(ts), r.open, r.high, r.low, r.close, r.volume]
+                for ts, r in zip(recent["timestamp"], recent.itertuples(index=False))
+            ]
+
+        monkeypatch.setattr(data_mod, "_build_ohlcv_from_trades", _build)
+        monkeypatch.setattr(data_mod, "_fetch_range", _range)
+        monkeypatch.setattr(data_mod, "_fetch_ohlcv_once", _once)
+        monkeypatch.setattr(data_mod, "get_exchange", lambda ex: object())
+        monkeypatch.setattr(data_mod, "_cached_markets", lambda ex: {})
+
+    def test_all_available_builds_full_history_from_zero(self, lake, monkeypatch):
+        seen: dict = {}
+        self._wire(monkeypatch, seen)
+        rec = data_mod.fetch_ohlcv_chunked(SYMBOL, TF, exchange_id="kraken", all_available=True)
+        wins = seen.get("trades_windows")
+        assert wins and len(wins) == 1 and wins[0][0] == 0  # trades from the start
+        assert "range_start" not in seen  # OHLC deep path not used
+        assert not rec.get("capped") and not rec.get("warning")
+
+    def test_far_past_since_builds_from_trades(self, lake, monkeypatch):
+        seen: dict = {}
+        self._wire(monkeypatch, seen)
+        old = int(datetime(2021, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
+        rec = data_mod.fetch_ohlcv_chunked(SYMBOL, TF, exchange_id="kraken", since_ms=old)
+        wins = seen.get("trades_windows")
+        assert wins and wins[0][0] == old
+        assert not rec.get("capped") and not rec.get("warning")
+
+    def test_large_limit_builds_from_trades(self, lake, monkeypatch):
+        seen: dict = {}
+        self._wire(monkeypatch, seen)
+        data_mod.fetch_ohlcv_chunked(SYMBOL, TF, exchange_id="kraken", limit=5000)
+        wins = seen.get("trades_windows")
+        assert wins and wins[0][0] < wins[0][1]  # a ~5000-bar window
+
+    def test_recent_since_uses_ohlc_not_trades(self, lake, monkeypatch):
+        seen: dict = {}
+        self._wire(monkeypatch, seen)
+        recent_since = int(datetime.now(timezone.utc).timestamp() * 1000) - 50 * 3600 * 1000
+        data_mod.fetch_ohlcv_chunked(SYMBOL, TF, exchange_id="kraken", since_ms=recent_since)
+        assert "trades_windows" not in seen  # trades not used for a recent window
+        assert seen.get("range_start") == recent_since
+
+    def test_default_small_fetch_uses_ohlc(self, lake, monkeypatch):
+        seen: dict = {}
+        self._wire(monkeypatch, seen)
+        data_mod.fetch_ohlcv_chunked(SYMBOL, TF, exchange_id="kraken", limit=200)
+        assert "trades_windows" not in seen
+        assert seen.get("once_since") is None  # recent-window OHLC, no since=0
+
+    def test_backfill_full_merges_not_tail_append(self, lake, monkeypatch):
+        # A trades backfill spans old→now; with a recent bar already on disk the
+        # tail-append fast-path would drop the older bars — the full merge must run.
+        data_mod.save_parquet(_bars(_closed_start(2), 1), SYMBOL, TF, source="kraken")
+        old_bars = _bars(_closed_start(200), 50)  # all older than the seeded bar
+        seen: dict = {}
+        self._wire(monkeypatch, seen, bars=old_bars)
+        old = int(datetime(2020, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
+        data_mod.fetch_ohlcv_chunked(SYMBOL, TF, exchange_id="kraken", since_ms=old)
+        after = len(data_mod.load_parquet(SYMBOL, TF))
+        assert after >= 50  # backfilled bars persisted, not dropped
+
+
+class TestTradesOhlcvBuild:
+    def test_aggregates_trades_into_bars(self, monkeypatch):
+        base = int(datetime(2021, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)  # hour-aligned
+        H = 3_600_000
+        trades = [
+            {"timestamp": base + 0, "price": 100, "amount": 1},
+            {"timestamp": base + 60_000, "price": 110, "amount": 2},
+            {"timestamp": base + 120_000, "price": 90, "amount": 1},
+            {"timestamp": base + H, "price": 200, "amount": 5},
+            {"timestamp": base + H + 60_000, "price": 190, "amount": 1},
+        ]
+        calls = {"n": 0}
+
+        def _fake(exchange, symbol, since, limit):
+            calls["n"] += 1
+            return trades if calls["n"] == 1 else []
+
+        monkeypatch.setattr(data_mod, "_fetch_trades_once", _fake)
+        df = data_mod._build_ohlcv_from_trades(object(), "BTC/USDT", "1h", base, base + 2 * H)
+        assert len(df) == 2
+        h0 = df.iloc[0]
+        assert (h0["open"], h0["high"], h0["low"], h0["close"], h0["volume"]) == (100, 110, 90, 90, 4)
+        h1 = df.iloc[1]
+        assert (h1["open"], h1["close"], h1["volume"]) == (200, 190, 6)
+
+    def test_paginates_until_partial_page(self, monkeypatch):
+        base = int(datetime(2021, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
+        H = 3_600_000
+        page1 = [{"timestamp": base + i, "price": 100 + i, "amount": 1} for i in range(data_mod.TRADES_PAGE_LIMIT)]
+        page2 = [{"timestamp": base + H + i, "price": 200, "amount": 2} for i in range(3)]
+        calls = {"n": 0}
+
+        def _fake(exchange, symbol, since, limit):
+            calls["n"] += 1
+            return {1: page1, 2: page2}.get(calls["n"], [])
+
+        monkeypatch.setattr(data_mod, "_fetch_trades_once", _fake)
+        df = data_mod._build_ohlcv_from_trades(object(), "BTC/USDT", "1h", base, base + 5 * H)
+        assert calls["n"] == 2  # full page → continue; partial page → stop
+        assert len(df) == 2
+
+    def test_drops_trades_past_end_bound(self, monkeypatch):
+        base = int(datetime(2021, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
+        H = 3_600_000
+        trades = [
+            {"timestamp": base, "price": 100, "amount": 1},
+            {"timestamp": base + H, "price": 200, "amount": 1},
+            {"timestamp": base + 3 * H, "price": 300, "amount": 1},  # past the bound
+        ]
+        monkeypatch.setattr(data_mod, "_fetch_trades_once", lambda e, s, since, limit: trades if since <= base else [])
+        df = data_mod._build_ohlcv_from_trades(object(), "BTC/USDT", "1h", base, base + 2 * H)
+        assert len(df) == 2  # hour-3 trade excluded
+
+
+# ---------------------------------------------------------------------------
+# CSV upload — headerless exchange dumps + epoch timestamps (Kraken OHLCVT).
+# ---------------------------------------------------------------------------
+
+
+class TestCsvUploadFormats:
+    # Raw Kraken OHLCVT export: no header, epoch-SECONDS ts, 7 cols.
+    KRAKEN_RAW = (
+        b"1609459200,29000.1,29100.0,28950.0,29050.5,12.5,340\n"
+        b"1609462800,29050.5,29200.0,29010.0,29180.0,8.3,210\n"
+        b"1609466400,29180.0,29250.0,29100.0,29120.0,5.1,150"
+    )
+
+    def test_headerless_epoch_seconds_upload(self, lake):
+        p = data_mod.preview_csv(self.KRAKEN_RAW)
+        assert p["detected_timestamp_column"] == "timestamp"
+        assert all(p["has_required_columns"].values())
+
+        rec = data_mod.process_csv_upload(self.KRAKEN_RAW, "XBTUSDT_60.csv", "BTC-USDT", "1h")
+        df = data_mod.load_parquet("BTC-USDT", "1h")
+        # Epoch seconds parsed to 2021, NOT 1970.
+        assert str(df["timestamp"].iloc[0]).startswith("2021-01-01")
+        assert float(df["open"].iloc[0]) == 29000.1
+        assert int(rec["row_count"]) == 3
+
+    def test_millisecond_epoch_with_header(self, lake):
+        csv = (
+            b"time,open,high,low,close,volume\n"
+            b"1609459200000,1,2,0.5,1.5,10\n"
+            b"1609462800000,1.5,2.5,1,2,12"
+        )
+        data_mod.process_csv_upload(csv, "x.csv", "ETH-USDT", "1h")
+        df = data_mod.load_parquet("ETH-USDT", "1h")
+        assert str(df["timestamp"].iloc[0]).startswith("2021-01-01")
+
+    def test_iso_string_timestamps_still_work(self, lake):
+        csv = (
+            b"timestamp,open,high,low,close,volume\n"
+            b"2021-01-01T00:00:00Z,1,2,0.5,1.5,10\n"
+            b"2021-01-01T01:00:00Z,1.5,2.5,1,2,12"
+        )
+        data_mod.process_csv_upload(csv, "y.csv", "SOL-USDT", "1h")
+        df = data_mod.load_parquet("SOL-USDT", "1h")
+        assert str(df["timestamp"].iloc[0]).startswith("2021-01-01")
+
+    def test_headerless_unknown_layout_raises_clear_error(self, lake):
+        # 4 numeric columns — not a recognized OHLCV shape.
+        bad = b"1609459200,1,2,3\n1609462800,4,5,6"
+        with pytest.raises(ValueError, match="no header row"):
+            data_mod.process_csv_upload(bad, "bad.csv", "BTC-USDT", "1h")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_data_remaining_phases.py
+++ b/tests/test_data_remaining_phases.py
@@ -110,9 +110,12 @@ class TestPerpResolution:
 
 
 # ---------------------------------------------------------------------------
-# Venue OHLC ceiling (Kraken) — an "all available" / deep-history request must
-# not send an out-of-window `since` (Kraken 400s it with EGeneral:Invalid
-# arguments); it is clamped to the recent window and flagged capped instead.
+# Venue OHLC ceiling (Kraken). Kraken's REST OHLC returns at most ~720 candles
+# per request and 400s a since=0 (EGeneral:Invalid arguments). A download must
+# NEVER hard-fail on that: an unservable request is collapsed to the recent
+# window and MERGED (accumulated history is preserved, not truncated). A warning
+# is attached ONLY when the user explicitly picked a start date older than the
+# reachable window — not for the "all available" checkbox or a default limit.
 # ---------------------------------------------------------------------------
 
 
@@ -132,6 +135,7 @@ class TestVenueOhlcvCap:
 
         def _once(exchange, symbol, timeframe, since, limit):
             seen["once_since"] = since
+            seen["once_called"] = True
             return [
                 [data_mod._to_ms(ts), r.open, r.high, r.low, r.close, r.volume]
                 for ts, r in zip(recent["timestamp"], recent.itertuples(index=False))
@@ -146,18 +150,34 @@ class TestVenueOhlcvCap:
         monkeypatch.setattr(data_mod, "get_exchange", lambda ex: object())
         monkeypatch.setattr(data_mod, "_cached_markets", lambda ex: {})
 
-    def test_all_available_kraken_clamps_and_warns(self, lake, monkeypatch):
+    def test_all_available_kraken_downloads_without_warning(self, lake, monkeypatch):
         seen: dict = {}
         self._wire(monkeypatch, seen)
 
         rec = data_mod.fetch_ohlcv_chunked(SYMBOL, TF, exchange_id="kraken", all_available=True)
 
-        # Never sent the since=0 that Kraken rejects.
+        # Downloads (never sends the since=0 that Kraken rejects) and, because
+        # "all available" got everything obtainable, does NOT flag a shortfall.
+        assert seen.get("once_called") is True
         assert seen.get("once_since") is None
-        assert seen.get("range_start") is None  # deep-history range path not taken
-        assert rec["capped"] is True
-        assert "kraken" in rec["warning"].lower()
-        assert "720" in rec["warning"]
+        assert seen.get("range_start") is None  # the since=0 range path is skipped
+        assert not rec.get("capped")
+        assert not rec.get("warning")
+
+    def test_all_available_kraken_preserves_accumulated_history(self, lake, monkeypatch):
+        # A dataset already grown past the recent window (via prior accumulation)
+        # must not be truncated to the ~720 window when "all available" re-runs.
+        old = _bars(_closed_start(5000), 4000)  # far older than the recent fetch
+        data_mod.save_parquet(old, SYMBOL, TF, source="kraken")
+        before = len(data_mod.load_parquet(SYMBOL, TF))
+        assert before == 4000
+
+        seen: dict = {}
+        self._wire(monkeypatch, seen)
+        data_mod.fetch_ohlcv_chunked(SYMBOL, TF, exchange_id="kraken", all_available=True)
+
+        after = len(data_mod.load_parquet(SYMBOL, TF))
+        assert after >= before  # merged forward, nothing dropped
 
     def test_far_past_since_kraken_clamps_and_warns(self, lake, monkeypatch):
         seen: dict = {}
@@ -179,6 +199,18 @@ class TestVenueOhlcvCap:
 
         # A satisfiable request is honoured as-is, no cap flag.
         assert seen.get("range_start") == recent_since
+        assert not rec.get("capped")
+        assert not rec.get("warning")
+
+    def test_large_limit_kraken_clamps_without_warning(self, lake, monkeypatch):
+        seen: dict = {}
+        self._wire(monkeypatch, seen)
+
+        # A bar-count request beyond the cap downloads what's available; a
+        # count is not a date selection, so no warning is raised.
+        rec = data_mod.fetch_ohlcv_chunked(SYMBOL, TF, exchange_id="kraken", limit=5000)
+
+        assert seen.get("once_since") is None  # never the crashing since=0
         assert not rec.get("capped")
         assert not rec.get("warning")
 

--- a/tests/test_data_remaining_phases.py
+++ b/tests/test_data_remaining_phases.py
@@ -278,6 +278,30 @@ class TestKrakenTradesHistory:
         after = len(data_mod.load_parquet(SYMBOL, TF))
         assert after >= 50  # backfilled bars persisted, not dropped
 
+    def test_all_available_heals_gappy_series(self, lake, monkeypatch):
+        # A stored trade-built series with no-trade holes is forward-filled to a
+        # continuous series when "all available" re-runs (even with no new data).
+        base = int(datetime(2021, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
+        H = 3_600_000
+        gappy = pd.DataFrame(
+            [
+                {"timestamp": pd.to_datetime(base, unit="ms", utc=True),
+                 "open": 100, "high": 100, "low": 100, "close": 100, "volume": 1},
+                {"timestamp": pd.to_datetime(base + 5 * H, unit="ms", utc=True),
+                 "open": 100, "high": 100, "low": 100, "close": 100, "volume": 1},
+            ]
+        )
+        data_mod.save_parquet(gappy, SYMBOL, TF, source="kraken")
+        monkeypatch.setattr(
+            data_mod, "_build_ohlcv_from_trades",
+            lambda *a, **k: data_mod._normalize_ohlcv_frame(pd.DataFrame()),
+        )
+        monkeypatch.setattr(data_mod, "get_exchange", lambda ex: object())
+        monkeypatch.setattr(data_mod, "_cached_markets", lambda ex: {})
+        data_mod.fetch_ohlcv_chunked(SYMBOL, TF, exchange_id="kraken", all_available=True)
+        df = data_mod.load_parquet(SYMBOL, TF)
+        assert len(df) == 6  # hours 0..5 now continuous
+
 
 class TestTradesOhlcvBuild:
     def test_aggregates_trades_into_bars(self, monkeypatch):
@@ -331,6 +355,39 @@ class TestTradesOhlcvBuild:
         monkeypatch.setattr(data_mod, "_fetch_trades_once", lambda e, s, since, limit: trades if since <= base else [])
         df = data_mod._build_ohlcv_from_trades(object(), "BTC/USDT", "1h", base, base + 2 * H)
         assert len(df) == 2  # hour-3 trade excluded
+
+    def test_forward_fill_fills_no_trade_gaps(self):
+        base = int(datetime(2021, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
+        H = 3_600_000
+        frame = pd.DataFrame(
+            [
+                {"timestamp": pd.to_datetime(base, unit="ms", utc=True),
+                 "open": 100, "high": 110, "low": 90, "close": 105, "volume": 5},
+                {"timestamp": pd.to_datetime(base + 3 * H, unit="ms", utc=True),
+                 "open": 130, "high": 140, "low": 125, "close": 135, "volume": 3},
+            ]
+        )
+        out = data_mod._forward_fill_ohlcv(frame, H).reset_index(drop=True)
+        assert len(out) == 4  # hours 0..3 continuous
+        h1, h2 = out.iloc[1], out.iloc[2]
+        # empty hours → flat bar at hour-0's close (105), volume 0
+        assert (h1["open"], h1["high"], h1["low"], h1["close"], h1["volume"]) == (105, 105, 105, 105, 0)
+        assert (h2["close"], h2["volume"]) == (105, 0)
+        # real bars untouched
+        assert out.iloc[0]["close"] == 105 and out.iloc[3]["close"] == 135
+
+    def test_forward_fill_noop_on_continuous(self):
+        base = int(datetime(2021, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
+        H = 3_600_000
+        frame = pd.DataFrame(
+            [
+                {"timestamp": pd.to_datetime(base + i * H, unit="ms", utc=True),
+                 "open": 1, "high": 1, "low": 1, "close": 1, "volume": 1}
+                for i in range(3)
+            ]
+        )
+        out = data_mod._forward_fill_ohlcv(frame, H)
+        assert len(out) == 3  # already continuous — unchanged
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_data_remaining_phases.py
+++ b/tests/test_data_remaining_phases.py
@@ -110,6 +110,91 @@ class TestPerpResolution:
 
 
 # ---------------------------------------------------------------------------
+# Venue OHLC ceiling (Kraken) — an "all available" / deep-history request must
+# not send an out-of-window `since` (Kraken 400s it with EGeneral:Invalid
+# arguments); it is clamped to the recent window and flagged capped instead.
+# ---------------------------------------------------------------------------
+
+
+class TestVenueOhlcvCap:
+    @pytest.fixture(autouse=True)
+    def _reset_breakers(self):
+        with data_mod._candle_breakers_lock:
+            data_mod._candle_breakers.clear()
+        yield
+        with data_mod._candle_breakers_lock:
+            data_mod._candle_breakers.clear()
+
+    def _wire(self, monkeypatch, seen: dict):
+        # Kraken returns its recent window; capture the `since` / `start_ms`
+        # each fetch path was actually handed so we can assert it was never 0.
+        recent = _bars(_closed_start(30), 10)
+
+        def _once(exchange, symbol, timeframe, since, limit):
+            seen["once_since"] = since
+            return [
+                [data_mod._to_ms(ts), r.open, r.high, r.low, r.close, r.volume]
+                for ts, r in zip(recent["timestamp"], recent.itertuples(index=False))
+            ]
+
+        def _range(exchange, sym, tf, start_ms, end_ms, *a, **k):
+            seen["range_start"] = start_ms
+            return data_mod._normalize_ohlcv_frame(recent)
+
+        monkeypatch.setattr(data_mod, "_fetch_ohlcv_once", _once)
+        monkeypatch.setattr(data_mod, "_fetch_range", _range)
+        monkeypatch.setattr(data_mod, "get_exchange", lambda ex: object())
+        monkeypatch.setattr(data_mod, "_cached_markets", lambda ex: {})
+
+    def test_all_available_kraken_clamps_and_warns(self, lake, monkeypatch):
+        seen: dict = {}
+        self._wire(monkeypatch, seen)
+
+        rec = data_mod.fetch_ohlcv_chunked(SYMBOL, TF, exchange_id="kraken", all_available=True)
+
+        # Never sent the since=0 that Kraken rejects.
+        assert seen.get("once_since") is None
+        assert seen.get("range_start") is None  # deep-history range path not taken
+        assert rec["capped"] is True
+        assert "kraken" in rec["warning"].lower()
+        assert "720" in rec["warning"]
+
+    def test_far_past_since_kraken_clamps_and_warns(self, lake, monkeypatch):
+        seen: dict = {}
+        self._wire(monkeypatch, seen)
+
+        old = int(datetime(2021, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
+        rec = data_mod.fetch_ohlcv_chunked(SYMBOL, TF, exchange_id="kraken", since_ms=old)
+
+        assert seen.get("once_since") is None  # collapsed to recent-window fetch
+        assert rec["capped"] is True
+        assert rec.get("warning")
+
+    def test_in_window_since_kraken_not_clamped(self, lake, monkeypatch):
+        seen: dict = {}
+        self._wire(monkeypatch, seen)
+
+        recent_since = int(datetime.now(timezone.utc).timestamp() * 1000) - 50 * 3600 * 1000
+        rec = data_mod.fetch_ohlcv_chunked(SYMBOL, TF, exchange_id="kraken", since_ms=recent_since)
+
+        # A satisfiable request is honoured as-is, no cap flag.
+        assert seen.get("range_start") == recent_since
+        assert not rec.get("capped")
+        assert not rec.get("warning")
+
+    def test_binance_all_available_unaffected(self, lake, monkeypatch):
+        seen: dict = {}
+        self._wire(monkeypatch, seen)
+
+        rec = data_mod.fetch_ohlcv_chunked(SYMBOL, TF, exchange_id="binance", all_available=True)
+
+        # Deep-history paging from 0 is preserved for uncapped venues.
+        assert seen.get("range_start") == 0
+        assert not rec.get("capped")
+        assert not rec.get("warning")
+
+
+# ---------------------------------------------------------------------------
 # Phase 3: candle-path circuit breaker
 # ---------------------------------------------------------------------------
 

--- a/tests/test_dataeng_foundation.py
+++ b/tests/test_dataeng_foundation.py
@@ -106,6 +106,56 @@ def test_catalog_scan_reads_partitioned_source_paths(tmp_path):
     assert row["end_ts"] == "2026-02-01T00:15:00Z"
 
 
+def test_catalog_scan_skips_unchanged_files_and_rescans_modified(tmp_path, monkeypatch):
+    from forven.dataeng import catalog as catalog_mod
+    from forven.dataeng.catalog import Catalog
+
+    data_root = tmp_path / "data"
+    parquet_path = data_root / "ohlcv" / "BTC-USDT" / "1h.parquet"
+    parquet_path.parent.mkdir(parents=True)
+
+    def write(periods: int) -> None:
+        pd.DataFrame(
+            {
+                "timestamp": pd.date_range("2026-01-01", periods=periods, freq="1h", tz="UTC"),
+                "open": [1.0] * periods,
+                "high": [2.0] * periods,
+                "low": [0.5] * periods,
+                "close": [1.5] * periods,
+                "volume": [10.0] * periods,
+            }
+        ).to_parquet(parquet_path, index=False)
+
+    write(3)
+    catalog = Catalog(tmp_path / "catalog.duckdb")
+
+    reads: list[object] = []
+    real_read = catalog_mod._read_parquet_bounds
+
+    def counting_read(path):
+        reads.append(path)
+        return real_read(path)
+
+    monkeypatch.setattr(catalog_mod, "_read_parquet_bounds", counting_read)
+
+    first = catalog.scan_lake(data_root)
+    assert [row.row_count for row in first] == [3]
+    assert len(reads) == 1
+
+    # Unchanged file: served from the persisted coverage without re-reading.
+    second = catalog.scan_lake(data_root)
+    assert len(reads) == 1
+    assert [row.row_count for row in second] == [3]
+    assert catalog.list_coverage()[0]["row_count"] == 3
+
+    # Modified file (size changes): re-read and coverage updated.
+    write(5)
+    third = catalog.scan_lake(data_root)
+    assert len(reads) == 2
+    assert [row.row_count for row in third] == [5]
+    assert catalog.list_coverage()[0]["row_count"] == 5
+
+
 def test_data_engine_settings_defaults_and_roundtrip(forven_db):
     from forven import api_core
     from forven.dataeng.settings import load_data_engine_settings


### PR DESCRIPTION
## Summary

Seven data-manager fixes/improvements that shipped together on this branch:

### Performance — Data page no longer hangs (fcc9d210)
- Root cause of the stuck **"Loading..."** Datasets tab: with the Data Engine enabled, `/api/data/engine/status` ran `catalog.scan_lake()` on every page load, re-aggregating every OHLCV parquet (364 files / 1.15 GB post-universe-seed) with a fresh DuckDB connection per file plus per-row catalog connects behind the process lock (~32s uncontended, minutes under contention).
- `scan_lake` is now **incremental** (size+mtime fingerprint over cold file + tail sidecar; batch upsert on one connection): measured **18s cold / 0.17s warm** on the real lake. `hub.status()` no longer scans at all. The Data page renders the dataset list as soon as its own request answers, with a 15s total abort budget on engine status.
- Note: first status call after the next backend restart pays the one-time cold scan to build fingerprints.

### Kraken deep history (7eeaaf85, cc20ec21, 7e083c50, 5ea1290c)
- Handle Kraken's recent-720-candles-per-request OHLC ceiling instead of crashing; collapse unservable ranges to the servable window and merge.
- "All available" downloads no longer emit a spurious cap warning (warning reserved for explicit far-past dates).
- Full Kraken history via the Trades feed + robust CSV import; trade-built candles forward-fill no-trade gaps.
- Venue-cap warnings surfaced through run → dataset detail → UI banner and the agent fetch tool.

### UI (f72e3593, 1ed39929)
- Coverage matrix capped at 480px with its own scroll + sticky header (50-symbol universe made it swallow the Overview tab).
- Maintenance tab reorganized around user intent: one **Downloads & Coverage** card with three numbered plain-English rows (Track more markets / Extend history further back / Fill recent gaps) replacing the seed/backfill/catch-up jargon spread over three cards; storage card reworded as **Data health**; Data Engine card is status-only and translates circuit-breaker states (closed/open/half-open → healthy/failing/recovering). No behavior changes.

## Testing
- All 67 data-engine/Kraken suite tests pass at the tip (`test_data_remaining_phases`, `test_dataeng_foundation` incl. new incremental-scan regression test, `test_data_engine_catchup`, `test_dataeng_streaming`).
- Wider data-family sweep: 180 passed; the 2 failures (`test_market_data_source` unclosed-bar tests) fail identically on `origin/main` locally — pre-existing, not from this branch.
- `svelte-check`: 0 errors across 707 files.
- Incremental scan benchmarked against the real 364-file lake with exact row parity cold vs warm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)