### PR TITLE
Dethrone deny-cooldown + approvals redesign, reasoning-model recovery, Live Trades badge fix

### DIFF
--- a/forven/ai.py
+++ b/forven/ai.py
@@ -86,6 +86,52 @@ _LMSTUDIO_CHAT_ENDPOINT = "/api/v1/chat"
 _ZAI_DEFAULT_BASE_URL = "https://api.z.ai/api/paas/v4"
 
 
+class EmptyProviderResponse(RuntimeError):
+    """A provider returned no usable text.
+
+    ``truncated`` is True when the emptiness came from hitting ``max_tokens``
+    (finish_reason ``length`` / stop_reason ``max_tokens``) — typically a
+    reasoning model that spent its entire output budget "thinking" before
+    emitting any answer. A larger budget can recover it, so :func:`call_ai`
+    retries the SAME provider with an escalated ``max_tokens`` before falling
+    through the chain. When ``truncated`` is False the emptiness is not
+    budget-related (a bigger request won't help) and the chain fails over.
+    """
+
+    def __init__(self, provider: str, model: str, *, truncated: bool):
+        self.provider = provider
+        self.model = model
+        self.truncated = bool(truncated)
+        hint = " (truncated at max_tokens - raise the token budget)" if truncated else ""
+        super().__init__(f"{provider}/{model} returned an empty response{hint}")
+
+
+# When a provider truncates with EMPTY output, retry the same provider with a
+# larger budget before trying the next in the chain. Jump straight to real
+# headroom on the first bump so small-budget callers recover in one step; cap at
+# a value inside typical model output limits so we never request more than a
+# model can return.
+_TRUNCATION_RETRY_FLOOR = 4096
+_TRUNCATION_RETRY_CEILING = 8192
+
+
+def _next_truncation_budget(current: int) -> int:
+    """Next ``max_tokens`` to try after a truncated-empty response, or the same
+    value when already at the ceiling (the signal to stop retrying)."""
+    current = int(current or 0)
+    if current >= _TRUNCATION_RETRY_CEILING:
+        return current
+    return min(_TRUNCATION_RETRY_CEILING, max(current * 2, _TRUNCATION_RETRY_FLOOR))
+
+
+def _openai_finish_reason(data: dict) -> str:
+    """Lowercased finish_reason of the first choice in an OpenAI-style payload."""
+    choices = data.get("choices") if isinstance(data, dict) else None
+    if isinstance(choices, list) and choices and isinstance(choices[0], dict):
+        return str(choices[0].get("finish_reason") or "").strip().lower()
+    return ""
+
+
 def _write_lmstudio_debug_event(event_type: str, payload: dict) -> None:
     """Persist LM Studio request/response metadata for local debugging."""
     try:
@@ -777,6 +823,43 @@ def _record_fallback_event(primary: str, used: str) -> None:
         pass
 
 
+async def _call_single_with_budget_retry(
+    provider: str,
+    model: str,
+    messages: list[dict],
+    max_tokens: int,
+    temperature: float,
+    system: str | None,
+    *,
+    response_schema: dict | None,
+    response_schema_name: str,
+) -> str:
+    """Call one provider, auto-escalating ``max_tokens`` when it truncates with
+    EMPTY output (a reasoning model that spent its whole budget thinking).
+
+    This is the shared "bump the budget and retry" behaviour, so every
+    ``call_ai`` caller — not just the no-code builder — recovers from a reasoning
+    model that would otherwise return nothing. Non-truncation emptiness and all
+    other errors propagate unchanged so the fallback chain can fail over.
+    """
+    budget = int(max_tokens)
+    while True:
+        try:
+            return await _call_single(
+                provider, model, messages, budget, temperature, system,
+                response_schema=response_schema, response_schema_name=response_schema_name,
+            )
+        except EmptyProviderResponse as exc:
+            nxt = _next_truncation_budget(budget)
+            if not exc.truncated or nxt <= budget:
+                raise  # not budget-related, or already at the ceiling
+            log.warning(
+                "%s/%s returned empty (truncated at max_tokens=%d) — retrying at %d",
+                provider, model, budget, nxt,
+            )
+            budget = nxt
+
+
 async def call_ai(
     provider: str,
     model: str | None = None,
@@ -823,7 +906,7 @@ async def call_ai(
             raise ValueError("call_ai(route=...) given an empty route")
     elif not fallback:
         try:
-            result = await _call_single(
+            result = await _call_single_with_budget_retry(
                 provider,
                 model,
                 messages,
@@ -857,7 +940,7 @@ async def call_ai(
     primary_fb = chain[0][0] if chain else provider
     for i, (fb_provider, fb_model) in enumerate(chain):
         try:
-            result = await _call_single(
+            result = await _call_single_with_budget_retry(
                 fb_provider,
                 fb_model,
                 messages,
@@ -1084,12 +1167,35 @@ async def _call_openai(
         resp.raise_for_status()
         data = resp.json()
 
-        text = data["choices"][0]["message"]["content"]
+        choice = (data.get("choices") or [{}])[0]
+        message = choice.get("message") if isinstance(choice, dict) else None
+        message = message if isinstance(message, dict) else {}
+        finish_reason = str(choice.get("finish_reason") or "").strip().lower() if isinstance(choice, dict) else ""
+
+        # Extract robustly: content may be a plain string, a list of typed
+        # blocks, or empty. Reasoning models (e.g. glm-* via opencode-go) can
+        # leave "content" empty and put their answer in "reasoning_content" — but
+        # ONLY trust reasoning as the answer when the model stopped normally. A
+        # `length` cutoff means the reasoning itself is unfinished thinking, not
+        # the final output, so we must not hand that back as the response.
+        text = _extract_text_from_blocks(message.get("content"))
+        if not text and finish_reason != "length":
+            text = _extract_text_from_blocks(message.get("reasoning_content"))
+
         usage = data.get("usage", {})
         log.info(
             "%s/%s: %d input, %d output tokens",
             provider_label, model, usage.get("prompt_tokens", 0), usage.get("completion_tokens", 0),
         )
+
+        if not text:
+            # A silent empty string is a failure, not a valid completion —
+            # downstream callers would parse "" and fail confusingly (e.g. the
+            # no-code builder's "Expecting value: line 1 column 1"). Raise so
+            # call_ai retries with a larger budget (reasoning models) or fails
+            # over. `length` == hit max_tokens (truncated, a bigger budget helps).
+            raise EmptyProviderResponse(provider_label, model, truncated=(finish_reason == "length"))
+
         return text
 
     raise last_error
@@ -1153,7 +1259,13 @@ async def _call_minimax(
             "minimax/%s: %d input, %d output tokens",
             model, usage.get("input_tokens", 0), usage.get("output_tokens", 0),
         )
-        return "\n".join(text_parts)
+        text = "\n".join(text_parts)
+        if not text.strip():
+            # No usable text — surface it (never silently return "") so call_ai
+            # can bump the budget on a truncation or fail over otherwise.
+            truncated = str(data.get("stop_reason") or "").strip().lower() in {"max_tokens", "length"}
+            raise EmptyProviderResponse("minimax", model, truncated=truncated)
+        return text
 
     if last_error is not None:
         raise last_error
@@ -1362,6 +1474,15 @@ async def _call_zai(
             usage.get("prompt_tokens", usage.get("input_tokens", 0)),
             usage.get("completion_tokens", usage.get("output_tokens", 0)),
         )
+        if not text:
+            # Never silently return "" — let call_ai bump the budget on a
+            # truncation (reasoning model) or fail over otherwise.
+            truncated = (
+                str(data.get("stop_reason") or "").strip().lower() == "max_tokens"
+                if anthropic_mode
+                else _openai_finish_reason(data) == "length"
+            )
+            raise EmptyProviderResponse("zai", model, truncated=truncated)
         return text
 
     if last_error is not None:

--- a/forven/brain.py
+++ b/forven/brain.py
@@ -10,7 +10,7 @@ import logging
 import re
 import sqlite3
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
@@ -38,6 +38,7 @@ from forven.workspace import (
     today_memory_path,
 )
 from forven.util import normalize_stage
+from forven.dethrone_cooldown import clear_dethrone_cooldown, dethrone_cooldown_active_until
 from forven.policy import evaluate_promotion, load_pipeline_config
 from forven.strategies.certification import certify_execution_strategy
 
@@ -611,6 +612,73 @@ def _find_active_promotion_approval(conn, strategy_id: str, requested_status: st
     ).fetchone()
 
 
+_SNAPSHOT_FORWARD_WINDOW_DAYS = 14
+
+
+def _strategy_approval_snapshot(conn, strategy_id: str) -> dict | None:
+    """Point-in-time strategy summary embedded in approval payloads.
+
+    Fail-soft by contract: returns None on any error — a broken metrics blob
+    or schema drift must never block approval creation.
+    """
+    try:
+        row = conn.execute(
+            "SELECT display_id, name, display_name, symbol, timeframe, stage, "
+            "stage_changed_at, metrics FROM strategies WHERE id = ?",
+            (strategy_id,),
+        ).fetchone()
+        if not row:
+            return None
+
+        metrics = _parse_metrics_blob(row["metrics"])
+        _, sharpe = _metric_with_key(metrics, "sharpe", "sharpe_ratio")
+        _, total_return = _metric_with_key(metrics, "total_return", "total_return_pct", "return_pct")
+        _, max_drawdown = _metric_with_key(metrics, "max_drawdown", "max_drawdown_pct", "max_dd")
+        _, trades = _metric_with_key(metrics, "trades", "num_trades", "total_trades", "trade_count")
+
+        cutoff = (
+            datetime.now(timezone.utc) - timedelta(days=_SNAPSHOT_FORWARD_WINDOW_DAYS)
+        ).isoformat()
+        forward_row = conn.execute(
+            "SELECT COUNT(*) AS c, SUM(pnl_pct) AS pnl_sum, "
+            "SUM(CASE WHEN pnl_pct > 0 THEN 1 ELSE 0 END) AS wins "
+            "FROM trades WHERE COALESCE(strategy_id, strategy) = ? "
+            "AND status = 'CLOSED' AND pnl_pct IS NOT NULL "
+            "AND datetime(closed_at) >= datetime(?)",
+            (strategy_id, cutoff),
+        ).fetchone()
+
+        return {
+            "display_id": row["display_id"],
+            "name": row["name"],
+            "display_name": row["display_name"],
+            "symbol": row["symbol"],
+            "timeframe": row["timeframe"],
+            "stage": row["stage"],
+            "stage_changed_at": row["stage_changed_at"],
+            "backtest": {
+                "sharpe": sharpe,
+                "total_return": total_return,
+                "max_drawdown": max_drawdown,
+                "trades": int(trades) if trades is not None else None,
+            },
+            "forward": {
+                "window_days": _SNAPSHOT_FORWARD_WINDOW_DAYS,
+                "closed_trades": int(forward_row["c"]) if forward_row else 0,
+                "realized_pnl_pct_sum": (
+                    round(float(forward_row["pnl_sum"]), 4)
+                    if forward_row and forward_row["pnl_sum"] is not None
+                    else None
+                ),
+                "wins": int(forward_row["wins"]) if forward_row and forward_row["wins"] is not None else 0,
+            },
+            "captured_at": datetime.now(timezone.utc).isoformat(),
+        }
+    except Exception:
+        log.warning("strategy approval snapshot failed for %s", strategy_id, exc_info=True)
+        return None
+
+
 def _queue_promotion_approval(
     conn,
     *,
@@ -619,6 +687,7 @@ def _queue_promotion_approval(
     requested_status: str,
     actor: str,
     reason: str,
+    evidence: dict | None = None,
 ) -> tuple[int, bool]:
     existing = _find_active_promotion_approval(conn, strategy_id, requested_status)
     if existing:
@@ -631,6 +700,21 @@ def _queue_promotion_approval(
     if compact_reason:
         approval_reason = f"{approval_reason}: {compact_reason[:220]}"
 
+    payload = {
+        "strategy_id": strategy_id,
+        "current_stage": current_stage,
+        "recommended_action": "promote",
+        "recommended_target_stage": requested_status,
+        "operator_required": True,
+        "trigger_actor": actor,
+        "trigger_reason": compact_reason or None,
+    }
+    if evidence:
+        payload["evidence"] = dict(evidence)
+    snapshot = _strategy_approval_snapshot(conn, strategy_id)
+    if snapshot:
+        payload["strategy_snapshot"] = snapshot
+
     approval_id = create_approval(
         _PROMOTION_APPROVAL_TYPE,
         target_type="strategy",
@@ -639,15 +723,7 @@ def _queue_promotion_approval(
         status="pending_approval",
         actor=actor,
         reason=approval_reason,
-        payload={
-            "strategy_id": strategy_id,
-            "current_stage": current_stage,
-            "recommended_action": "promote",
-            "recommended_target_stage": requested_status,
-            "operator_required": True,
-            "trigger_actor": actor,
-            "trigger_reason": compact_reason or None,
-        },
+        payload=payload,
         owner="ceo",
         conn=conn,
     )
@@ -666,6 +742,64 @@ def _requires_operator_dethrone_approval(current_stage: str, target_stage: str) 
     if current_rank is None or target_rank is None:
         return False
     return target_rank < current_rank
+
+
+def _paper_dethrone_soak_block(conn, strategy_id: str, current_stage: str) -> str | None:
+    """Paper soak guard: no dethrone RECOMMENDATION until the strategy has had
+    a real chance to prove itself.
+
+    Hard floor of dethrone.paper_min_soak_days; between the floor and
+    dethrone.paper_max_soak_days the strategy stays protected while it has
+    fewer than dethrone.paper_min_closed_trades closed paper trades in the
+    current stay (low-frequency strategies may execute once a week or less).
+    Returns a human-readable block reason while protected, else None.
+    Fail-open: unreadable config/rows allow the recommendation.
+    """
+    if _normalize_stage(current_stage) != "paper":
+        return None
+    try:
+        cfg = load_pipeline_config().get("dethrone") or {}
+        min_days = float(cfg.get("paper_min_soak_days", 7))
+        max_days = float(cfg.get("paper_max_soak_days", 14))
+        min_trades = int(cfg.get("paper_min_closed_trades", 5))
+        if min_days <= 0 and max_days <= 0:
+            return None
+
+        row = conn.execute(
+            "SELECT stage_changed_at FROM strategies WHERE id = ?", (strategy_id,)
+        ).fetchone()
+        stage_changed_raw = str(row["stage_changed_at"] or "").strip() if row else ""
+        if not stage_changed_raw:
+            return None
+        stage_changed = datetime.fromisoformat(stage_changed_raw)
+        if stage_changed.tzinfo is None:
+            stage_changed = stage_changed.replace(tzinfo=timezone.utc)
+        age_days = (datetime.now(timezone.utc) - stage_changed).total_seconds() / 86400.0
+
+        if age_days >= max(min_days, max_days):
+            return None
+        if age_days < min_days:
+            return (
+                f"paper soak: {age_days:.1f}d of the {min_days:.0f}d minimum before "
+                f"dethrone recommendations"
+            )
+        trade_row = conn.execute(
+            "SELECT COUNT(*) AS c FROM trades "
+            "WHERE COALESCE(strategy_id, strategy) = ? AND status = 'CLOSED' "
+            "AND LOWER(COALESCE(execution_type, '')) LIKE 'paper%' "
+            "AND datetime(closed_at) >= datetime(?)",
+            (strategy_id, stage_changed_raw),
+        ).fetchone()
+        closed_trades = int(trade_row["c"]) if trade_row else 0
+        if closed_trades < min_trades:
+            return (
+                f"paper soak extended: only {closed_trades}/{min_trades} closed paper "
+                f"trades in {age_days:.1f}d (protected until {max_days:.0f}d)"
+            )
+        return None
+    except Exception:
+        log.warning("paper dethrone soak check failed for %s", strategy_id, exc_info=True)
+        return None
 
 
 def _find_active_dethrone_approval(
@@ -701,6 +835,7 @@ def _queue_dethrone_approval(
     requested_status: str,
     actor: str,
     reason: str,
+    evidence: dict | None = None,
 ) -> tuple[int, bool]:
     existing = _find_active_dethrone_approval(conn, strategy_id, requested_status)
     if existing:
@@ -713,6 +848,21 @@ def _queue_dethrone_approval(
     if compact_reason:
         approval_reason = f"{approval_reason}: {compact_reason[:220]}"
 
+    payload = {
+        "strategy_id": strategy_id,
+        "current_stage": current_stage,
+        "recommended_action": "dethrone",
+        "recommended_target_stage": requested_status,
+        "operator_required": True,
+        "trigger_actor": actor,
+        "trigger_reason": compact_reason or None,
+    }
+    if evidence:
+        payload["evidence"] = dict(evidence)
+    snapshot = _strategy_approval_snapshot(conn, strategy_id)
+    if snapshot:
+        payload["strategy_snapshot"] = snapshot
+
     approval_id = create_approval(
         _DETHRONE_APPROVAL_TYPE,
         target_type="strategy",
@@ -721,15 +871,7 @@ def _queue_dethrone_approval(
         status="pending_approval",
         actor=actor,
         reason=approval_reason,
-        payload={
-            "strategy_id": strategy_id,
-            "current_stage": current_stage,
-            "recommended_action": "dethrone",
-            "recommended_target_stage": requested_status,
-            "operator_required": True,
-            "trigger_actor": actor,
-            "trigger_reason": compact_reason or None,
-        },
+        payload=payload,
         owner="ceo",
         conn=conn,
     )
@@ -1258,6 +1400,7 @@ def transition_stage(
     notes: str | None = None,
     force: bool = False,
     skip_approval_gate: bool = False,
+    evidence: dict | None = None,
 ) -> dict[str, str | None]:
     """Move a strategy between lifecycle stages in one atomic update path."""
     normalized_target = _normalize_stage(target_stage)
@@ -1368,6 +1511,29 @@ def transition_stage(
             raise ValueError(f"Invalid transition: {current_stage} -> {normalized_target}")
 
         if _requires_operator_dethrone_approval(current_stage, normalized_target) and not force:
+            # Deny cooldown: the operator recently rejected a dethrone rec for
+            # this strategy, so background demotion attempts stay blocked
+            # WITHOUT re-filing a new approval until the window expires.
+            # Fail-open on read errors — the safe fallback is surfacing the
+            # approval, not suppressing recommendations forever.
+            try:
+                cooldown_until = dethrone_cooldown_active_until(strategy_id, conn=conn)
+            except Exception:
+                cooldown_until = None
+            if cooldown_until:
+                return _record_blocked_transition(
+                    (
+                        f"Dethrone suppressed: operator denied a recent recommendation "
+                        f"for {strategy_id} (cooldown until {cooldown_until})"
+                    ),
+                    "dethrone_cooldown_active",
+                )
+            soak_block = _paper_dethrone_soak_block(conn, strategy_id, current_stage)
+            if soak_block:
+                return _record_blocked_transition(
+                    f"Dethrone suppressed: {soak_block}",
+                    "dethrone_soak_active",
+                )
             approval_id, reused = _queue_dethrone_approval(
                 conn,
                 strategy_id=strategy_id,
@@ -1375,6 +1541,7 @@ def transition_stage(
                 requested_status=normalized_target,
                 actor=actor,
                 reason=reason,
+                evidence=evidence,
             )
             action = "Existing dethrone approval reused" if reused else "Dethrone approval queued"
             blocked = _record_blocked_transition(
@@ -1595,6 +1762,7 @@ def transition_stage(
                 requested_status=normalized_target,
                 actor=actor,
                 reason=reason,
+                evidence=evidence,
             )
             action = "Existing promotion approval reused" if reused else "Promotion approval queued"
             blocked = _record_blocked_transition(
@@ -1785,6 +1953,15 @@ def transition_stage(
                 strategy_id,
             ),
         )
+
+        # The strategy actually left its operator-owned stage — any deny
+        # cooldown belongs to the stay that just ended. Uses the held conn
+        # (nested kv writes here would self-deadlock on the WAL writer lock).
+        if current_stage in _OPERATOR_OWNED_STAGES and normalized_target != current_stage:
+            try:
+                clear_dethrone_cooldown(strategy_id, conn=conn)
+            except Exception:
+                log.warning("dethrone cooldown clear failed for %s", strategy_id, exc_info=True)
 
         conn.execute(
             "INSERT INTO strategy_events "

--- a/forven/control_plane/approvals.py
+++ b/forven/control_plane/approvals.py
@@ -1,6 +1,6 @@
 import json
 from collections.abc import Mapping
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Any
 
 from fastapi import HTTPException
@@ -12,7 +12,6 @@ from forven.db import (
     create_task_container,
     get_approval,
     get_db,
-    kv_set,
     list_approvals,
     log_activity,
     update_approval,
@@ -23,6 +22,12 @@ from forven.control_plane.models import (
     ApprovalHandoffBody,
     ApprovalTroubleshootBody,
 )
+from forven.dethrone_cooldown import (
+    clear_dethrone_cooldown,
+    dethrone_cooldown_active_until,
+    get_dethrone_cooldown_state,
+    record_dethrone_deny,
+)
 
 _ACTIVE_TASK_STATUSES = {"pending", "running", "blocked"}
 _DETHRONE_APPROVAL_TYPE = "strategy_dethrone_recommendation"
@@ -31,7 +36,6 @@ _PROMOTION_APPROVAL_TYPE = "strategy_promotion_approval"
 _REGIME_CHAMPION_APPROVAL_TYPE = "regime_champion_promotion"
 _SKILL_UPDATE_APPROVAL_TYPE = "skill_update_proposal"
 _ROUTINE_CREATE_APPROVAL_TYPE = "routine_create"
-_DETHRONE_COOLDOWN_HOURS = 24
 _TASK_SUMMARY_COLUMNS = """
     id,
     display_id,
@@ -313,24 +317,6 @@ def _recommended_mode(
     return "diagnosis"
 
 
-def _dethrone_cooldown_key(strategy_id: str) -> str:
-    return f"forven:dethrone:cooldown:{strategy_id}"
-
-
-def _clear_dethrone_cooldown(strategy_id: str) -> None:
-    if not strategy_id:
-        return
-    kv_set(_dethrone_cooldown_key(strategy_id), None)
-
-
-def _set_dethrone_cooldown(strategy_id: str) -> str:
-    if not strategy_id:
-        return ""
-    until = datetime.now(timezone.utc) + timedelta(hours=_DETHRONE_COOLDOWN_HOURS)
-    kv_set(_dethrone_cooldown_key(strategy_id), until.isoformat())
-    return until.isoformat()
-
-
 def _apply_dethrone_recommendation(
     approval: Mapping[str, object],
     body: ApprovalDecisionBody,
@@ -392,7 +378,7 @@ def _apply_dethrone_recommendation(
     if blocked_reason:
         raise HTTPException(status_code=400, detail=f"Dethrone transition blocked: {blocked_reason}")
 
-    _clear_dethrone_cooldown(strategy_id)
+    clear_dethrone_cooldown(strategy_id)
     return {
         "strategy_id": strategy_id,
         "target_stage": recommended_target,
@@ -671,6 +657,82 @@ def get_approvals_list(
     return _augment_approval_rows(rows)
 
 
+def _strategy_approval_context(target_id: str) -> dict[str, object] | None:
+    """Live decision context for a strategy-targeted approval.
+
+    Fail-soft by contract: any error returns None — the context endpoint must
+    never break because a strategy row or its metrics blob is unhealthy.
+    """
+    strategy_id = str(target_id or "").strip()
+    if not strategy_id:
+        return None
+    try:
+        with get_db() as conn:
+            row = conn.execute(
+                "SELECT id, display_id, name, display_name, symbol, timeframe, stage, "
+                "stage_changed_at, metrics FROM strategies WHERE id = ?",
+                (strategy_id,),
+            ).fetchone()
+            if not row:
+                return None
+
+            sharpe = None
+            try:
+                metrics = json.loads(row["metrics"]) if row["metrics"] else {}
+                if isinstance(metrics, dict):
+                    for key in ("sharpe", "sharpe_ratio"):
+                        if metrics.get(key) is not None:
+                            sharpe = float(metrics[key])
+                            break
+            except Exception:
+                sharpe = None
+
+            history: dict[str, object] = {
+                "pending": 0,
+                "approved": 0,
+                "denied": 0,
+                "expired": 0,
+                "last_denied_at": None,
+            }
+            for hist_row in conn.execute(
+                "SELECT LOWER(status) AS s, COUNT(*) AS c, MAX(decided_at) AS last_decided "
+                "FROM approvals WHERE approval_type = ? AND target_type = 'strategy' "
+                "AND LOWER(COALESCE(target_id, '')) = LOWER(?) GROUP BY LOWER(status)",
+                (_DETHRONE_APPROVAL_TYPE, strategy_id),
+            ):
+                status = str(hist_row["s"] or "")
+                if status == "pending_approval":
+                    status = "pending"
+                if status in history:
+                    history[status] = int(hist_row["c"])
+                if status == "denied":
+                    history["last_denied_at"] = hist_row["last_decided"]
+
+        cooldown_state = get_dethrone_cooldown_state(strategy_id)
+        active_until = dethrone_cooldown_active_until(strategy_id)
+        return {
+            "strategy": {
+                "id": row["id"],
+                "display_id": row["display_id"],
+                "name": row["name"],
+                "display_name": row["display_name"],
+                "symbol": row["symbol"],
+                "timeframe": row["timeframe"],
+                "stage": row["stage"],
+                "stage_changed_at": row["stage_changed_at"],
+                "sharpe": sharpe,
+            },
+            "dethrone_history": history,
+            "cooldown": {
+                "active": active_until is not None,
+                "until": active_until,
+                "deny_count": cooldown_state.get("deny_count", 0),
+            },
+        }
+    except Exception:
+        return None
+
+
 def get_approval_context(approval_id: int) -> dict[str, object]:
     approval = get_approval(approval_id)
     if not approval:
@@ -679,12 +741,16 @@ def get_approval_context(approval_id: int) -> dict[str, object]:
     enriched = _augment_approval_rows([approval])[0]
     linked_task = enriched.get("linked_task")
     troubleshoot_task = enriched.get("troubleshoot_task")
+    strategy_context = None
+    if str(approval.get("target_type") or "").strip().lower() == "strategy":
+        strategy_context = _strategy_approval_context(str(approval.get("target_id") or ""))
     return {
         "approval": enriched,
         "linked_task": linked_task,
         "troubleshoot_task": troubleshoot_task,
         "linked_task_detail": _task_detail(linked_task if isinstance(linked_task, Mapping) else None),
         "troubleshoot_task_detail": _task_detail(troubleshoot_task if isinstance(troubleshoot_task, Mapping) else None),
+        "strategy_context": strategy_context,
         "recommended_mode": _recommended_mode(
             enriched,
             linked_task if isinstance(linked_task, Mapping) else None,
@@ -971,7 +1037,7 @@ def post_deny_approval(approval_id: int, body: ApprovalDecisionBody) -> dict[str
     if approval_type == _DETHRONE_APPROVAL_TYPE:
         payload = _approval_payload(approval)
         strategy_id = str(payload.get("strategy_id") or approval.get("target_id") or "").strip()
-        cooldown_until = _set_dethrone_cooldown(strategy_id)
+        cooldown_state = record_dethrone_deny(strategy_id)
         log_activity(
             "info",
             "operator",
@@ -979,7 +1045,8 @@ def post_deny_approval(approval_id: int, body: ApprovalDecisionBody) -> dict[str
             {
                 "approval_id": approval_id,
                 "strategy_id": strategy_id,
-                "cooldown_until": cooldown_until or None,
+                "cooldown_until": cooldown_state.get("until"),
+                "deny_count": cooldown_state.get("deny_count"),
                 "feedback": body.feedback,
                 "reason": body.reason,
             },
@@ -989,7 +1056,8 @@ def post_deny_approval(approval_id: int, body: ApprovalDecisionBody) -> dict[str
             "approval_id": approval_id,
             "status": updated["status"] if updated else "denied",
             "strategy_id": strategy_id or None,
-            "cooldown_until": cooldown_until or None,
+            "cooldown_until": cooldown_state.get("until"),
+            "deny_count": cooldown_state.get("deny_count"),
         }
 
     if approval_type == _CRUCIBLE_DETHRONE_APPROVAL_TYPE:

--- a/forven/control_plane/approvals.py
+++ b/forven/control_plane/approvals.py
@@ -1167,8 +1167,6 @@ def post_handoff_approval(approval_id: int, body: ApprovalHandoffBody) -> dict[s
 
 def post_user_complete_approval(approval_id: int, body: ApprovalDecisionBody) -> dict[str, object]:
     """Mark the linked task as done by the user and notify the Brain."""
-    from datetime import datetime, timezone
-
     approval = get_approval(approval_id)
     if not approval:
         raise HTTPException(status_code=404, detail=f"Approval {approval_id} not found")

--- a/forven/control_plane/status.py
+++ b/forven/control_plane/status.py
@@ -277,15 +277,34 @@ def _build_nav_indicator(
 
 
 
+def _is_live_open_trade(trade: dict[str, Any]) -> bool:
+    """True only for REAL live exchange exposure.
+
+    ``read_open_trades`` returns every OPEN row — paper AND live — so the
+    "Live Trades" badge must not count paper positions (that would show, e.g.,
+    12 when there are zero live positions). A row is live when its
+    ``execution_type`` is 'live', or when it's a synthetic exchange-only
+    position (``source='exchange'``) appended from a real HyperLiquid position
+    that carries no ``execution_type``.
+    """
+    execution_type = str(trade.get("execution_type") or "").strip().lower()
+    if execution_type == "live":
+        return True
+    if execution_type in {"paper", "replay"}:
+        return False
+    return str(trade.get("source") or "").strip().lower() == "exchange"
+
+
 def _build_live_trades_nav_indicator(open_trades: list[dict[str, Any]]) -> dict[str, object]:
-    live_trade_count = len(open_trades)
+    live_trades = [trade for trade in open_trades if _is_live_open_trade(trade)]
+    live_trade_count = len(live_trades)
     if live_trade_count > 0:
         return _build_nav_indicator(
             "count",
             "info",
             str(live_trade_count),
             f"{_pluralize(live_trade_count, 'live trade')} open",
-            _build_seen_key("trades-live", [trade.get("id") or trade.get("trade_id") for trade in open_trades[:8]]),
+            _build_seen_key("trades-live", [trade.get("id") or trade.get("trade_id") for trade in live_trades[:8]]),
             count=live_trade_count,
         )
     return _empty_nav_indicator()

--- a/forven/dethrone_cooldown.py
+++ b/forven/dethrone_cooldown.py
@@ -1,0 +1,167 @@
+"""Shared dethrone deny-cooldown state.
+
+When the operator DENIES a strategy_dethrone_recommendation approval, the
+strategy enters a deny cooldown: every dethrone-approval creation path
+(brain.transition_stage's operator gate, policy's challenger/repeated-failure
+paths) suppresses new recommendations for that strategy until the cooldown
+expires. Repeated denials escalate the window (24h -> 72h -> 168h). The
+cooldown clears when a dethrone approval is APPROVED or when the strategy
+actually leaves an operator-owned stage.
+
+This is a leaf module (imports only forven.db, lazily) so brain, policy and
+control_plane can all import it at module top without cycles.
+
+Every function takes an optional ``conn``. brain.transition_stage holds the
+single WAL writer connection for its whole body, so any kv read/write made
+from inside it MUST go through that connection — opening a nested get_db()
+write there self-deadlocks. Callers outside a held transaction can omit
+``conn`` and get the ordinary kv helpers.
+"""
+
+import json
+import logging
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+log = logging.getLogger("forven.dethrone_cooldown")
+
+_COOLDOWN_KEY_PREFIX = "forven:dethrone:cooldown:"
+
+# Escalating deny windows: 1st deny, 2nd deny, 3rd-and-later denies.
+DENY_COOLDOWN_ESCALATION_HOURS = (24, 72, 168)
+
+
+def _cooldown_key(strategy_id: str) -> str:
+    return f"{_COOLDOWN_KEY_PREFIX}{str(strategy_id or '').strip()}"
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_iso_utc(value: object) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).strip())
+    except Exception:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _kv_read(key: str, conn=None):
+    if conn is not None:
+        try:
+            row = conn.execute("SELECT value FROM kv WHERE key = ?", (key,)).fetchone()
+        except sqlite3.OperationalError as exc:
+            if "no such table: kv" in str(exc).lower():
+                return None
+            raise
+        if not row:
+            return None
+        raw_value = row["value"]
+        if isinstance(raw_value, (str, bytes, bytearray)):
+            try:
+                return json.loads(raw_value)
+            except Exception:
+                return None
+        return raw_value
+
+    from forven.db import kv_get
+
+    return kv_get(key)
+
+
+def _kv_write(key: str, value, conn=None) -> None:
+    if conn is not None:
+        conn.execute(
+            "INSERT OR REPLACE INTO kv (key, value, updated_at) VALUES (?, ?, ?)",
+            (key, json.dumps(value), _now_utc().isoformat()),
+        )
+        return
+
+    from forven.db import kv_set
+
+    kv_set(key, value)
+
+
+def get_dethrone_cooldown_state(strategy_id: str, conn=None) -> dict:
+    """Current cooldown state: {"until", "deny_count", "last_denied_at"}.
+
+    Legacy compatibility: values written before escalation existed were a bare
+    ISO expiry string — those parse as deny_count=1 with that expiry.
+    """
+    empty = {"until": None, "deny_count": 0, "last_denied_at": None}
+    strategy_id = str(strategy_id or "").strip()
+    if not strategy_id:
+        return empty
+    try:
+        raw = _kv_read(_cooldown_key(strategy_id), conn=conn)
+    except Exception:
+        log.warning("dethrone cooldown read failed for %s", strategy_id, exc_info=True)
+        return empty
+    if isinstance(raw, str) and raw.strip():
+        return {"until": raw.strip(), "deny_count": 1, "last_denied_at": None}
+    if isinstance(raw, dict):
+        try:
+            deny_count = max(0, int(raw.get("deny_count") or 0))
+        except Exception:
+            deny_count = 0
+        until = raw.get("until")
+        return {
+            "until": str(until).strip() if until else None,
+            "deny_count": deny_count,
+            "last_denied_at": raw.get("last_denied_at") or None,
+        }
+    return empty
+
+
+def dethrone_cooldown_active_until(strategy_id: str, conn=None) -> str | None:
+    """ISO expiry while the deny cooldown is active, else None.
+
+    The stored value IS the expiry timestamp. Unparseable values fail OPEN
+    (None): the safe fallback for this gate is "surface the approval", not
+    "suppress recommendations forever".
+    """
+    state = get_dethrone_cooldown_state(strategy_id, conn=conn)
+    until = _parse_iso_utc(state.get("until"))
+    if until is None:
+        return None
+    if _now_utc() < until:
+        return until.isoformat()
+    return None
+
+
+def record_dethrone_deny(strategy_id: str, conn=None) -> dict:
+    """Bump the deny count and arm the escalated cooldown; returns new state.
+
+    The prior deny_count is honored even when the previous window already
+    expired, so a strategy the operator keeps denying escalates 24h -> 72h ->
+    168h instead of restarting at 24h each time.
+    """
+    strategy_id = str(strategy_id or "").strip()
+    if not strategy_id:
+        return {"until": None, "deny_count": 0, "last_denied_at": None}
+    prior = get_dethrone_cooldown_state(strategy_id, conn=conn)
+    deny_count = int(prior.get("deny_count") or 0) + 1
+    hours = DENY_COOLDOWN_ESCALATION_HOURS[
+        min(deny_count - 1, len(DENY_COOLDOWN_ESCALATION_HOURS) - 1)
+    ]
+    now = _now_utc()
+    state = {
+        "until": (now + timedelta(hours=hours)).isoformat(),
+        "deny_count": deny_count,
+        "last_denied_at": now.isoformat(),
+    }
+    _kv_write(_cooldown_key(strategy_id), state, conn=conn)
+    return state
+
+
+def clear_dethrone_cooldown(strategy_id: str, conn=None) -> None:
+    """Reset the cooldown AND the deny count (approve / stage-exit path)."""
+    strategy_id = str(strategy_id or "").strip()
+    if not strategy_id:
+        return
+    _kv_write(_cooldown_key(strategy_id), None, conn=conn)

--- a/forven/monitoring.py
+++ b/forven/monitoring.py
@@ -200,6 +200,15 @@ def run_decay_tracker(
                 reason=candidate["note"],
                 actor="decay_tracker",
                 notes=candidate["merged_notes"],
+                evidence={
+                    "trigger": "decay_tracker",
+                    "baseline_sharpe": candidate["baseline_sharpe"],
+                    "live_sharpe_72h": candidate["live_sharpe_72h"],
+                    "degradation": candidate["degradation"],
+                    "trade_count_72h": candidate["trade_count_72h"],
+                    "window_hours": window_hours,
+                    "degradation_threshold": degradation_threshold,
+                },
             )
             status_after = str(transition.get("to") or demote_status)
             candidate["status_after"] = status_after
@@ -208,6 +217,7 @@ def run_decay_tracker(
                     {
                         "strategy_id": strategy_id,
                         "reason": "approval_required",
+                        "reason_code": transition.get("reason_code"),
                         "requested_status": demote_status,
                         "current_status": status_after,
                         "approval_id": transition.get("approval_id"),

--- a/forven/policy.py
+++ b/forven/policy.py
@@ -9,6 +9,7 @@ from statistics import mean, pstdev
 from typing import Any
 
 from forven.db import create_approval, get_db, kv_get, kv_set, log_activity, log_gate_rejection
+from forven.dethrone_cooldown import dethrone_cooldown_active_until
 
 from forven.gauntlet.legitimacy import validate_robustness_payload
 from forven.util import normalize_stage
@@ -223,6 +224,17 @@ DEFAULT_PIPELINE_CONFIG = {
         # OOS Sharpe may not exceed IS Sharpe by more than this ratio (OOS>>IS
         # signals a lucky/overfit OOS window).
         "max_oos_is_ratio": 1.5,
+    },
+    "dethrone": {
+        # Paper soak protection (2026-07-06 operator request): a paper strategy
+        # may not be RECOMMENDED for dethrone until it has had a chance to
+        # prove itself. Hard floor of paper_min_soak_days; low-frequency
+        # strategies (fewer than paper_min_closed_trades forward executions —
+        # some trade once a week or less) stay protected up to
+        # paper_max_soak_days. Operator force-demotions bypass this entirely.
+        "paper_min_soak_days": 7,
+        "paper_max_soak_days": 14,
+        "paper_min_closed_trades": 5,
     },
     "live_graduated": {
         "allocation_schedule": [
@@ -2598,7 +2610,6 @@ _EVIDENCE_ABSENCE_REASON_CODES = {
 }
 _DETHRONE_APPROVAL_TYPE = "strategy_dethrone_recommendation"
 _DETHRONE_MANUAL_STAGES = {"paper", "paper_trading", "live_graduated", "deployed"}
-_DETHRONE_REVIEW_COOLDOWN_HOURS = 24
 
 
 def _resolve_dethrone_target_stage(current_stage: str) -> str:
@@ -2608,23 +2619,6 @@ def _resolve_dethrone_target_stage(current_stage: str) -> str:
     if normalized in {"live_graduated", "deployed"}:
         return "paper"
     return "archived"
-
-
-def _dethrone_cooldown_key(strategy_id: str) -> str:
-    return f"forven:dethrone:cooldown:{strategy_id}"
-
-
-def _is_dethrone_cooldown_active(strategy_id: str) -> bool:
-    raw = kv_get(_dethrone_cooldown_key(strategy_id))
-    if not isinstance(raw, str) or not raw.strip():
-        return False
-    try:
-        ts = datetime.fromisoformat(raw.strip())
-    except Exception:
-        return False
-    if ts.tzinfo is None:
-        ts = ts.replace(tzinfo=timezone.utc)
-    return datetime.now(timezone.utc) < (ts + timedelta(hours=_DETHRONE_REVIEW_COOLDOWN_HOURS))
 
 
 def _queue_dethrone_recommendation(
@@ -2912,7 +2906,45 @@ def _queue_challenger_dethrone(
     if pending:
         return int(pending["id"])
 
-    recommended_target_stage = _resolve_dethrone_target_stage(incumbent_stage)
+    if dethrone_cooldown_active_until(incumbent_id, conn=conn):
+        logging.getLogger("forven.policy").info(
+            "challenger dethrone suppressed by deny cooldown: %s", incumbent_id
+        )
+        return None
+
+    try:
+        from forven.brain import _paper_dethrone_soak_block
+
+        soak_block = _paper_dethrone_soak_block(conn, incumbent_id, incumbent_stage)
+    except Exception:
+        soak_block = None
+    if soak_block:
+        logging.getLogger("forven.policy").info(
+            "challenger dethrone suppressed for %s: %s", incumbent_id, soak_block
+        )
+        return None
+
+    payload = {
+        "strategy_id": incumbent_id,
+        "current_stage": incumbent_stage,
+        "trigger": "superior_challenger",
+        "challenger_id": challenger_id,
+        "challenger_sharpe": challenger_sharpe,
+        "incumbent_sharpe": incumbent_sharpe,
+        "recommended_action": "dethrone",
+        "recommended_target_stage": _resolve_dethrone_target_stage(incumbent_stage),
+        "operator_required": True,
+    }
+    try:
+        from forven.brain import _strategy_approval_snapshot
+
+        snapshot = _strategy_approval_snapshot(conn, incumbent_id)
+        if snapshot:
+            payload["strategy_snapshot"] = snapshot
+    except Exception:
+        pass
+
+    recommended_target_stage = payload["recommended_target_stage"]
     approval_id = create_approval(
         approval_type=_DETHRONE_APPROVAL_TYPE,
         target_type="strategy",
@@ -2924,17 +2956,7 @@ def _queue_challenger_dethrone(
             f"Dethrone recommendation: challenger {challenger_id} (Sharpe {challenger_sharpe}) "
             f"materially beats incumbent {incumbent_id} (Sharpe {incumbent_sharpe}) on the same slot"
         ),
-        payload={
-            "strategy_id": incumbent_id,
-            "current_stage": incumbent_stage,
-            "trigger": "superior_challenger",
-            "challenger_id": challenger_id,
-            "challenger_sharpe": challenger_sharpe,
-            "incumbent_sharpe": incumbent_sharpe,
-            "recommended_action": "dethrone",
-            "recommended_target_stage": recommended_target_stage,
-            "operator_required": True,
-        },
+        payload=payload,
         owner="ceo",
         conn=conn,
     )
@@ -3091,7 +3113,7 @@ def _check_repeated_failure_auto_archive(
                         strategy_id, current_stage, failure_count, gate, reason_code,
                     )
                     return
-                if _is_dethrone_cooldown_active(strategy_id):
+                if dethrone_cooldown_active_until(strategy_id, conn=conn):
                     return
                 approval_id = _queue_dethrone_recommendation(
                     conn=conn,

--- a/forven/strategies/nl_spec_gen.py
+++ b/forven/strategies/nl_spec_gen.py
@@ -23,6 +23,14 @@ from forven.strategies.builtin.rule_engine import (
     validate_rule_spec,
 )
 
+# Reasoning models (e.g. glm-5.2 via opencode-go) spend output tokens "thinking"
+# before emitting the spec — a tight cap truncates the JSON, or empties it
+# entirely when the reasoning alone exhausts the budget. Give generous headroom,
+# then retry once even larger if the first response comes back empty/truncated.
+# For non-reasoning models these are just ceilings (they stop at the spec), so a
+# larger budget costs nothing extra there.
+_NL_SPEC_TOKEN_BUDGETS: tuple[int, ...] = (4000, 8000)
+
 
 def _build_system_prompt() -> str:
     lines: list[str] = []
@@ -93,6 +101,26 @@ def _normalize_spec(obj: object) -> dict:
     }
 
 
+def _parse_failure_message(raw: object, exc: Exception | None) -> str:
+    """Actionable message for a response we couldn't turn into a spec.
+
+    Distinguishes an *empty* reply (the model spent its whole budget reasoning)
+    from *truncated* JSON (it ran out mid-spec), rather than the raw, opaque
+    ``json.loads`` error the UI used to show.
+    """
+    if not str(raw or "").strip():
+        return (
+            "The AI model returned an empty response — it likely used its entire "
+            "output budget reasoning before writing the strategy. Try a shorter, "
+            "simpler description, or choose a non-reasoning model in Settings."
+        )
+    return (
+        "The AI response was cut off before a complete strategy spec was produced. "
+        "Try simplifying the idea or switching models in Settings."
+        + (f" ({exc})" if exc is not None else "")
+    )
+
+
 async def nl_to_rule_spec(*, description: str, symbol: str = "BTC", timeframe: str = "1h") -> dict:
     """Return ``{valid, spec, errors, warnings, provider}``.
 
@@ -124,22 +152,46 @@ async def nl_to_rule_spec(*, description: str, symbol: str = "BTC", timeframe: s
         f"Strategy idea:\n{description}\n\n"
         "Return ONLY the JSON rule spec."
     )
-    try:
-        raw = await ai.call_ai(provider, prompt=user, system=system, max_tokens=1600, temperature=0.1)
-    except Exception as exc:  # noqa: BLE001 — surface a friendly message to the UI
-        return {"valid": False, "spec": None, "errors": [f"AI request failed: {exc}"], "warnings": [], "provider": provider}
+    raw: str = ""
+    spec: dict | None = None
+    call_error: Exception | None = None
+    parse_error: Exception | None = None
+    for max_tokens in _NL_SPEC_TOKEN_BUDGETS:
+        try:
+            raw = await ai.call_ai(
+                provider, prompt=user, system=system, max_tokens=max_tokens, temperature=0.1
+            )
+            call_error = None
+        except Exception as exc:  # noqa: BLE001 — an empty/truncated reply now raises here
+            call_error = exc
+            raw = ""
+            continue  # a larger budget may let a reasoning model finish
+        try:
+            spec = _normalize_spec(_extract_json(raw))
+            parse_error = None
+            break
+        except Exception as exc:  # noqa: BLE001 — usually truncated JSON; retry bigger
+            parse_error = exc
 
-    try:
-        spec = _normalize_spec(_extract_json(raw))
-    except Exception as exc:  # noqa: BLE001
+    if spec is not None:
+        errors = validate_rule_spec(spec)
+        return {"valid": len(errors) == 0, "spec": spec, "errors": errors, "warnings": [], "provider": provider}
+
+    if parse_error is not None:
+        # We got text back but couldn't complete a spec — almost always a
+        # reasoning model truncated past its budget. Give the actionable message.
         return {
             "valid": False, "spec": None,
-            "errors": [f"Could not parse a rule spec from the AI response: {exc}"],
+            "errors": [_parse_failure_message(raw, parse_error)],
             "warnings": [], "provider": provider, "raw": str(raw)[:2000],
         }
-
-    errors = validate_rule_spec(spec)
-    return {"valid": len(errors) == 0, "spec": spec, "errors": errors, "warnings": [], "provider": provider}
+    # Never got a usable response at all. call_error now carries the client's
+    # "empty response (truncated at max_tokens)" detail for reasoning models.
+    return {
+        "valid": False, "spec": None,
+        "errors": [f"AI request failed: {call_error}"],
+        "warnings": [], "provider": provider,
+    }
 
 
 __all__ = ["nl_to_rule_spec"]

--- a/forven/strategy_lifecycle.py
+++ b/forven/strategy_lifecycle.py
@@ -1123,6 +1123,21 @@ def set_strategy_display_name(strategy_id: str, display_name: str | None, actor:
     }
 
 
+def _is_stage_demotion(current_status: str, target_status: str) -> bool:
+    """True when the move is strictly DOWN the stage progression.
+
+    Fail-soft: unknown stages read as not-a-demotion, which preserves the
+    old (neutered-force) behavior.
+    """
+    try:
+        from forven.brain import _STAGE_PROGRESS_RANK
+    except Exception:
+        return False
+    current_rank = _STAGE_PROGRESS_RANK.get(str(current_status or "").strip().lower())
+    target_rank = _STAGE_PROGRESS_RANK.get(str(target_status or "").strip().lower())
+    return current_rank is not None and target_rank is not None and target_rank < current_rank
+
+
 def promote_strategy(strategy_id: str, body: StrategyPromoteBody):
     try:
         from forven.brain import transition_stage
@@ -1186,7 +1201,25 @@ def promote_strategy(strategy_id: str, body: StrategyPromoteBody):
         # re-enables the bypass for those stages (the endpoint is operator-only
         # and actor="api" is a recognised user actor, so this can only originate
         # from a human at the UI after an informed confirmation).
-        force = (bool(body.force) and resolved_target not in {"paper", "live_graduated"}) or override
+        # Exception: a DEMOTION into paper (live_graduated -> paper) keeps force —
+        # the operator's click IS the dethrone approval, and it only ever reduces
+        # capital exposure. live_graduated as a target can never be a demotion
+        # (top rank), so every go-live guard below stays fully intact.
+        demotion = _is_stage_demotion(current_status, resolved_target)
+        force = (
+            bool(body.force)
+            and (
+                resolved_target not in {"paper", "live_graduated"}
+                or (demotion and resolved_target == "paper")
+            )
+        ) or override
+        if force and demotion and not override and resolved_target == "paper":
+            log_activity(
+                "warning",
+                "api",
+                f"Operator forced demotion: {strategy_id} from {current_status} to {resolved_target}",
+                {"strategy_id": strategy_id, "to_status": resolved_target, "reason": body.reason or ""},
+            )
         # GO-LIVE-1: a request that can actually LAND in live_graduated (an
         # operator override past the approval gate, or auto-live explicitly
         # enabled) must carry the typed confirmation + initial per-asset
@@ -1999,7 +2032,34 @@ def transition_lifecycle_strategy(body: LifecycleTransitionBody):
         from forven.brain import _USER_ACTORS
 
         override = bool(body.override)
-        force = (bool(body.force) and target_status not in {"paper", "live_graduated"}) or override
+        # Same demotion exception as promote_strategy: an operator forcing a
+        # move DOWN into paper is a dethrone-by-click, not a gate bypass.
+        # Fail-soft: if the current stage can't be read, treat as non-demotion.
+        current_status = ""
+        try:
+            with get_db() as conn:
+                row = conn.execute(
+                    "SELECT COALESCE(stage, status, '') AS stage FROM strategies WHERE id = ?",
+                    (strategy_id,),
+                ).fetchone()
+            current_status = str(row["stage"] if row else "").strip().lower()
+        except Exception:
+            current_status = ""
+        demotion = _is_stage_demotion(current_status, target_status)
+        force = (
+            bool(body.force)
+            and (
+                target_status not in {"paper", "live_graduated"}
+                or (demotion and target_status == "paper")
+            )
+        ) or override
+        if force and demotion and not override and target_status == "paper":
+            log_activity(
+                "warning",
+                "api",
+                f"Operator forced demotion: {strategy_id} from {current_status} to {target_status}",
+                {"strategy_id": strategy_id, "to_state": target_status, "actor": body.actor or "api"},
+            )
         actor = body.actor or "api"
         # transition_stage only honours a force-bypass for recognised user actors,
         # so an operator override must run under one (the lifecycle router is

--- a/frontend/src/lib/api/forven.ts
+++ b/frontend/src/lib/api/forven.ts
@@ -1898,12 +1898,57 @@ export interface ApprovalTaskDetail {
 	tool_calls: Array<Record<string, unknown>>;
 }
 
+/** Point-in-time strategy summary embedded in promotion/dethrone approval payloads
+ *  (payload.strategy_snapshot). Everything optional: approvals created before
+ *  2026-07-06 carry no snapshot. */
+export interface StrategySnapshot {
+	display_id?: string | null;
+	name?: string | null;
+	display_name?: string | null;
+	symbol?: string | null;
+	timeframe?: string | null;
+	stage?: string | null;
+	stage_changed_at?: string | null;
+	backtest?: {
+		sharpe?: number | null;
+		total_return?: number | null;
+		max_drawdown?: number | null;
+		trades?: number | null;
+	} | null;
+	forward?: {
+		window_days?: number | null;
+		closed_trades?: number | null;
+		realized_pnl_pct_sum?: number | null;
+		wins?: number | null;
+	} | null;
+	captured_at?: string | null;
+}
+
+/** Live decision context returned by GET /approvals/{id}/context for
+ *  strategy-targeted approvals. */
+export interface ApprovalStrategyContext {
+	strategy?: Record<string, unknown> | null;
+	dethrone_history?: {
+		pending?: number;
+		approved?: number;
+		denied?: number;
+		expired?: number;
+		last_denied_at?: string | null;
+	} | null;
+	cooldown?: {
+		active?: boolean;
+		until?: string | null;
+		deny_count?: number;
+	} | null;
+}
+
 export interface ApprovalContextResponse {
 	approval: ApprovalRecord;
 	linked_task?: ApprovalTaskSummary | null;
 	troubleshoot_task?: ApprovalTaskSummary | null;
 	linked_task_detail?: ApprovalTaskDetail | null;
 	troubleshoot_task_detail?: ApprovalTaskDetail | null;
+	strategy_context?: ApprovalStrategyContext | null;
 	recommended_mode: 'diagnosis' | 'execution' | string;
 }
 

--- a/frontend/src/lib/components/approvals/CrucibleDethroneCard.svelte
+++ b/frontend/src/lib/components/approvals/CrucibleDethroneCard.svelte
@@ -1,0 +1,183 @@
+<script lang="ts">
+	/**
+	 * Renderer for `crucible_dethrone` (crucibles.request_dethrone_approval):
+	 *   { current_protection_status, current_crucible_status,
+	 *     initial_viability_evidence_id, current_verdict_memo,
+	 *     new_evidence: {...}, recommended_action, intent_history?: [...] }
+	 */
+	import type { ApprovalRecord } from '$lib/api/forven';
+
+	export let approval: ApprovalRecord;
+
+	$: payload = (approval.payload ?? {}) as Record<string, unknown>;
+	$: memo = str(payload.current_verdict_memo);
+	$: newEvidence = isRecord(payload.new_evidence) ? (payload.new_evidence as Record<string, unknown>) : null;
+	$: intentHistory = Array.isArray(payload.intent_history) ? (payload.intent_history as Array<Record<string, unknown>>) : [];
+
+	function str(value: unknown): string {
+		return typeof value === 'string' ? value.trim() : value === null || value === undefined ? '' : String(value);
+	}
+
+	function isRecord(value: unknown): value is Record<string, unknown> {
+		return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+	}
+
+	function pretty(value: unknown): string {
+		if (typeof value === 'string') return value;
+		try {
+			return JSON.stringify(value, null, 2);
+		} catch {
+			return String(value);
+		}
+	}
+</script>
+
+<div class="card">
+	<div class="row">
+		<span class="chip" title="Crucible id">{approval.target_id || '(unknown crucible)'}</span>
+		{#if str(payload.current_crucible_status)}<span class="chip chip--status">{str(payload.current_crucible_status)}</span>{/if}
+		{#if str(payload.current_protection_status)}<span class="chip chip--protect">{str(payload.current_protection_status)}</span>{/if}
+		{#if str(payload.recommended_action)}<span class="chip chip--action">{str(payload.recommended_action)}</span>{/if}
+	</div>
+
+	{#if memo}
+		<section class="section">
+			<h4>Current verdict memo</h4>
+			<p class="memo">{memo}</p>
+		</section>
+	{/if}
+
+	{#if newEvidence && Object.keys(newEvidence).length > 0}
+		<section class="section">
+			<h4>New evidence (vs initial viability {str(payload.initial_viability_evidence_id) || '—'})</h4>
+			<pre class="evidence">{pretty(newEvidence)}</pre>
+		</section>
+	{/if}
+
+	{#if intentHistory.length > 0}
+		<section class="section">
+			<h4>Prior dethrone intents ({intentHistory.length})</h4>
+			<ul class="intent-list">
+				{#each intentHistory as intent}
+					<li>{str(intent.recommended_action) || 'intent'} → {str(intent.requested_status) || '?'}</li>
+				{/each}
+			</ul>
+		</section>
+	{/if}
+
+	<details class="raw">
+		<summary>Raw payload</summary>
+		<pre>{JSON.stringify(payload, null, 2)}</pre>
+	</details>
+</div>
+
+<style>
+	.card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.6rem;
+		padding: 0.75rem;
+		border: 1px solid #1f1f1f;
+		background: #050505;
+	}
+
+	.row {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		flex-wrap: wrap;
+	}
+
+	.chip {
+		font-size: 0.625rem;
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+		padding: 0.2rem 0.5rem;
+		border: 1px solid #2a2a2a;
+		color: #ccc;
+		font-family: ui-monospace, monospace;
+	}
+
+	.chip--status {
+		color: #6ee7b7;
+		border-color: rgba(52, 211, 153, 0.35);
+	}
+
+	.chip--protect {
+		color: #fde68a;
+		border-color: rgba(250, 204, 21, 0.35);
+	}
+
+	.chip--action {
+		color: #fca5a5;
+		border-color: rgba(248, 113, 113, 0.35);
+	}
+
+	.section {
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+	}
+
+	.section h4 {
+		margin: 0;
+		font-size: 0.625rem;
+		text-transform: uppercase;
+		letter-spacing: 0.18em;
+		color: #888;
+		font-weight: 600;
+	}
+
+	.memo {
+		margin: 0;
+		font-size: 0.8rem;
+		color: #ccc;
+		white-space: pre-wrap;
+	}
+
+	.evidence {
+		margin: 0;
+		max-height: 160px;
+		overflow: auto;
+		border: 1px solid #1f1f1f;
+		background: #000;
+		padding: 0.5rem;
+		font-size: 0.6875rem;
+		color: #a7f3d0;
+		white-space: pre-wrap;
+		word-break: break-word;
+	}
+
+	.intent-list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.2rem;
+		font-size: 0.75rem;
+		color: #888;
+		font-family: ui-monospace, monospace;
+	}
+
+	.raw summary {
+		font-size: 0.6875rem;
+		color: #666;
+		cursor: pointer;
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+	}
+
+	.raw pre {
+		margin-top: 0.4rem;
+		max-height: 200px;
+		overflow: auto;
+		border: 1px solid #1f1f1f;
+		background: #000;
+		padding: 0.5rem;
+		font-size: 0.6875rem;
+		color: #888;
+		white-space: pre-wrap;
+		word-break: break-word;
+	}
+</style>

--- a/frontend/src/lib/components/approvals/RegimeChampionCard.svelte
+++ b/frontend/src/lib/components/approvals/RegimeChampionCard.svelte
@@ -1,0 +1,172 @@
+<script lang="ts">
+	/**
+	 * Renderer for `regime_champion_promotion` (lab_matrix_engine):
+	 *   { program_id, model_version_id, score_version,
+	 *     container_payloads: [...],           // heavy — raw toggle only
+	 *     champion_changes: [{ regime, old_champion_strategy_id,
+	 *                          new_champion_strategy_id, new_champion_score }] }
+	 */
+	import type { ApprovalRecord } from '$lib/api/forven';
+
+	export let approval: ApprovalRecord;
+
+	$: payload = (approval.payload ?? {}) as Record<string, unknown>;
+	$: changes = Array.isArray(payload.champion_changes)
+		? (payload.champion_changes as Array<Record<string, unknown>>)
+		: [];
+
+	function str(value: unknown): string {
+		return typeof value === 'string' ? value.trim() : value === null || value === undefined ? '' : String(value);
+	}
+
+	function num(value: unknown): string {
+		const parsed = Number(value);
+		return Number.isFinite(parsed) ? parsed.toFixed(3) : '—';
+	}
+</script>
+
+<div class="card">
+	<div class="row">
+		{#if str(payload.program_id)}<span class="chip">program {str(payload.program_id)}</span>{/if}
+		{#if str(payload.model_version_id)}<span class="chip">model {str(payload.model_version_id)}</span>{/if}
+		{#if str(payload.score_version)}<span class="chip chip--muted">score {str(payload.score_version)}</span>{/if}
+	</div>
+
+	{#if changes.length > 0}
+		<table class="changes">
+			<thead>
+				<tr><th>Regime</th><th>Current champion</th><th></th><th>Proposed champion</th><th>Score</th></tr>
+			</thead>
+			<tbody>
+				{#each changes as change}
+					<tr>
+						<td class="regime">{str(change.regime) || '—'}</td>
+						<td class="old">{str(change.old_champion_strategy_id) || '(none)'}</td>
+						<td class="arrow">→</td>
+						<td class="new">
+							{#if str(change.new_champion_strategy_id)}
+								<a href={'/lab/strategy/' + encodeURIComponent(str(change.new_champion_strategy_id))}>{str(change.new_champion_strategy_id)}</a>
+							{:else}
+								—
+							{/if}
+						</td>
+						<td class="score">{num(change.new_champion_score)}</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	{:else}
+		<p class="fine-print">No champion changes listed in this proposal.</p>
+	{/if}
+
+	<details class="raw">
+		<summary>Raw payload (incl. container payloads)</summary>
+		<pre>{JSON.stringify(payload, null, 2)}</pre>
+	</details>
+</div>
+
+<style>
+	.card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.6rem;
+		padding: 0.75rem;
+		border: 1px solid #1f1f1f;
+		background: #050505;
+	}
+
+	.row {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		flex-wrap: wrap;
+	}
+
+	.chip {
+		font-size: 0.625rem;
+		letter-spacing: 0.08em;
+		padding: 0.2rem 0.5rem;
+		border: 1px solid #2a2a2a;
+		color: #ccc;
+		font-family: ui-monospace, monospace;
+	}
+
+	.chip--muted {
+		color: #666;
+	}
+
+	.changes {
+		width: 100%;
+		font-size: 0.75rem;
+		border-collapse: collapse;
+	}
+
+	.changes th {
+		text-align: left;
+		font-weight: 600;
+		color: #888;
+		padding: 0.3rem 0.5rem;
+		border-bottom: 1px solid #1f1f1f;
+		font-size: 0.625rem;
+		text-transform: uppercase;
+		letter-spacing: 0.14em;
+	}
+
+	.changes td {
+		padding: 0.35rem 0.5rem;
+		border-bottom: 1px solid #141414;
+		font-family: ui-monospace, monospace;
+	}
+
+	.regime {
+		color: #fff;
+		font-weight: 600;
+	}
+
+	.old {
+		color: #888;
+	}
+
+	.arrow {
+		color: #666;
+	}
+
+	.new a {
+		color: #6ee7b7;
+	}
+
+	.new a:hover {
+		text-decoration: underline;
+	}
+
+	.score {
+		color: #ccc;
+	}
+
+	.fine-print {
+		margin: 0;
+		font-size: 0.6875rem;
+		color: #666;
+	}
+
+	.raw summary {
+		font-size: 0.6875rem;
+		color: #666;
+		cursor: pointer;
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+	}
+
+	.raw pre {
+		margin-top: 0.4rem;
+		max-height: 200px;
+		overflow: auto;
+		border: 1px solid #1f1f1f;
+		background: #000;
+		padding: 0.5rem;
+		font-size: 0.6875rem;
+		color: #888;
+		white-space: pre-wrap;
+		word-break: break-word;
+	}
+</style>

--- a/frontend/src/lib/components/approvals/RoutineCreateCard.svelte
+++ b/frontend/src/lib/components/approvals/RoutineCreateCard.svelte
@@ -1,0 +1,179 @@
+<script lang="ts">
+	/**
+	 * Renderer for `routine_create` (tools_brain.propose_routine):
+	 *   { name, prompt, cron_expr, tools_context, channel, rationale,
+	 *     proposed_by }
+	 * The cron expression is translated to local-time plain English with the
+	 * same util the Routines page uses.
+	 */
+	import type { ApprovalRecord } from '$lib/api/forven';
+	import { describeCronLocal } from '$lib/utils/schedule';
+
+	export let approval: ApprovalRecord;
+
+	$: payload = (approval.payload ?? {}) as Record<string, unknown>;
+	$: cronExpr = str(payload.cron_expr);
+	$: schedule = cronExpr ? describeCronLocal(cronExpr) : '';
+
+	function str(value: unknown): string {
+		return typeof value === 'string' ? value.trim() : value === null || value === undefined ? '' : String(value);
+	}
+</script>
+
+<div class="card">
+	<header class="card-header">
+		<div>
+			<div class="card-eyebrow">Proposed routine</div>
+			<div class="card-title">{str(payload.name) || '(unnamed routine)'}</div>
+		</div>
+		{#if str(payload.proposed_by)}<span class="chip">by {str(payload.proposed_by)}</span>{/if}
+	</header>
+
+	<div class="facts">
+		<div class="fact">
+			<div class="fact-label">Schedule</div>
+			<div class="fact-value">{schedule || '—'}{#if cronExpr}<span class="cron"> ({cronExpr})</span>{/if}</div>
+		</div>
+		<div class="fact">
+			<div class="fact-label">Delivery channel</div>
+			<div class="fact-value">{str(payload.channel) || 'default'}</div>
+		</div>
+	</div>
+
+	{#if str(payload.rationale)}
+		<section class="section">
+			<h4>Why the Brain wants this</h4>
+			<p class="text">{str(payload.rationale)}</p>
+		</section>
+	{/if}
+
+	{#if str(payload.prompt)}
+		<details class="prompt">
+			<summary>Routine prompt</summary>
+			<pre>{str(payload.prompt)}</pre>
+		</details>
+	{/if}
+
+	<details class="raw">
+		<summary>Raw payload</summary>
+		<pre>{JSON.stringify(payload, null, 2)}</pre>
+	</details>
+</div>
+
+<style>
+	.card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.6rem;
+		padding: 0.75rem;
+		border: 1px solid #1f1f1f;
+		background: #050505;
+	}
+
+	.card-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+		gap: 0.75rem;
+	}
+
+	.card-eyebrow {
+		font-size: 0.625rem;
+		text-transform: uppercase;
+		letter-spacing: 0.18em;
+		color: #888;
+	}
+
+	.card-title {
+		font-size: 0.95rem;
+		font-weight: 600;
+		color: #fff;
+		margin-top: 0.125rem;
+	}
+
+	.chip {
+		font-size: 0.625rem;
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+		padding: 0.2rem 0.5rem;
+		border: 1px solid #2a2a2a;
+		color: #888;
+		white-space: nowrap;
+	}
+
+	.facts {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+		gap: 0.5rem;
+	}
+
+	.fact {
+		padding: 0.45rem 0.55rem;
+		border: 1px solid #1f1f1f;
+		background: rgba(0, 0, 0, 0.3);
+	}
+
+	.fact-label {
+		font-size: 0.5625rem;
+		text-transform: uppercase;
+		letter-spacing: 0.14em;
+		color: #666;
+	}
+
+	.fact-value {
+		margin-top: 0.15rem;
+		font-size: 0.8rem;
+		color: #fff;
+	}
+
+	.cron {
+		color: #666;
+		font-family: ui-monospace, monospace;
+		font-size: 0.7rem;
+	}
+
+	.section {
+		display: flex;
+		flex-direction: column;
+		gap: 0.3rem;
+	}
+
+	.section h4 {
+		margin: 0;
+		font-size: 0.625rem;
+		text-transform: uppercase;
+		letter-spacing: 0.18em;
+		color: #888;
+		font-weight: 600;
+	}
+
+	.text {
+		margin: 0;
+		font-size: 0.8rem;
+		color: #ccc;
+		white-space: pre-wrap;
+	}
+
+	.prompt summary,
+	.raw summary {
+		font-size: 0.6875rem;
+		color: #666;
+		cursor: pointer;
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+	}
+
+	.prompt pre,
+	.raw pre {
+		margin-top: 0.4rem;
+		max-height: 200px;
+		overflow: auto;
+		border: 1px solid #1f1f1f;
+		background: #000;
+		padding: 0.5rem;
+		font-size: 0.6875rem;
+		color: #888;
+		white-space: pre-wrap;
+		word-break: break-word;
+	}
+</style>

--- a/frontend/src/lib/components/approvals/StrategyApprovalCard.svelte
+++ b/frontend/src/lib/components/approvals/StrategyApprovalCard.svelte
@@ -1,0 +1,469 @@
+<script lang="ts">
+	/**
+	 * Renderer for `strategy_dethrone_recommendation` and
+	 * `strategy_promotion_approval` — the two approval types that dominate the
+	 * queue. Everything renders defensively: approvals created before the
+	 * 2026-07-06 payload enrichment carry no evidence/strategy_snapshot.
+	 *
+	 * Payload shape (brain._queue_dethrone_approval / _queue_promotion_approval):
+	 *   { strategy_id, current_stage, recommended_action,
+	 *     recommended_target_stage, trigger_actor, trigger_reason,
+	 *     evidence?: {...}, strategy_snapshot?: StrategySnapshot }
+	 * plus the policy variants: repeated-failure (gate, reason_code,
+	 * failure_count, threshold) and superior_challenger (challenger_id,
+	 * challenger_sharpe, incumbent_sharpe).
+	 */
+	import {
+		getApprovalContext,
+		type ApprovalRecord,
+		type ApprovalStrategyContext,
+		type StrategySnapshot,
+	} from '$lib/api/forven';
+
+	export let approval: ApprovalRecord;
+
+	const STAGE_RANK: Record<string, number> = {
+		quick_screen: 0,
+		research_only: 0,
+		gauntlet: 1,
+		paper: 2,
+		live_graduated: 3,
+	};
+	const TERMINAL_STAGES = new Set(['archived', 'rejected', 'backtest_failed']);
+
+	let context: ApprovalStrategyContext | null = null;
+	let contextLoading = false;
+	let contextError = '';
+	let historyOpen = false;
+
+	$: payload = (approval.payload ?? {}) as Record<string, unknown>;
+	$: strategyId = str(payload.strategy_id) || str(approval.target_id);
+	$: fromStage = str(payload.current_stage);
+	$: toStage = str(payload.recommended_target_stage) || str(approval.requested_status);
+	$: triggerActor = str(payload.trigger_actor) || str(approval.actor);
+	$: triggerReason = str(payload.trigger_reason);
+	$: snapshot = (payload.strategy_snapshot ?? null) as StrategySnapshot | null;
+	$: evidence = isRecord(payload.evidence) ? (payload.evidence as Record<string, unknown>) : null;
+	$: isChallenger = str(payload.trigger) === 'superior_challenger';
+	$: isRepeatedFailure = payload.failure_count !== undefined && payload.gate !== undefined;
+	$: isDecay = str(evidence?.trigger) === 'decay_tracker';
+	$: strategyLabel = snapshot?.display_name || snapshot?.name || strategyId || '(unknown strategy)';
+	$: genericEvidence = evidence && !isDecay
+		? Object.entries(evidence).filter(([key]) => key !== 'trigger')
+		: [];
+
+	function str(value: unknown): string {
+		return typeof value === 'string' ? value.trim() : value === null || value === undefined ? '' : String(value);
+	}
+
+	function isRecord(value: unknown): value is Record<string, unknown> {
+		return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+	}
+
+	function num(value: unknown, digits = 2): string {
+		const parsed = Number(value);
+		return Number.isFinite(parsed) ? parsed.toFixed(digits) : '—';
+	}
+
+	function pct(value: unknown): string {
+		const parsed = Number(value);
+		return Number.isFinite(parsed) ? `${(parsed * 100).toFixed(1)}%` : '—';
+	}
+
+	function intOrDash(value: unknown): string {
+		const parsed = Number(value);
+		return Number.isFinite(parsed) ? String(Math.round(parsed)) : '—';
+	}
+
+	function fmtDate(value: unknown): string {
+		if (!value) return '—';
+		const date = new Date(String(value));
+		if (Number.isNaN(date.getTime())) return '—';
+		return `${date.toLocaleDateString()} ${date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+	}
+
+	function stageTone(stage: string, isTarget: boolean): string {
+		const key = stage.toLowerCase();
+		if (TERMINAL_STAGES.has(key)) return 'chip chip--terminal';
+		if (!isTarget) return 'chip chip--current';
+		const fromRank = STAGE_RANK[fromStage.toLowerCase()];
+		const toRank = STAGE_RANK[key];
+		if (fromRank !== undefined && toRank !== undefined && toRank < fromRank) return 'chip chip--down';
+		return 'chip chip--up';
+	}
+
+	async function toggleHistory() {
+		historyOpen = !historyOpen;
+		if (!historyOpen || context || contextLoading) return;
+		contextLoading = true;
+		contextError = '';
+		try {
+			const response = await getApprovalContext(approval.id);
+			context = response.strategy_context ?? null;
+			if (!context) contextError = 'No strategy context available.';
+		} catch (err) {
+			contextError = err instanceof Error ? err.message : 'Failed to load strategy context.';
+		} finally {
+			contextLoading = false;
+		}
+	}
+</script>
+
+<div class="card">
+	<header class="card-header">
+		<div class="min-w-0">
+			<div class="card-eyebrow">{approval.approval_type === 'strategy_promotion_approval' ? 'Promotion request' : 'Dethrone recommendation'}</div>
+			{#if strategyId}
+				<a class="card-title" href={'/lab/strategy/' + encodeURIComponent(strategyId)}>{strategyLabel}</a>
+			{:else}
+				<span class="card-title">{strategyLabel}</span>
+			{/if}
+			{#if snapshot?.symbol || snapshot?.timeframe}
+				<span class="market">{snapshot?.symbol ?? ''}{snapshot?.timeframe ? ` · ${snapshot.timeframe}` : ''}</span>
+			{/if}
+		</div>
+		<div class="stage-flow">
+			{#if fromStage}<span class={stageTone(fromStage, false)}>{fromStage}</span>{/if}
+			<span class="arrow">→</span>
+			{#if toStage}<span class={stageTone(toStage, true)}>{toStage}</span>{:else}<span class="chip chip--current">?</span>{/if}
+		</div>
+	</header>
+
+	<div class="trigger-row">
+		<span class="trigger-actor" title="Who attempted this transition">{triggerActor || 'unknown actor'}</span>
+		<span class="trigger-reason">{triggerReason || approval.reason || 'No reason recorded.'}</span>
+	</div>
+
+	{#if isDecay && evidence}
+		<section class="section">
+			<h4>Decay evidence</h4>
+			<div class="metric-grid">
+				<div class="metric"><div class="metric-label">Baseline Sharpe</div><div class="metric-value">{num(evidence.baseline_sharpe)}</div></div>
+				<div class="metric"><div class="metric-label">Live Sharpe ({intOrDash(evidence.window_hours)}h)</div><div class="metric-value metric-value--bad">{num(evidence.live_sharpe_72h)}</div></div>
+				<div class="metric"><div class="metric-label">Degradation</div><div class="metric-value metric-value--bad">{pct(evidence.degradation)}</div></div>
+				<div class="metric"><div class="metric-label">Trades in window</div><div class="metric-value">{intOrDash(evidence.trade_count_72h)}</div></div>
+			</div>
+		</section>
+	{:else if isChallenger}
+		<section class="section">
+			<h4>Challenger comparison (backtest Sharpe)</h4>
+			<div class="metric-grid metric-grid--two">
+				<div class="metric metric--good">
+					<div class="metric-label">Challenger {str(payload.challenger_id)}</div>
+					<div class="metric-value">{num(payload.challenger_sharpe)}</div>
+				</div>
+				<div class="metric">
+					<div class="metric-label">Incumbent {strategyId}</div>
+					<div class="metric-value">{num(payload.incumbent_sharpe)}</div>
+				</div>
+			</div>
+		</section>
+	{:else if isRepeatedFailure}
+		<section class="section">
+			<h4>Repeated gate failures</h4>
+			<div class="metric-grid">
+				<div class="metric"><div class="metric-label">Gate</div><div class="metric-value metric-value--mono">{str(payload.gate) || '—'}</div></div>
+				<div class="metric"><div class="metric-label">Reason</div><div class="metric-value metric-value--mono">{str(payload.reason_code) || '—'}</div></div>
+				<div class="metric"><div class="metric-label">Failures</div><div class="metric-value metric-value--bad">{intOrDash(payload.failure_count)} / {intOrDash(payload.threshold)}</div></div>
+			</div>
+			{#if str(payload.reason_text)}<p class="fine-print">{str(payload.reason_text)}</p>{/if}
+		</section>
+	{:else if genericEvidence.length > 0}
+		<section class="section">
+			<h4>Evidence</h4>
+			<div class="metric-grid">
+				{#each genericEvidence as [key, value]}
+					<div class="metric"><div class="metric-label">{key.replaceAll('_', ' ')}</div><div class="metric-value">{typeof value === 'number' ? num(value) : str(value) || '—'}</div></div>
+				{/each}
+			</div>
+		</section>
+	{/if}
+
+	{#if snapshot}
+		<section class="section">
+			<h4>Strategy at recommendation time</h4>
+			<div class="metric-grid">
+				<div class="metric"><div class="metric-label">Backtest Sharpe</div><div class="metric-value">{num(snapshot.backtest?.sharpe)}</div></div>
+				<div class="metric"><div class="metric-label">Return</div><div class="metric-value">{num(snapshot.backtest?.total_return)}</div></div>
+				<div class="metric"><div class="metric-label">Max DD</div><div class="metric-value">{num(snapshot.backtest?.max_drawdown)}</div></div>
+				<div class="metric"><div class="metric-label">BT trades</div><div class="metric-value">{intOrDash(snapshot.backtest?.trades)}</div></div>
+			</div>
+			<div class="metric-grid">
+				<div class="metric"><div class="metric-label">Fwd trades ({intOrDash(snapshot.forward?.window_days)}d)</div><div class="metric-value">{intOrDash(snapshot.forward?.closed_trades)}</div></div>
+				<div class="metric"><div class="metric-label">Fwd wins</div><div class="metric-value">{intOrDash(snapshot.forward?.wins)}</div></div>
+				<div class="metric"><div class="metric-label">Fwd PnL % sum</div><div class="metric-value {Number(snapshot.forward?.realized_pnl_pct_sum) < 0 ? 'metric-value--bad' : ''}">{num(snapshot.forward?.realized_pnl_pct_sum)}</div></div>
+				<div class="metric"><div class="metric-label">In stage since</div><div class="metric-value metric-value--small">{fmtDate(snapshot.stage_changed_at)}</div></div>
+			</div>
+		</section>
+	{:else}
+		<p class="fine-print">No snapshot captured with this approval (created before payload enrichment) — open the strategy page for current numbers.</p>
+	{/if}
+
+	<div class="footer-row">
+		<button type="button" class="history-toggle" on:click={() => void toggleHistory()}>
+			{historyOpen ? 'Hide history' : 'Decision history'}
+		</button>
+		<details class="raw">
+			<summary>Raw payload</summary>
+			<pre>{JSON.stringify(payload, null, 2)}</pre>
+		</details>
+	</div>
+
+	{#if historyOpen}
+		<section class="section history">
+			{#if contextLoading}
+				<div class="fine-print">Loading decision history…</div>
+			{:else if contextError}
+				<div class="fine-print">{contextError}</div>
+			{:else if context}
+				<div class="metric-grid">
+					<div class="metric"><div class="metric-label">Denied before</div><div class="metric-value">{intOrDash(context.dethrone_history?.denied)}</div></div>
+					<div class="metric"><div class="metric-label">Approved before</div><div class="metric-value">{intOrDash(context.dethrone_history?.approved)}</div></div>
+					<div class="metric"><div class="metric-label">Last denied</div><div class="metric-value metric-value--small">{fmtDate(context.dethrone_history?.last_denied_at)}</div></div>
+					<div class="metric">
+						<div class="metric-label">Deny cooldown</div>
+						<div class="metric-value metric-value--small {context.cooldown?.active ? 'metric-value--warn' : ''}">
+							{context.cooldown?.active ? `until ${fmtDate(context.cooldown?.until)} (deny #${context.cooldown?.deny_count ?? 0})` : 'inactive'}
+						</div>
+					</div>
+				</div>
+			{/if}
+		</section>
+	{/if}
+</div>
+
+<style>
+	.card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		padding: 0.75rem;
+		border: 1px solid #1f1f1f;
+		background: #050505;
+	}
+
+	.card-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+		gap: 0.75rem;
+		flex-wrap: wrap;
+	}
+
+	.card-eyebrow {
+		font-size: 0.625rem;
+		text-transform: uppercase;
+		letter-spacing: 0.18em;
+		color: #888;
+	}
+
+	.card-title {
+		font-family: ui-monospace, monospace;
+		font-size: 0.95rem;
+		font-weight: 600;
+		color: #fff;
+		margin-top: 0.125rem;
+		display: inline-block;
+	}
+
+	a.card-title:hover {
+		text-decoration: underline;
+		color: #7dd3fc;
+	}
+
+	.market {
+		margin-left: 0.5rem;
+		font-size: 0.7rem;
+		color: #888;
+	}
+
+	.stage-flow {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+	}
+
+	.arrow {
+		color: #666;
+		font-size: 0.8rem;
+	}
+
+	.chip {
+		font-size: 0.625rem;
+		text-transform: uppercase;
+		letter-spacing: 0.14em;
+		padding: 0.2rem 0.55rem;
+		border: 1px solid #333;
+		color: #ccc;
+	}
+
+	.chip--current {
+		border-color: #333;
+		color: #ccc;
+	}
+
+	.chip--up {
+		border-color: rgba(52, 211, 153, 0.4);
+		color: #6ee7b7;
+		background: rgba(52, 211, 153, 0.06);
+	}
+
+	.chip--down {
+		border-color: rgba(250, 204, 21, 0.4);
+		color: #fde68a;
+		background: rgba(250, 204, 21, 0.06);
+	}
+
+	.chip--terminal {
+		border-color: rgba(248, 113, 113, 0.4);
+		color: #fca5a5;
+		background: rgba(248, 113, 113, 0.06);
+	}
+
+	.trigger-row {
+		display: flex;
+		gap: 0.5rem;
+		align-items: baseline;
+		font-size: 0.8rem;
+		flex-wrap: wrap;
+	}
+
+	.trigger-actor {
+		font-family: ui-monospace, monospace;
+		font-size: 0.7rem;
+		padding: 0.1rem 0.4rem;
+		border: 1px solid #2a2a2a;
+		color: #888;
+		white-space: nowrap;
+	}
+
+	.trigger-reason {
+		color: #ccc;
+		min-width: 0;
+	}
+
+	.section {
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+	}
+
+	.section h4 {
+		margin: 0;
+		font-size: 0.625rem;
+		text-transform: uppercase;
+		letter-spacing: 0.18em;
+		color: #888;
+		font-weight: 600;
+	}
+
+	.metric-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+		gap: 0.5rem;
+	}
+
+	.metric-grid--two {
+		grid-template-columns: 1fr 1fr;
+	}
+
+	.metric {
+		padding: 0.45rem 0.55rem;
+		border: 1px solid #1f1f1f;
+		background: rgba(0, 0, 0, 0.3);
+	}
+
+	.metric--good {
+		border-color: rgba(52, 211, 153, 0.25);
+		background: rgba(52, 211, 153, 0.04);
+	}
+
+	.metric-label {
+		font-size: 0.5625rem;
+		text-transform: uppercase;
+		letter-spacing: 0.14em;
+		color: #666;
+	}
+
+	.metric-value {
+		margin-top: 0.15rem;
+		font-size: 0.9rem;
+		font-weight: 600;
+		color: #fff;
+	}
+
+	.metric-value--bad {
+		color: #fca5a5;
+	}
+
+	.metric-value--warn {
+		color: #fde68a;
+	}
+
+	.metric-value--mono {
+		font-family: ui-monospace, monospace;
+		font-size: 0.75rem;
+	}
+
+	.metric-value--small {
+		font-size: 0.7rem;
+		font-weight: 400;
+		color: #ccc;
+	}
+
+	.fine-print {
+		margin: 0;
+		font-size: 0.6875rem;
+		color: #666;
+		line-height: 1.4;
+	}
+
+	.footer-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+	}
+
+	.history-toggle {
+		font-size: 0.6875rem;
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+		color: #888;
+		background: transparent;
+		border: 1px solid #2a2a2a;
+		padding: 0.25rem 0.6rem;
+		cursor: pointer;
+	}
+
+	.history-toggle:hover {
+		color: #fff;
+		border-color: #555;
+	}
+
+	.raw summary {
+		font-size: 0.6875rem;
+		color: #666;
+		cursor: pointer;
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+	}
+
+	.raw pre {
+		margin-top: 0.4rem;
+		max-height: 200px;
+		overflow: auto;
+		border: 1px solid #1f1f1f;
+		background: #000;
+		padding: 0.5rem;
+		font-size: 0.6875rem;
+		color: #888;
+		white-space: pre-wrap;
+		word-break: break-word;
+	}
+
+	.history {
+		border-top: 1px solid #1a1a1a;
+		padding-top: 0.6rem;
+	}
+</style>

--- a/frontend/src/lib/components/approvals/TaskApprovalCard.svelte
+++ b/frontend/src/lib/components/approvals/TaskApprovalCard.svelte
@@ -1,0 +1,133 @@
+<script lang="ts">
+	/**
+	 * Renderer for `task_approval` / `code_change` payloads
+	 * (brain.py _queue task approvals):
+	 *   { task_id, task_display_id, agent_id, task_type, strategy_id,
+	 *     assigned_by?, priority? }
+	 * The linked_task enrichment (title/status) rides on the approval row.
+	 */
+	import type { ApprovalRecord } from '$lib/api/forven';
+
+	export let approval: ApprovalRecord;
+
+	$: payload = (approval.payload ?? {}) as Record<string, unknown>;
+	$: task = approval.linked_task ?? null;
+	$: taskDisplayId = str(payload.task_display_id) || task?.display_id || (payload.task_id ? `Task #${payload.task_id}` : '');
+	$: agentId = str(payload.agent_id) || str(task?.agent_id);
+	$: taskType = str(payload.task_type) || str(task?.type);
+	$: strategyId = str(payload.strategy_id) || str(task?.strategy_id);
+	$: assignedBy = str(payload.assigned_by);
+
+	function str(value: unknown): string {
+		return typeof value === 'string' ? value.trim() : value === null || value === undefined ? '' : String(value);
+	}
+</script>
+
+<div class="card">
+	<div class="row">
+		{#if taskDisplayId}
+			<a class="task-link" href={'/tasks/' + encodeURIComponent(taskDisplayId) + '?returnTo=' + encodeURIComponent('/approval')}>{taskDisplayId}</a>
+		{:else}
+			<span class="task-link task-link--dead">No task reference</span>
+		{/if}
+		{#if taskType}<span class="tag">{taskType}</span>{/if}
+		{#if agentId}<span class="tag" title="Assigned agent">{agentId}</span>{/if}
+		{#if assignedBy}<span class="tag tag--muted" title="Assigned by">by {assignedBy}</span>{/if}
+		{#if strategyId}
+			<a class="tag tag--strategy" href={'/lab/strategy/' + encodeURIComponent(strategyId)}>{strategyId}</a>
+		{/if}
+	</div>
+	{#if task?.title || task?.description}
+		<p class="task-title">{task?.title || task?.description}</p>
+	{/if}
+	<details class="raw">
+		<summary>Raw payload</summary>
+		<pre>{JSON.stringify(payload, null, 2)}</pre>
+	</details>
+</div>
+
+<style>
+	.card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		padding: 0.75rem;
+		border: 1px solid #1f1f1f;
+		background: #050505;
+	}
+
+	.row {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+	}
+
+	.task-link {
+		font-family: ui-monospace, monospace;
+		font-size: 0.85rem;
+		font-weight: 600;
+		color: #fff;
+	}
+
+	.task-link:hover {
+		text-decoration: underline;
+		color: #7dd3fc;
+	}
+
+	.task-link--dead {
+		color: #666;
+	}
+
+	.tag {
+		font-size: 0.625rem;
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+		padding: 0.15rem 0.45rem;
+		border: 1px solid #2a2a2a;
+		color: #aaa;
+	}
+
+	.tag--muted {
+		color: #666;
+	}
+
+	.tag--strategy {
+		font-family: ui-monospace, monospace;
+		text-transform: none;
+		letter-spacing: 0;
+		color: #7dd3fc;
+		border-color: rgba(125, 211, 252, 0.3);
+	}
+
+	.tag--strategy:hover {
+		text-decoration: underline;
+	}
+
+	.task-title {
+		margin: 0;
+		font-size: 0.8rem;
+		color: #ccc;
+	}
+
+	.raw summary {
+		font-size: 0.6875rem;
+		color: #666;
+		cursor: pointer;
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+	}
+
+	.raw pre {
+		margin-top: 0.4rem;
+		max-height: 200px;
+		overflow: auto;
+		border: 1px solid #1f1f1f;
+		background: #000;
+		padding: 0.5rem;
+		font-size: 0.6875rem;
+		color: #888;
+		white-space: pre-wrap;
+		word-break: break-word;
+	}
+</style>

--- a/frontend/src/lib/components/approvals/renderers.ts
+++ b/frontend/src/lib/components/approvals/renderers.ts
@@ -1,0 +1,61 @@
+/**
+ * Approval-type registry for the /approval queue.
+ *
+ * Friendly titles for every known approval_type plus the per-type payload
+ * renderer map. Unknown/future types fall back to a prettified title and the
+ * raw-JSON block in the page.
+ */
+import type { ComponentType, SvelteComponent } from 'svelte';
+import type { ApprovalRecord } from '$lib/api/forven';
+
+import StrategyApprovalCard from './StrategyApprovalCard.svelte';
+import TaskApprovalCard from './TaskApprovalCard.svelte';
+import CrucibleDethroneCard from './CrucibleDethroneCard.svelte';
+import RegimeChampionCard from './RegimeChampionCard.svelte';
+import RoutineCreateCard from './RoutineCreateCard.svelte';
+
+export const APPROVAL_TYPE_TITLES: Record<string, string> = {
+	strategy_dethrone_recommendation: 'Dethrone Recommendation',
+	strategy_promotion_approval: 'Strategy Promotion',
+	task_approval: 'Agent Task Approval',
+	code_change: 'Code Change',
+	skill_update_proposal: 'Skill Update Proposal',
+	routine_create: 'New Routine Proposal',
+	crucible_dethrone: 'Crucible Dethrone',
+	regime_champion_promotion: 'Regime Champion Promotion',
+};
+
+export function friendlyTitle(approvalType: string | null | undefined): string {
+	const key = String(approvalType || '').trim().toLowerCase();
+	if (!key) return 'Approval';
+	if (APPROVAL_TYPE_TITLES[key]) return APPROVAL_TYPE_TITLES[key];
+	return key
+		.split('_')
+		.map((word) => (word ? word[0].toUpperCase() + word.slice(1) : word))
+		.join(' ');
+}
+
+type ApprovalCard = ComponentType<SvelteComponent<{ approval: ApprovalRecord }>>;
+
+/** Per-type payload renderer. skill_update_proposal is dispatched separately
+ *  in the page (its card takes `payload`, kept unchanged). */
+const PAYLOAD_RENDERERS: Record<string, ApprovalCard> = {
+	strategy_dethrone_recommendation: StrategyApprovalCard,
+	strategy_promotion_approval: StrategyApprovalCard,
+	task_approval: TaskApprovalCard,
+	code_change: TaskApprovalCard,
+	crucible_dethrone: CrucibleDethroneCard,
+	regime_champion_promotion: RegimeChampionCard,
+	routine_create: RoutineCreateCard,
+};
+
+export function payloadRenderer(approvalType: string | null | undefined): ApprovalCard | null {
+	return PAYLOAD_RENDERERS[String(approvalType || '').trim().toLowerCase()] ?? null;
+}
+
+/** True for the strategy lifecycle types that support the deny-reason picker
+ *  (deny arms the escalating dethrone cooldown for these). */
+export function isStrategyLifecycleType(approvalType: string | null | undefined): boolean {
+	const key = String(approvalType || '').trim().toLowerCase();
+	return key === 'strategy_dethrone_recommendation' || key === 'strategy_promotion_approval';
+}

--- a/frontend/src/lib/settings/manifest.ts
+++ b/frontend/src/lib/settings/manifest.ts
@@ -1356,6 +1356,48 @@ export const SETTINGS_MANIFEST: SettingsEntry[] = [
 
   // Paper trading gates
   {
+    id: 'pipeline.dethrone.paper_min_soak_days',
+    label: 'Dethrone protection: paper soak floor',
+    unit: 'days',
+    default: 7,
+    type: 'number',
+    area: 'lab',
+    subsection: 'lab-pipeline-paper-live-gates',
+    backendSection: 'pipeline',
+    backendPath: 'dethrone.paper_min_soak_days',
+    description:
+      'A paper strategy may not be recommended for dethrone (demotion/archive) until it has soaked this many days — it has to get a chance to prove itself first. Operator force-demotions bypass this.',
+    usedBy: ['forven.brain', 'forven.policy'],
+  },
+  {
+    id: 'pipeline.dethrone.paper_max_soak_days',
+    label: 'Dethrone protection: low-activity extension',
+    unit: 'days',
+    default: 14,
+    type: 'number',
+    area: 'lab',
+    subsection: 'lab-pipeline-paper-live-gates',
+    backendSection: 'pipeline',
+    backendPath: 'dethrone.paper_max_soak_days',
+    description:
+      'Strategies that trade rarely (once a week or less) stay dethrone-protected past the soak floor, up to this many days, until they reach the minimum closed-trade count below.',
+    usedBy: ['forven.brain', 'forven.policy'],
+  },
+  {
+    id: 'pipeline.dethrone.paper_min_closed_trades',
+    label: 'Dethrone protection: min closed trades',
+    unit: 'trades',
+    default: 5,
+    type: 'number',
+    area: 'lab',
+    subsection: 'lab-pipeline-paper-live-gates',
+    backendSection: 'pipeline',
+    backendPath: 'dethrone.paper_min_closed_trades',
+    description:
+      'Closed paper trades (in the current paper stay) that end the low-activity dethrone protection early, between the soak floor and the extension limit.',
+    usedBy: ['forven.brain', 'forven.policy'],
+  },
+  {
     id: 'pipeline.paper_trading.min_paper_days',
     label: 'Paper min duration',
     unit: 'days',

--- a/frontend/src/lib/stores/heartbeat.ts
+++ b/frontend/src/lib/stores/heartbeat.ts
@@ -142,7 +142,17 @@ function buildFallbackNavIndicators(heartbeat: SystemHeartbeatResponse): Record<
 
 	// Paper and live each have their own page now, so each carries its own badge:
 	// open live positions on Live Trades, paper session activity on Paper Trades.
-	const liveTrades = Array.isArray(heartbeat.open_trades) ? heartbeat.open_trades : [];
+	// heartbeat.open_trades is the UNFILTERED ledger (paper AND live rows), so the
+	// live badge must exclude paper — otherwise open paper positions inflate it
+	// (e.g. "12" live when zero are live). Synthetic exchange-only rows carry no
+	// execution_type but source='exchange' and are real live exposure, so keep them.
+	const openTrades = Array.isArray(heartbeat.open_trades) ? heartbeat.open_trades : [];
+	const liveTrades = openTrades.filter((trade) => {
+		const executionType = String(trade?.execution_type ?? '').trim().toLowerCase();
+		if (executionType === 'live') return true;
+		if (executionType === 'paper' || executionType === 'replay') return false;
+		return String(trade?.source ?? '').trim().toLowerCase() === 'exchange';
+	});
 	const paperSessions = Array.isArray(heartbeat.paper_sessions) ? heartbeat.paper_sessions : [];
 	const activePaperSessions = paperSessions.filter((session) =>
 		['position_open', 'warming_up', 'watching'].includes(normalizeStatus(session.status)),

--- a/frontend/src/routes/approval/+page.svelte
+++ b/frontend/src/routes/approval/+page.svelte
@@ -21,6 +21,7 @@
 		type ApprovalTaskSummary,
 	} from '$lib/api/forven';
 	import SkillUpdateProposalCard from '$lib/components/approvals/SkillUpdateProposalCard.svelte';
+	import { friendlyTitle, isStrategyLifecycleType, payloadRenderer } from '$lib/components/approvals/renderers';
 
 	type PendingDecision = 'approve' | 'deny' | 'revise';
 	type ViewMode = 'pending' | 'history';
@@ -50,6 +51,14 @@
 	let settingsLoading = true;
 	let approvalModes: Record<string, string> = {};
 	let defaultApprovalMode = '';
+
+	let filterType = '';
+	let filterText = '';
+	let collapsedGroups: Set<string> = new Set();
+	let denyPickerId: number | null = null;
+	let denyPreset = '';
+	let denyFreeText = '';
+	const DENY_PRESETS = ['Performing fine', 'Insufficient evidence', 'Wrong target stage'];
 
 	let selectedApprovalId: number | null = null;
 	let approvalContext: ApprovalContextResponse | null = null;
@@ -457,7 +466,33 @@
 		reviseInput = { ...reviseInput, [approvalId]: value };
 	}
 
-	async function submitDecision(approvalId: number, action: PendingDecision, preferredTab?: DrawerTab) {
+	function toggleGroup(groupType: string) {
+		const next = new Set(collapsedGroups);
+		if (next.has(groupType)) next.delete(groupType);
+		else next.add(groupType);
+		collapsedGroups = next;
+	}
+
+	// Denying a strategy dethrone/promotion arms an escalating cooldown on the
+	// backend, so it deserves a real reason instead of the old boilerplate
+	// "Manual decision via UI: deny". Other types keep one-click deny.
+	function handleDenyClick(approval: ApprovalRecord) {
+		if (isStrategyLifecycleType(approval.approval_type)) {
+			denyPickerId = denyPickerId === approval.id ? null : approval.id;
+			denyPreset = '';
+			denyFreeText = '';
+			return;
+		}
+		void submitDecision(approval.id, 'deny');
+	}
+
+	async function confirmDeny(approvalId: number) {
+		const reason = [denyPreset, denyFreeText.trim()].filter(Boolean).join(' — ') || 'Denied via UI';
+		denyPickerId = null;
+		await submitDecision(approvalId, 'deny', undefined, reason);
+	}
+
+	async function submitDecision(approvalId: number, action: PendingDecision, preferredTab?: DrawerTab, reasonOverride?: string) {
 		if (isBusy(approvalId)) return;
 		// GO-LIVE-1: approving a paper→live promotion is never a bare click — the
 		// backend requires a typed "GO LIVE" confirmation plus an initial per-asset
@@ -493,7 +528,7 @@
 		try {
 			const payload = {
 				actor: 'operator',
-				reason: `Manual decision via UI: ${action}`,
+				reason: reasonOverride || `Manual decision via UI: ${action}`,
 				feedback: (reviseInput[approvalId] || '').trim() || undefined,
 				...(goLive ?? {}),
 			};
@@ -627,6 +662,28 @@
 	$: oldestVisibleAge = approvals.length > 0
 		? fmtAge(approvals.reduce((oldest, row) => (parseDate(row.created_at) < parseDate(oldest.created_at) ? row : oldest)).created_at)
 		: '--';
+	$: presentTypes = [...new Set(approvals.map((row) => row.approval_type))].sort();
+	$: filteredApprovals = approvals.filter((row) => {
+		if (filterType && row.approval_type !== filterType) return false;
+		const needle = filterText.trim().toLowerCase();
+		if (needle) {
+			const haystack = `${row.target_id || ''} ${row.reason || ''} ${row.actor || ''} ${row.approval_type || ''}`.toLowerCase();
+			if (!haystack.includes(needle)) return false;
+		}
+		return true;
+	});
+	// Pending view groups by type (dethrone recs dominate the queue); history
+	// stays a flat newest-first list under a single hidden header.
+	$: displayGroups = (() => {
+		if (viewMode !== 'pending') return [['__all__', filteredApprovals]] as Array<[string, ApprovalRecord[]]>;
+		const groups = new Map<string, ApprovalRecord[]>();
+		for (const row of filteredApprovals) {
+			const key = row.approval_type || 'unknown';
+			if (!groups.has(key)) groups.set(key, []);
+			groups.get(key)!.push(row);
+		}
+		return [...groups.entries()].sort((left, right) => right[1].length - left[1].length);
+	})();
 	$: selectedApproval = approvalContext?.approval ?? approvals.find((approval) => approval.id === selectedApprovalId) ?? null;
 	$: diagnosisLog = buildTaskLog(approvalContext?.troubleshoot_task, approvalContext?.troubleshoot_task_detail);
 	$: executionLog = buildTaskLog(approvalContext?.linked_task, approvalContext?.linked_task_detail);
@@ -692,18 +749,55 @@
 		</div>
 	</div>
 
+	<div class="flex flex-wrap items-center gap-2">
+		<select bind:value={filterType} class="bg-black border border-[#222] text-xs px-2 py-1.5 text-white">
+			<option value="">All types</option>
+			{#each presentTypes as presentType}
+				<option value={presentType}>{friendlyTitle(presentType)}</option>
+			{/each}
+		</select>
+		<input
+			type="text"
+			placeholder="Filter by strategy, reason, actor..."
+			class="flex-1 min-w-[220px] max-w-md bg-black border border-[#222] text-xs px-3 py-1.5 text-white"
+			bind:value={filterText}
+		/>
+		{#if filterType || filterText}
+			<button type="button" class="text-xs border border-[#333] px-3 py-1.5 text-[#888] hover:text-white" on:click={() => { filterType = ''; filterText = ''; }}>Clear filters</button>
+			<span class="text-xs text-[#666]">{filteredApprovals.length} of {approvals.length} shown</span>
+		{/if}
+	</div>
+
 	{#if loading}
 		<div class="text-[#666]">Loading approvals...</div>
-	{:else if approvals.length === 0}
-		<div class="text-[#666]">No {viewMode === 'pending' ? 'pending' : 'historical'} approvals.</div>
+	{:else if filteredApprovals.length === 0}
+		<div class="text-[#666]">
+			{approvals.length === 0
+				? `No ${viewMode === 'pending' ? 'pending' : 'historical'} approvals.`
+				: 'No approvals match the current filters.'}
+		</div>
 	{:else}
-		<div class="space-y-3">
-			{#each approvals as approval}
+		<div class="space-y-4">
+			{#each displayGroups as [groupType, groupRows] (groupType)}
+			<section class="space-y-3">
+			{#if groupType !== '__all__'}
+				<button
+					type="button"
+					class="w-full flex items-center gap-2 border border-[#222] bg-[#0a0a0a] px-3 py-2 text-left hover:border-[#444]"
+					on:click={() => toggleGroup(groupType)}
+				>
+					<span class="text-sm font-semibold text-white uppercase tracking-wider">{friendlyTitle(groupType)}</span>
+					<span class="inline-flex items-center justify-center min-w-[1.5rem] px-1.5 py-0.5 text-xs border border-[#333] bg-black text-[#ccc]">{groupRows.length}</span>
+					<span class="ml-auto text-[#666] text-xs">{collapsedGroups.has(groupType) ? '+ expand' : '− collapse'}</span>
+				</button>
+			{/if}
+			{#if !collapsedGroups.has(groupType)}
+			{#each groupRows as approval (approval.id)}
 				<article class="terminal-card p-4 space-y-3">
 					<div class="flex items-start justify-between gap-3">
 						<div>
-							<div class="text-xs uppercase tracking-wider text-[#666]">Approval #{approval.id}</div>
-							<div class="text-lg font-semibold text-white">{approval.approval_type}</div>
+							<div class="text-xs uppercase tracking-wider text-[#666]">Approval #{approval.id} <span class="font-mono normal-case text-[#444]">· {approval.approval_type}</span></div>
+							<div class="text-lg font-semibold text-white">{friendlyTitle(approval.approval_type)}</div>
 							<div class="mt-1 text-sm text-[#888]">{reasonText(approval)}</div>
 							<div class="mt-2 flex flex-wrap items-center gap-2">
 								<span
@@ -744,6 +838,9 @@
 						<div class="text-right text-xs text-[#666]">
 							<div class="inline-flex items-center px-2 py-0.5 border uppercase {statusClass(approval.status)}">{approval.status}</div>
 							<div class="mt-1">{fmtDate(approval.created_at)}</div>
+							{#if approval.actor}
+								<div class="mt-1 font-mono" title="Requesting actor">{approval.actor}</div>
+							{/if}
 							{#if deadlineState(approval)}
 								<div class="mt-1 inline-flex items-center px-2 py-0.5 border uppercase tracking-wider {deadlineState(approval)!.className}">{deadlineState(approval)!.label}</div>
 							{/if}
@@ -767,6 +864,8 @@
 
 					{#if approval.approval_type === 'skill_update_proposal' && typeof approval.payload === 'object' && approval.payload}
 						<SkillUpdateProposalCard payload={approval.payload as Record<string, unknown>} />
+					{:else if payloadRenderer(approval.approval_type) && typeof approval.payload === 'object' && approval.payload}
+						<svelte:component this={payloadRenderer(approval.approval_type)} {approval} />
 					{:else}
 						<pre class="text-[11px] text-[#888] bg-black border border-[#222] p-2 max-h-40 overflow-auto whitespace-pre-wrap">{typeof approval.payload === 'object' ? JSON.stringify(approval.payload, null, 2) : String(approval.payload || '-')}</pre>
 					{/if}
@@ -783,9 +882,32 @@
 						{#if viewMode === 'pending'}
 							<button type="button" disabled={isBusy(approval.id)} class="terminal-button-primary text-xs px-3 py-2 disabled:opacity-40" on:click={() => void submitDecision(approval.id, 'approve')}>{isBusy(approval.id) ? 'Approving...' : 'Approve'}</button>
 							<button type="button" disabled={isBusy(approval.id)} class="terminal-button text-xs px-3 py-2 disabled:opacity-40" on:click={() => void handleUserComplete(approval.id)}>{isBusy(approval.id) ? 'Completing...' : 'I Did This'}</button>
-							<button type="button" disabled={isBusy(approval.id)} class="terminal-button-danger text-xs px-3 py-2 disabled:opacity-40" on:click={() => void submitDecision(approval.id, 'deny')}>{isBusy(approval.id) ? 'Denying...' : 'Deny'}</button>
+							<button type="button" disabled={isBusy(approval.id)} class="terminal-button-danger text-xs px-3 py-2 disabled:opacity-40" on:click={() => handleDenyClick(approval)}>{isBusy(approval.id) ? 'Denying...' : 'Deny'}</button>
 						{/if}
 					</div>
+
+					{#if denyPickerId === approval.id && viewMode === 'pending'}
+						<div class="border border-red-900/60 bg-red-950/15 p-3 space-y-2">
+							<div class="text-[10px] uppercase tracking-wider text-red-300">Why deny?</div>
+							<div class="flex flex-wrap gap-2">
+								{#each DENY_PRESETS as preset}
+									<button
+										type="button"
+										class="text-xs border px-3 py-1.5 {denyPreset === preset ? 'border-red-500 bg-red-900/40 text-red-200' : 'border-[#333] text-[#888] hover:text-white'}"
+										on:click={() => denyPreset = denyPreset === preset ? '' : preset}
+									>
+										{preset}
+									</button>
+								{/each}
+							</div>
+							<input type="text" placeholder="Optional details..." class="w-full bg-black border border-[#222] text-xs px-3 py-2 text-white" bind:value={denyFreeText} />
+							<div class="text-[10px] text-[#666]">Denying pauses dethrone re-asks for this strategy: 24h on the first deny, then 3 days, then 7 days. Approving one (or the strategy leaving paper/live) resets the ladder.</div>
+							<div class="flex gap-2">
+								<button type="button" disabled={isBusy(approval.id)} class="terminal-button-danger text-xs px-3 py-2 disabled:opacity-40" on:click={() => void confirmDeny(approval.id)}>Confirm deny</button>
+								<button type="button" class="terminal-button text-xs px-3 py-2" on:click={() => denyPickerId = null}>Cancel</button>
+							</div>
+						</div>
+					{/if}
 
 					{#if viewMode === 'pending'}
 						<div class="flex gap-2">
@@ -793,12 +915,17 @@
 							<button type="button" disabled={isBusy(approval.id)} class="terminal-button text-xs px-3 py-2 disabled:opacity-40" on:click={() => void submitDecision(approval.id, 'revise')}>{isBusy(approval.id) ? 'Revising...' : 'Revise'}</button>
 						</div>
 					{:else}
-						<div class="grid sm:grid-cols-2 gap-3 text-xs border-t border-[#222] pt-3">
+						<div class="grid sm:grid-cols-4 gap-3 text-xs border-t border-[#222] pt-3">
 							<div><div class="text-[#666] uppercase tracking-wider">Decision</div><div class="text-white font-semibold">{approval.decision || 'N/A'}</div></div>
+							<div><div class="text-[#666] uppercase tracking-wider">Decided</div><div class="text-white">{fmtDate(approval.decided_at)}</div></div>
+							<div><div class="text-[#666] uppercase tracking-wider">Actor</div><div class="text-white font-mono">{approval.actor || '-'}</div></div>
 							<div><div class="text-[#666] uppercase tracking-wider">Feedback</div><div class="text-white">{approval.feedback || '-'}</div></div>
 						</div>
 					{/if}
 				</article>
+			{/each}
+			{/if}
+			</section>
 			{/each}
 		</div>
 	{/if}

--- a/tests/test_control_plane_approvals.py
+++ b/tests/test_control_plane_approvals.py
@@ -270,9 +270,13 @@ def test_deny_dethrone_recommendation_sets_cooldown(forven_db):
     assert result["ok"] is True
     assert result["strategy_id"] == "s-dethrone-deny"
     assert isinstance(result.get("cooldown_until"), str)
+    assert result.get("deny_count") == 1
     assert row["stage"] == "paper"
     assert row["status"] == "paper"
-    assert isinstance(cooldown, str)
+    # The cooldown is structured state now: escalating deny_count + expiry.
+    assert isinstance(cooldown, dict)
+    assert cooldown["deny_count"] == 1
+    assert isinstance(cooldown["until"], str)
 
 
 def test_approve_promotion_recommendation_transitions_strategy(forven_db, monkeypatch):

--- a/tests/test_control_plane_status.py
+++ b/tests/test_control_plane_status.py
@@ -101,7 +101,7 @@ def test_get_system_heartbeat_nav_indicators_use_frontend_route_keys(monkeypatch
     monkeypatch.setattr(control_plane_status, "get_sentiment", lambda: {"composite": 0.5})
     monkeypatch.setattr(control_plane_status, "get_regime", lambda: {"BTC": {"regime": "trend"}})
     monkeypatch.setattr(control_plane_status, "get_scanner_state", lambda: {"last_scan": "2026-03-06T00:00:00+00:00"})
-    monkeypatch.setattr("forven.api_domains.trading.read_open_trades", lambda verify_exchange=False: [{"id": "t1"}])
+    monkeypatch.setattr("forven.api_domains.trading.read_open_trades", lambda verify_exchange=False: [{"id": "t1", "execution_type": "live"}])
     monkeypatch.setattr("forven.api_domains.tasks.get_agent_tasks", lambda: [])
     monkeypatch.setattr("forven.api_domains.data.get_datasets_stub", lambda remote_skip=False: [])
     monkeypatch.setattr("forven.api_domains.analytics.get_research_feed_metrics_stub", lambda: {"new_count": 0})
@@ -146,6 +146,32 @@ def test_get_system_heartbeat_nav_indicators_use_frontend_route_keys(monkeypatch
     assert nav["/live-trades"]["count"] == 1
     # No paper sessions in this fixture — the paper tab must stay quiet.
     assert nav["/paper-trades"]["kind"] == "none"
+
+
+def test_live_trades_nav_indicator_excludes_paper_positions():
+    # Regression: read_open_trades returns the UNFILTERED ledger (paper AND live).
+    # The "Live Trades" badge must count only live exposure — 12 open paper
+    # positions with zero live must render NO badge, not "12".
+    open_trades = [
+        {"id": f"E{i:04d}", "execution_type": "paper", "source": "paper"}
+        for i in range(12)
+    ]
+    indicator = control_plane_status._build_live_trades_nav_indicator(open_trades)
+    assert indicator["kind"] == "none"
+    assert indicator["count"] == 0
+
+
+def test_live_trades_nav_indicator_counts_live_and_exchange_only():
+    # execution_type='live' rows and synthetic exchange-only rows (source='exchange',
+    # no execution_type — real HyperLiquid exposure) both count; paper does not.
+    open_trades = [
+        {"id": "L1", "execution_type": "live"},
+        {"id": "hl:mainnet:BTC:long", "source": "exchange"},
+        {"id": "P1", "execution_type": "paper", "source": "paper"},
+    ]
+    indicator = control_plane_status._build_live_trades_nav_indicator(open_trades)
+    assert indicator["kind"] == "count"
+    assert indicator["count"] == 2
 
 
 def test_system_heartbeat_route_sanitizes_nonfinite_values(monkeypatch):

--- a/tests/test_dethrone_cooldown.py
+++ b/tests/test_dethrone_cooldown.py
@@ -1,0 +1,445 @@
+"""Dethrone deny-cooldown: escalation, creation-path suppression, evidence payloads.
+
+Covers the 2026-07-06 fix set for "dethrone recommendations fire too easily":
+- deny arms an ESCALATING cooldown (24h -> 72h -> 168h) that the approval
+  CREATION paths honor (transition_stage gate + challenger path), so denied
+  recommendations stop re-filing hourly;
+- approving a dethrone or actually leaving paper/live clears the state;
+- dethrone/promotion approvals now embed decision evidence and a strategy
+  snapshot so the approvals page has something to render.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from forven.db import create_approval, get_db, kv_get, kv_set
+from forven.dethrone_cooldown import (
+    DENY_COOLDOWN_ESCALATION_HOURS,
+    clear_dethrone_cooldown,
+    dethrone_cooldown_active_until,
+    get_dethrone_cooldown_state,
+    record_dethrone_deny,
+)
+
+
+def _seed_strategy(
+    sid="S-CD1",
+    stage="paper",
+    metrics='{"sharpe": 2.5, "total_return": 41.2, "max_drawdown": -8.3, "trades": 87}',
+    stage_age_days=30.0,
+):
+    # Default stage age is past the paper dethrone-soak window (7d floor / 14d
+    # low-activity extension) so cooldown-focused tests are not soak-blocked.
+    stage_changed = (datetime.now(timezone.utc) - timedelta(days=stage_age_days)).isoformat()
+    with get_db() as conn:
+        conn.execute(
+            """
+            INSERT INTO strategies
+                (id, name, type, symbol, timeframe, params, metrics, verdict, status, owner,
+                 stage, display_id, created_at, updated_at, stage_changed_at)
+            VALUES
+                (?, ?, 'ema_cross', 'BTC', '1h', '{}', ?, '{}', ?, 'risk-manager', ?, ?,
+                 CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, ?)
+            """,
+            (sid, sid, metrics, stage, stage, sid, stage_changed),
+        )
+    return sid
+
+
+def _seed_closed_trade(trade_id, sid, pnl_pct, closed_at=None, execution_type="paper"):
+    closed = closed_at or datetime.now(timezone.utc).isoformat()
+    with get_db() as conn:
+        conn.execute(
+            """
+            INSERT INTO trades
+                (id, strategy, strategy_id, asset, direction, entry_price, size, status,
+                 execution_type, pnl_pct, opened_at, closed_at)
+            VALUES (?, ?, ?, 'BTC', 'long', 100, 1, 'CLOSED', ?, ?, ?, ?)
+            """,
+            (trade_id, sid, sid, execution_type, pnl_pct, closed, closed),
+        )
+
+
+def _pending_dethrone_count(sid):
+    with get_db() as conn:
+        row = conn.execute(
+            "SELECT COUNT(*) AS c FROM approvals "
+            "WHERE approval_type = 'strategy_dethrone_recommendation' AND target_id = ?",
+            (sid,),
+        ).fetchone()
+    return int(row["c"])
+
+
+def _hours_until(iso_str):
+    until = datetime.fromisoformat(iso_str)
+    if until.tzinfo is None:
+        until = until.replace(tzinfo=timezone.utc)
+    return (until - datetime.now(timezone.utc)).total_seconds() / 3600
+
+
+# --- module semantics --------------------------------------------------------
+
+def test_deny_sets_escalating_cooldown(forven_db):
+    sid = "S-CD-ESC"
+    expected = list(DENY_COOLDOWN_ESCALATION_HOURS) + [DENY_COOLDOWN_ESCALATION_HOURS[-1]]
+    for deny_number, hours in enumerate(expected, start=1):
+        state = record_dethrone_deny(sid)
+        assert state["deny_count"] == deny_number
+        assert abs(_hours_until(state["until"]) - hours) < 0.1
+    assert get_dethrone_cooldown_state(sid)["deny_count"] == 4
+
+
+def test_legacy_string_cooldown_value_parses(forven_db):
+    sid = "S-CD-LEGACY"
+    legacy_until = (datetime.now(timezone.utc) + timedelta(hours=5)).isoformat()
+    kv_set(f"forven:dethrone:cooldown:{sid}", legacy_until)
+
+    state = get_dethrone_cooldown_state(sid)
+    assert state == {"until": legacy_until, "deny_count": 1, "last_denied_at": None}
+    assert dethrone_cooldown_active_until(sid) is not None
+    # A deny on top of the legacy value escalates to the SECOND rung.
+    assert abs(_hours_until(record_dethrone_deny(sid)["until"]) - DENY_COOLDOWN_ESCALATION_HOURS[1]) < 0.1
+
+
+def test_deny_count_survives_cooldown_expiry(forven_db):
+    sid = "S-CD-EXPIRED-COUNT"
+    kv_set(
+        f"forven:dethrone:cooldown:{sid}",
+        {
+            "until": (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(),
+            "deny_count": 2,
+            "last_denied_at": None,
+        },
+    )
+    assert dethrone_cooldown_active_until(sid) is None  # expired -> inactive
+    assert record_dethrone_deny(sid)["deny_count"] == 3  # ...but escalation continues
+
+
+def test_unparseable_until_fails_open(forven_db):
+    sid = "S-CD-GARBAGE"
+    kv_set(f"forven:dethrone:cooldown:{sid}", {"until": "not-a-date", "deny_count": 1})
+    assert dethrone_cooldown_active_until(sid) is None
+
+
+def test_clear_resets_count(forven_db):
+    sid = "S-CD-CLEAR"
+    record_dethrone_deny(sid)
+    record_dethrone_deny(sid)
+    clear_dethrone_cooldown(sid)
+    assert get_dethrone_cooldown_state(sid) == {"until": None, "deny_count": 0, "last_denied_at": None}
+    assert record_dethrone_deny(sid)["deny_count"] == 1  # restarts at the first rung
+
+
+# --- transition_stage creation gate ------------------------------------------
+
+def test_transition_stage_respects_deny_cooldown(forven_db):
+    from forven.brain import transition_stage
+
+    sid = _seed_strategy("S-CD-GATE")
+    record_dethrone_deny(sid)
+
+    result = transition_stage(sid, "archived", reason="decay", actor="decay_tracker")
+
+    assert result["to"] == "paper"  # stage unchanged
+    assert result.get("reason_code") == "dethrone_cooldown_active"
+    assert "cooldown" in str(result.get("blocked_reason") or "").lower()
+    assert _pending_dethrone_count(sid) == 0  # the whole point: no new approval
+
+
+def test_expired_cooldown_requeues_approval(forven_db):
+    from forven.brain import transition_stage
+
+    sid = _seed_strategy("S-CD-EXP")
+    kv_set(
+        f"forven:dethrone:cooldown:{sid}",
+        {"until": (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(), "deny_count": 1},
+    )
+
+    result = transition_stage(sid, "archived", reason="decay", actor="decay_tracker")
+
+    assert result.get("reason_code") == "operator_approval_required"
+    assert _pending_dethrone_count(sid) == 1
+
+
+def test_force_bypasses_cooldown(forven_db):
+    from forven.brain import transition_stage
+
+    sid = _seed_strategy("S-CD-FORCE")
+    record_dethrone_deny(sid)
+
+    result = transition_stage(sid, "gauntlet", reason="operator demote", actor="ui", force=True)
+
+    assert result["to"] == "gauntlet"
+    assert _pending_dethrone_count(sid) == 0
+
+
+def test_leaving_paper_clears_cooldown(forven_db):
+    from forven.brain import transition_stage
+
+    sid = _seed_strategy("S-CD-EXIT")
+    record_dethrone_deny(sid)
+
+    result = transition_stage(sid, "gauntlet", reason="operator demote", actor="ui", force=True)
+
+    assert result["to"] == "gauntlet"
+    assert get_dethrone_cooldown_state(sid)["deny_count"] == 0
+    assert dethrone_cooldown_active_until(sid) is None
+
+
+def test_approve_dethrone_clears_cooldown_and_count(forven_db):
+    from forven.control_plane import approvals as control_plane_approvals
+    from forven.control_plane.models import ApprovalDecisionBody
+
+    sid = _seed_strategy("S-CD-APPROVE")
+    record_dethrone_deny(sid)
+    approval_id = create_approval(
+        "strategy_dethrone_recommendation",
+        target_type="strategy",
+        target_id=sid,
+        requested_status="gauntlet",
+        payload={"strategy_id": sid, "recommended_target_stage": "gauntlet", "recommended_action": "dethrone"},
+    )
+
+    result = control_plane_approvals.post_approve_approval(approval_id, ApprovalDecisionBody(actor="operator"))
+
+    assert result["ok"] is True
+    assert get_dethrone_cooldown_state(sid)["deny_count"] == 0
+    assert record_dethrone_deny(sid)["deny_count"] == 1  # next deny restarts the ladder
+
+
+# --- evidence + snapshot payloads --------------------------------------------
+
+def test_dethrone_payload_has_evidence_and_snapshot(forven_db):
+    from forven.brain import transition_stage
+
+    sid = _seed_strategy("S-CD-EVID")
+    _seed_closed_trade("T-CD-1", sid, 1.2)
+    _seed_closed_trade("T-CD-2", sid, -0.5)
+
+    evidence = {
+        "trigger": "decay_tracker",
+        "baseline_sharpe": 2.5,
+        "live_sharpe_72h": 0.4,
+        "degradation": 0.84,
+        "trade_count_72h": 9,
+        "window_hours": 72,
+    }
+    result = transition_stage(sid, "archived", reason="decay", actor="decay_tracker", evidence=evidence)
+    assert result.get("reason_code") == "operator_approval_required"
+
+    with get_db() as conn:
+        row = conn.execute(
+            "SELECT payload FROM approvals WHERE target_id = ? ORDER BY id DESC LIMIT 1", (sid,)
+        ).fetchone()
+    import json
+
+    payload = json.loads(row["payload"])
+    assert payload["evidence"] == evidence
+    snapshot = payload["strategy_snapshot"]
+    assert snapshot["symbol"] == "BTC"
+    assert snapshot["backtest"]["sharpe"] == 2.5
+    assert snapshot["backtest"]["trades"] == 87
+    assert snapshot["forward"]["closed_trades"] == 2
+    assert snapshot["forward"]["wins"] == 1
+
+
+def test_snapshot_fail_soft_on_bad_metrics(forven_db):
+    from forven.brain import transition_stage
+
+    sid = _seed_strategy("S-CD-BADMETRICS", metrics="{not json")
+
+    result = transition_stage(sid, "archived", reason="decay", actor="decay_tracker")
+
+    assert result.get("reason_code") == "operator_approval_required"
+    assert _pending_dethrone_count(sid) == 1  # approval creation was never blocked
+
+
+def test_snapshot_none_for_missing_strategy(forven_db):
+    from forven.brain import _strategy_approval_snapshot
+
+    with get_db() as conn:
+        assert _strategy_approval_snapshot(conn, "S-DOES-NOT-EXIST") is None
+
+
+def test_decay_tracker_passes_structured_evidence(forven_db, monkeypatch):
+    from forven import monitoring
+
+    sid = _seed_strategy("S-CD-DECAY", metrics='{"sharpe": 2.0}')
+    now = datetime.now(timezone.utc)
+    for i, pnl in enumerate([-1.0, -2.0, -0.5, -1.5, -3.0, -1.1]):
+        _seed_closed_trade(f"T-DECAY-{i}", sid, pnl, closed_at=(now - timedelta(hours=i)).isoformat())
+
+    captured = {}
+
+    def _fake_transition(**kwargs):
+        captured.update(kwargs)
+        return {"from": "paper", "to": "paper", "reason_code": "operator_approval_required"}
+
+    monkeypatch.setattr("forven.brain.transition_stage", _fake_transition)
+
+    monitoring.run_decay_tracker(window_hours=72, degradation_threshold=0.30, min_trades=5)
+
+    evidence = captured.get("evidence")
+    assert evidence is not None
+    assert evidence["trigger"] == "decay_tracker"
+    assert evidence["baseline_sharpe"] == 2.0
+    assert evidence["window_hours"] == 72
+    assert evidence["trade_count_72h"] == 6
+    assert evidence["degradation"] > 0.30
+
+
+# --- paper soak guard ----------------------------------------------------------
+
+def test_young_paper_strategy_is_soak_protected(forven_db):
+    from forven.brain import transition_stage
+
+    sid = _seed_strategy("S-SOAK-YOUNG", stage_age_days=2.0)
+
+    result = transition_stage(sid, "archived", reason="brain sweep", actor="brain")
+
+    assert result["to"] == "paper"
+    assert result.get("reason_code") == "dethrone_soak_active"
+    assert "soak" in str(result.get("blocked_reason") or "").lower()
+    assert _pending_dethrone_count(sid) == 0
+
+
+def test_low_activity_paper_strategy_protected_past_floor(forven_db):
+    from forven.brain import transition_stage
+
+    sid = _seed_strategy("S-SOAK-LOWACT", stage_age_days=10.0)
+    _seed_closed_trade("T-SOAK-1", sid, 0.4)
+    _seed_closed_trade("T-SOAK-2", sid, -0.2)
+
+    result = transition_stage(sid, "archived", reason="decay", actor="decay_tracker")
+
+    assert result.get("reason_code") == "dethrone_soak_active"
+    assert _pending_dethrone_count(sid) == 0
+
+
+def test_active_paper_strategy_recommendable_after_floor(forven_db):
+    from forven.brain import transition_stage
+
+    sid = _seed_strategy("S-SOAK-ACTIVE", stage_age_days=10.0)
+    for i in range(5):
+        _seed_closed_trade(f"T-SOAK-A{i}", sid, -0.5)
+
+    result = transition_stage(sid, "archived", reason="decay", actor="decay_tracker")
+
+    assert result.get("reason_code") == "operator_approval_required"
+    assert _pending_dethrone_count(sid) == 1
+
+
+def test_soak_expires_at_max_even_with_no_trades(forven_db):
+    from forven.brain import transition_stage
+
+    sid = _seed_strategy("S-SOAK-MAXED", stage_age_days=15.0)
+
+    result = transition_stage(sid, "archived", reason="decay", actor="decay_tracker")
+
+    assert result.get("reason_code") == "operator_approval_required"
+    assert _pending_dethrone_count(sid) == 1
+
+
+def test_force_bypasses_soak(forven_db):
+    from forven.brain import transition_stage
+
+    sid = _seed_strategy("S-SOAK-FORCE", stage_age_days=1.0)
+
+    result = transition_stage(sid, "gauntlet", reason="operator demote", actor="ui", force=True)
+
+    assert result["to"] == "gauntlet"
+    assert _pending_dethrone_count(sid) == 0
+
+
+def test_live_strategy_not_soak_protected(forven_db):
+    from forven.brain import transition_stage
+
+    sid = _seed_strategy("S-SOAK-LIVE", stage="live_graduated", stage_age_days=1.0)
+
+    result = transition_stage(sid, "paper", reason="decay", actor="decay_tracker")
+
+    assert result.get("reason_code") == "operator_approval_required"
+    assert _pending_dethrone_count(sid) == 1
+
+
+def test_challenger_dethrone_respects_soak(forven_db):
+    from forven.policy import _queue_challenger_dethrone
+
+    sid = _seed_strategy("S-SOAK-CHAL", stage_age_days=2.0)
+
+    with get_db() as conn:
+        approval_id = _queue_challenger_dethrone(
+            conn=conn,
+            incumbent_id=sid,
+            incumbent_stage="paper",
+            challenger_id="S-CHALLENGER-2",
+            challenger_sharpe=3.5,
+            incumbent_sharpe=2.0,
+        )
+
+    assert approval_id is None
+    assert _pending_dethrone_count(sid) == 0
+
+
+# --- challenger path ----------------------------------------------------------
+
+def test_queue_challenger_dethrone_respects_cooldown(forven_db):
+    from forven.policy import _queue_challenger_dethrone
+
+    sid = _seed_strategy("S-CD-CHAL")
+    record_dethrone_deny(sid)
+
+    with get_db() as conn:
+        approval_id = _queue_challenger_dethrone(
+            conn=conn,
+            incumbent_id=sid,
+            incumbent_stage="paper",
+            challenger_id="S-CHALLENGER",
+            challenger_sharpe=3.2,
+            incumbent_sharpe=2.1,
+        )
+
+    assert approval_id is None
+    assert _pending_dethrone_count(sid) == 0
+
+
+# --- context endpoint ----------------------------------------------------------
+
+def test_approval_context_includes_strategy_context(forven_db):
+    from forven.control_plane import approvals as control_plane_approvals
+    from forven.control_plane.models import ApprovalDecisionBody
+
+    sid = _seed_strategy("S-CD-CTX")
+    approval_id = create_approval(
+        "strategy_dethrone_recommendation",
+        target_type="strategy",
+        target_id=sid,
+        requested_status="gauntlet",
+        payload={"strategy_id": sid, "recommended_target_stage": "gauntlet", "recommended_action": "dethrone"},
+    )
+    control_plane_approvals.post_deny_approval(approval_id, ApprovalDecisionBody(actor="operator", reason="fine"))
+
+    context = control_plane_approvals.get_approval_context(approval_id)
+
+    strategy_context = context["strategy_context"]
+    assert strategy_context["strategy"]["id"] == sid
+    assert strategy_context["strategy"]["sharpe"] == 2.5
+    assert strategy_context["dethrone_history"]["denied"] == 1
+    assert strategy_context["cooldown"]["active"] is True
+    assert strategy_context["cooldown"]["deny_count"] == 1
+
+
+def test_approval_context_fail_soft_missing_strategy(forven_db):
+    from forven.control_plane import approvals as control_plane_approvals
+
+    approval_id = create_approval(
+        "strategy_dethrone_recommendation",
+        target_type="strategy",
+        target_id="S-GHOST",
+        requested_status="gauntlet",
+        payload={"strategy_id": "S-GHOST"},
+    )
+
+    context = control_plane_approvals.get_approval_context(approval_id)
+
+    assert context["strategy_context"] is None
+    assert context["approval"]["id"] == approval_id

--- a/tests/test_dethrone_cooldown.py
+++ b/tests/test_dethrone_cooldown.py
@@ -11,7 +11,7 @@ Covers the 2026-07-06 fix set for "dethrone recommendations fire too easily":
 
 from datetime import datetime, timedelta, timezone
 
-from forven.db import create_approval, get_db, kv_get, kv_set
+from forven.db import create_approval, get_db, kv_set
 from forven.dethrone_cooldown import (
     DENY_COOLDOWN_ESCALATION_HOURS,
     clear_dethrone_cooldown,

--- a/tests/test_operator_gate_override.py
+++ b/tests/test_operator_gate_override.py
@@ -59,7 +59,18 @@ def test_force_is_neutered_for_live_without_override(forven_db, monkeypatch):
 def test_override_forces_live_promotion(forven_db, monkeypatch):
     sid = _seed(forven_db)
     cap = _capture_transition(monkeypatch)
-    promote_strategy(sid, StrategyPromoteBody(to_status="live_graduated", from_status="paper", override=True))
+    # GO-LIVE-1: an override that can land in live_graduated must carry the
+    # typed confirmation + notional ceiling, same as the UI sends.
+    promote_strategy(
+        sid,
+        StrategyPromoteBody(
+            to_status="live_graduated",
+            from_status="paper",
+            override=True,
+            confirm="GO LIVE",
+            live_notional_ceiling_usd=1000.0,
+        ),
+    )
     assert cap["force"] is True  # operator override re-enables the bypass
     assert cap["target_stage"] == "live_graduated"
 
@@ -71,13 +82,48 @@ def test_force_still_works_for_noncapital_stage(forven_db, monkeypatch):
     assert cap["force"] is True  # gauntlet is not a capital stage; force honoured
 
 
+def test_manual_live_to_paper_demotion_executes(forven_db, monkeypatch):
+    """An operator DEMOTION into paper keeps force: the click IS the dethrone
+    approval, so it must not bounce into a self-approval loop."""
+    sid = _seed(forven_db, stage="live_graduated")
+    cap = _capture_transition(monkeypatch)
+    promote_strategy(sid, StrategyPromoteBody(to_status="paper", force=True))
+    assert cap["force"] is True
+    assert cap["target_stage"] == "paper"
+
+
+def test_manual_promotion_into_paper_still_neutered(forven_db, monkeypatch):
+    """Moving UP into paper (gauntlet -> paper) keeps the neutered force."""
+    sid = _seed(forven_db, stage="gauntlet")
+    cap = _capture_transition(monkeypatch)
+    promote_strategy(sid, StrategyPromoteBody(to_status="paper", force=True))
+    assert cap["force"] is False
+
+
+def test_lifecycle_live_to_paper_demotion_executes(forven_db, monkeypatch):
+    sid = _seed(forven_db, stage="live_graduated")
+    cap = _capture_transition(monkeypatch)
+    transition_lifecycle_strategy(
+        LifecycleTransitionBody(strategy_id=sid, to_state="paper", actor="manual", force=True)
+    )
+    assert cap["force"] is True
+    assert cap["target_stage"] == "paper"
+
+
 # --- transition_lifecycle_strategy -----------------------------------------
 
 def test_lifecycle_override_forces_and_coerces_actor(forven_db, monkeypatch):
     sid = _seed(forven_db)
     cap = _capture_transition(monkeypatch)
     transition_lifecycle_strategy(
-        LifecycleTransitionBody(strategy_id=sid, to_state="live", actor="system", override=True)
+        LifecycleTransitionBody(
+            strategy_id=sid,
+            to_state="live",
+            actor="system",
+            override=True,
+            confirm="GO LIVE",
+            live_notional_ceiling_usd=1000.0,
+        )
     )
     assert cap["force"] is True
     # a non-user actor is coerced to a user actor so transition_stage honours force

--- a/tests/test_pipeline_hardening.py
+++ b/tests/test_pipeline_hardening.py
@@ -431,6 +431,8 @@ def test_transition_stage_queues_operator_approval_for_automated_paper_archive(f
             "max_drawdown_pct": 0.09,
             "total_return_pct": 9.0,
         },
+        # Past the paper dethrone-soak window so the recommendation may file.
+        stage_changed_at=(datetime.now(timezone.utc) - timedelta(days=30)).isoformat(),
     )
 
     transition = transition_stage(
@@ -514,6 +516,7 @@ def test_transition_stage_reuses_existing_dethrone_approval_for_automated_paper_
         stage="paper",
         owner="risk-manager",
         metrics={"fitness": 52.0, "total_trades": 25},
+        stage_changed_at=(datetime.now(timezone.utc) - timedelta(days=30)).isoformat(),
     )
     approval_id = create_approval(
         "strategy_dethrone_recommendation",
@@ -3232,7 +3235,12 @@ def test_materially_better_challenger_queues_dethrone_for_incumbent(forven_db):
     path (the auto-apply path is covered by test_auto_approve_dethrone_frees_the_slot).
     """
     kv_set("forven:settings", {"auto_approve_dethrone": False, "paper_slot_competition_enabled": True})
-    _insert_strategy("incumbent-weak2", stage="paper", metrics={"sharpe": 1.0, "total_trades": 40})
+    _insert_strategy(
+        "incumbent-weak2",
+        stage="paper",
+        metrics={"sharpe": 1.0, "total_trades": 40},
+        stage_changed_at=(datetime.now(timezone.utc) - timedelta(days=30)).isoformat(),
+    )
     _insert_strategy("challenger-strong2", stage="quick_screen", metrics={"sharpe": 3.0, "total_trades": 40})
 
     evaluate_promotion("challenger-strong2", "quick_screen", "gauntlet")
@@ -3307,7 +3315,12 @@ def test_auto_approve_dethrone_frees_the_slot(forven_db):
     """With auto_approve_dethrone enabled, a superior challenger's dethrone is applied,
     demoting the incumbent out of paper so the slot opens."""
     kv_set("forven:settings", {"auto_approve_dethrone": True, "paper_slot_competition_enabled": True})
-    _insert_strategy("incumbent-evicted", stage="paper", metrics={"sharpe": 1.0, "total_trades": 40})
+    _insert_strategy(
+        "incumbent-evicted",
+        stage="paper",
+        metrics={"sharpe": 1.0, "total_trades": 40},
+        stage_changed_at=(datetime.now(timezone.utc) - timedelta(days=30)).isoformat(),
+    )
     _insert_strategy("challenger-evictor", stage="quick_screen", metrics={"sharpe": 3.0, "total_trades": 40})
 
     evaluate_promotion("challenger-evictor", "quick_screen", "gauntlet")

--- a/tests/test_provider_extra.py
+++ b/tests/test_provider_extra.py
@@ -78,3 +78,143 @@ def test_discovery_belong_rules():
     assert "opencode-zen" in ac._MODEL_DISCOVERY_ALT_ENDPOINTS
     assert "opencode-go" not in ac._MODEL_DISCOVERY_ALT_ENDPOINTS
     assert not ac._discovery_model_should_belong("opencode-go", "glm-5.2")
+
+
+# --------------------------------------------------------------------------- #
+# _call_openai extraction contract — a reasoning model (e.g. glm-5.2 via
+# opencode-go) can return an empty "content" with its output/thinking in
+# "reasoning_content". Regression guard for the no-code builder's opaque
+# "Expecting value: line 1 column 1 (char 0)" crash: an empty/truncated reply
+# must RAISE (so the fallback chain engages) instead of silently returning "".
+# --------------------------------------------------------------------------- #
+def _run_call_openai(response_json: dict, *, provider_label: str = "opencode-go"):
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = response_json
+
+    async def _post(url, json=None, headers=None):
+        return resp
+
+    async def _run():
+        with patch("forven.ai.get_token", return_value="tok"):
+            with patch("forven.ai.httpx.AsyncClient") as MockClient:
+                client = MagicMock()
+                client.__aenter__ = AsyncMock(return_value=client)
+                client.__aexit__ = AsyncMock(return_value=False)
+                client.post = AsyncMock(side_effect=_post)
+                MockClient.return_value = client
+                return await ai._call_openai(
+                    "tok", "glm-5.2", [{"role": "user", "content": "hi"}],
+                    1600, 0.1, "sys",
+                    endpoint=ai.ENDPOINTS["opencode-go"], provider_label=provider_label,
+                )
+
+    return asyncio.run(_run())
+
+
+def test_call_openai_raises_on_truncated_empty_reasoning_response():
+    import pytest
+
+    # The exact live shape: reasoning ate the whole budget, content is empty,
+    # finish_reason=length. Must RAISE a *truncated* EmptyProviderResponse (not
+    # return the unfinished thinking) so call_ai bumps the budget and retries.
+    payload = {
+        "choices": [{
+            "message": {"content": "", "reasoning_content": "let me think... " * 50},
+            "finish_reason": "length",
+        }],
+        "usage": {"prompt_tokens": 2131, "completion_tokens": 1600},
+    }
+    with pytest.raises(ai.EmptyProviderResponse) as ei:
+        _run_call_openai(payload)
+    assert ei.value.truncated is True
+
+
+def test_call_openai_raises_non_truncated_on_null_content():
+    import pytest
+
+    # content: null with a normal stop must also raise rather than return None —
+    # but marked NOT truncated (a bigger budget won't help), so no retry, fail over.
+    payload = {"choices": [{"message": {"content": None}, "finish_reason": "stop"}], "usage": {}}
+    with pytest.raises(ai.EmptyProviderResponse) as ei:
+        _run_call_openai(payload)
+    assert ei.value.truncated is False
+
+
+def test_call_openai_recovers_reasoning_content_when_stopped():
+    # Model finished normally (stop) but placed the answer in reasoning_content —
+    # recover it. (Only trusted when NOT truncated.)
+    payload = {
+        "choices": [{
+            "message": {"content": "", "reasoning_content": '{"ok": true}'},
+            "finish_reason": "stop",
+        }],
+        "usage": {},
+    }
+    assert _run_call_openai(payload) == '{"ok": true}'
+
+
+def test_call_openai_returns_plain_string_content_unchanged():
+    # The common case must be untouched by the robust extractor.
+    payload = {"choices": [{"message": {"content": "hello world"}, "finish_reason": "stop"}], "usage": {}}
+    assert _run_call_openai(payload) == "hello world"
+
+
+# --------------------------------------------------------------------------- #
+# Shared budget auto-bump: call_ai must retry the SAME provider with a larger
+# max_tokens when it truncates with empty output — so EVERY caller (not just the
+# no-code builder) recovers from a reasoning model, without any per-call-site
+# retry loop.
+# --------------------------------------------------------------------------- #
+def test_call_ai_auto_bumps_budget_on_truncation():
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    budgets: list[int] = []
+
+    def fake_single(provider, model, messages, max_tokens, temperature, system, **kw):
+        budgets.append(max_tokens)
+        if len(budgets) == 1:
+            raise ai.EmptyProviderResponse(provider, model, truncated=True)
+        return "recovered"
+
+    with patch("forven.ai._call_single", new_callable=AsyncMock, side_effect=fake_single), \
+         patch("forven.ai.get_fallback_chain", return_value=[("opencode-go", "glm-5.2")]), \
+         patch("forven.ai._credentialed_chain", side_effect=lambda chain, requested: chain):
+        out = asyncio.run(ai.call_ai("opencode-go", "glm-5.2", prompt="hi", max_tokens=2048))
+
+    assert out == "recovered"
+    assert budgets[0] == 2048
+    assert budgets[1] > budgets[0]  # escalated on the truncation retry
+
+
+def test_call_ai_does_not_bump_on_non_truncated_empty():
+    import asyncio
+
+    import pytest
+    from unittest.mock import AsyncMock, patch
+
+    calls: list[int] = []
+
+    def fake_single(provider, model, messages, max_tokens, temperature, system, **kw):
+        calls.append(max_tokens)
+        raise ai.EmptyProviderResponse(provider, model, truncated=False)
+
+    with patch("forven.ai._call_single", new_callable=AsyncMock, side_effect=fake_single), \
+         patch("forven.ai.get_fallback_chain", return_value=[("opencode-go", "glm-5.2")]), \
+         patch("forven.ai._credentialed_chain", side_effect=lambda chain, requested: chain):
+        with pytest.raises(ai.EmptyProviderResponse):
+            asyncio.run(ai.call_ai("opencode-go", "glm-5.2", prompt="hi", max_tokens=2048))
+
+    assert calls == [2048]  # single attempt, no budget bump when not truncated
+
+
+def test_next_truncation_budget_escalates_to_ceiling():
+    # Small callers jump straight to real headroom; already-large stops (== ceiling).
+    assert ai._next_truncation_budget(512) == 4096
+    assert ai._next_truncation_budget(4096) == 8192
+    assert ai._next_truncation_budget(8192) == 8192  # at ceiling -> stop signal


### PR DESCRIPTION
## Summary

Three related fixes/features bundled on this branch (approvals + AI reliability + a nav-badge correctness fix).

### 1. Dethrone deny-cooldown + paper soak guard + approvals-page redesign (`ecea720e`)
- Escalating dethrone **deny cooldown** (24h / 72h / 168h) honored **at creation**, killing the repeat-dethrone spam (99-in-14d).
- Evidence + snapshot payloads on dethrone recommendations; manual demotions execute directly.
- Paper dethrone-**soak** guard so a recommendation can't file until past the soak window.
- Full **approvals-page per-type renderer redesign**: `CrucibleDethroneCard`, `RegimeChampionCard`, `RoutineCreateCard`, `StrategyApprovalCard`, `TaskApprovalCard`, `renderers.ts`.

### 2. Reasoning-model empty/truncated response recovery (`7395c773`)
- `_call_openai` now **raises on empty content** (instead of returning `""`, which silently defeated the fallback chain) and falls back to `reasoning_content`.
- `nl_spec_gen` 4000/8000-token budget retry so reasoning-heavy models (glm-5.2) don't blow the token budget on reasoning alone and return empty output.

### 3. Live Trades nav badge counts live-only (`c724e91c`)
- `read_open_trades()` returns the unfiltered ledger (paper **and** live OPEN rows), so the sidebar "Live Trades" badge showed the total open-position count — e.g. **12 when zero positions were actually live**.
- Badge now filters to genuine live exposure: `execution_type='live'` plus synthetic exchange-only rows (`source='exchange'`), excluding paper/replay. Fixed on both the server source-of-truth and the client fallback path.

## Test plan
- Backend branch suites: **183 passed** (1 unrelated failure that also fails on `main` — pre-existing local environmental baseline).
- Frontend unit tests: **393/393 pass**.
- `svelte-check`: **0 errors**.
- Frontend production build: **succeeds**.

## Deploy note
The Live Trades badge fix needs a **backend restart** to take effect on the running server (heartbeat is computed server-side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)