### PR TITLE
feat(agents): bulk "set every agent to" also applies a fallback chain

### DIFF
--- a/frontend/src/routes/agents/components/tabs/RoutingTab.svelte
+++ b/frontend/src/routes/agents/components/tabs/RoutingTab.svelte
@@ -57,7 +57,6 @@
 	import { addToast } from '$lib/stores/processTracker';
 	import { agentsConfig, selectableModelOptions } from '../agentsConfigStore';
 	import ModelSlotPicker from './ModelSlotPicker.svelte';
-	import ModelPicker from './ModelPicker.svelte';
 	import DirtyBar from '../DirtyBar.svelte';
 
 	// Notify the host page when this tab gains/loses unsaved edits, so it can
@@ -119,32 +118,58 @@
 
 	// ---- Bulk "set every agent to one model" -------------------------------- //
 	// The clone-to-all the operator wanted: switching models shouldn't mean
-	// re-picking the dropdown on every agent. Pick a model here, hit Apply, and it
-	// becomes the PRIMARY for every agent (the Brain included — which also derives
-	// the default model), marking each changed agent dirty so the one tab-wide Save
-	// persists them together. Per-agent fallback chains are left untouched.
+	// re-picking the dropdown on every agent. Pick a primary model AND an ordered
+	// fallback chain here, hit Apply, and every agent below gets both (the Brain
+	// included — which also derives the default model), marking each changed agent
+	// dirty so the one tab-wide Save persists them together. An EMPTY bulk chain
+	// deliberately leaves each agent's existing fallbacks untouched, so a quick
+	// primary-only swap can never wipe configured chains.
 	let bulkKey = '';
+	let bulkFallbacks: string[] = [];
+
+	function onBulkChange(e: CustomEvent<{ value: string; fallbacks: string[] }>) {
+		bulkKey = e.detail.value;
+		bulkFallbacks = e.detail.fallbacks;
+	}
+
+	function sameChain(a: string[], b: string[]): boolean {
+		return a.length === b.length && a.every((k, i) => k === b[i]);
+	}
 
 	function applyModelToAllAgents() {
 		if (!bulkKey || agentRows.length === 0) return;
+		const applyChain = bulkFallbacks.length > 0;
 		const nextKey = { ...agentKey };
+		const nextFallbacks = { ...agentFallbacks };
 		const nextDirty = { ...agentDirty };
 		let changed = 0;
 		for (const row of agentRows) {
-			if ((nextKey[row.id] ?? '') === bulkKey) continue;
+			const keySame = (nextKey[row.id] ?? '') === bulkKey;
+			const chainSame = !applyChain || sameChain(nextFallbacks[row.id] ?? [], bulkFallbacks);
+			if (keySame && chainSame) continue;
 			nextKey[row.id] = bulkKey;
+			if (applyChain) nextFallbacks[row.id] = [...bulkFallbacks];
 			nextDirty[row.id] = true;
 			changed += 1;
 		}
 		agentKey = nextKey;
+		agentFallbacks = nextFallbacks;
 		agentDirty = nextDirty;
 		if (changed > 0) {
+			const chainNote = applyChain
+				? ` + ${bulkFallbacks.length} fallback${bulkFallbacks.length === 1 ? '' : 's'}`
+				: '';
 			addToast(
-				`Set ${changed} agent${changed === 1 ? '' : 's'} to ${labelForOptionKey(bulkKey)} — review, then Save.`,
+				`Set ${changed} agent${changed === 1 ? '' : 's'} to ${labelForOptionKey(bulkKey)}${chainNote} — review, then Save.`,
 				'success'
 			);
 		} else {
-			addToast('Every agent was already on that model.', 'info');
+			addToast(
+				applyChain
+					? 'Every agent already had that model and fallback chain.'
+					: 'Every agent was already on that model.',
+				'info'
+			);
 		}
 	}
 
@@ -509,29 +534,30 @@
 			default model for any routing slot below with no explicit choice.
 		</p>
 		{#if agentRows.length > 0 && !noneSelectable}
-			<div class="flex flex-wrap items-end gap-2 border border-[#1a1a1a] bg-[#050505] px-3 py-2">
-				<div class="flex-1 min-w-[220px]">
-					<span class="block text-[10px] text-[#666] uppercase tracking-wider mb-1">
-						Set every agent to
-					</span>
-					<ModelPicker
+			<div class="space-y-2">
+				<ul>
+					<ModelSlotPicker
+						label="Set every agent to"
+						description="Pick a primary model — and optionally a fallback chain — then apply both to every agent below. An empty chain here leaves each agent's existing fallbacks untouched."
 						value={bulkKey}
+						fallbacks={bulkFallbacks}
 						{selectable}
 						allowUnset
 						unsetLabel="— pick a model —"
-						showStaleWarning={false}
-						on:change={(e) => (bulkKey = e.detail.value)}
+						on:change={onBulkChange}
 					/>
+				</ul>
+				<div class="flex justify-end">
+					<button
+						type="button"
+						on:click={applyModelToAllAgents}
+						disabled={!bulkKey}
+						class="terminal-button text-xs px-3 py-1.5 disabled:opacity-50"
+						title="Set this model (and fallback chain, if one is picked) for every agent below. An empty chain leaves existing chains as-is; nothing saves until you hit Save."
+					>
+						Apply to all {agentRows.length}
+					</button>
 				</div>
-				<button
-					type="button"
-					on:click={applyModelToAllAgents}
-					disabled={!bulkKey}
-					class="terminal-button text-xs px-3 py-1.5 disabled:opacity-50"
-					title="Set this model as the primary for every agent below. Fallback chains are left as-is; nothing saves until you hit Save."
-				>
-					Apply to all {agentRows.length}
-				</button>
 			</div>
 		{/if}
 		{#if agentRows.length === 0}

--- a/frontend/src/tests/routingTabBulkModel.test.ts
+++ b/frontend/src/tests/routingTabBulkModel.test.ts
@@ -145,4 +145,42 @@ describe('RoutingTab — set every agent to one model', () => {
 			model_id: 'claude-opus-4-8',
 		});
 	});
+
+	it('applies the bulk fallback chain to every agent; Save writes each agent:<id> chain', async () => {
+		target = document.createElement('div');
+		document.body.appendChild(target);
+		instance = mount(RoutingTab, { target, props: {} });
+		await flush();
+
+		// Bulk primary → Opus.
+		const bulk = bySelectFirstOption('pick a model');
+		bulk.value = OPUS;
+		bulk.dispatchEvent(new Event('change', { bubbles: true }));
+		await flush();
+
+		// Bulk fallback → Sonnet. The bulk card renders above the per-agent rows,
+		// so its add-fallback select and its Add button are first in the DOM.
+		const addSelect = bySelectFirstOption('pick a connected');
+		addSelect.value = SONNET;
+		addSelect.dispatchEvent(new Event('change', { bubbles: true }));
+		await flush();
+		byButtonText('Add').click();
+		await flush();
+
+		byButtonText('Apply to all').click();
+		await flush();
+
+		byButtonText('Save changes').click();
+		await flush();
+
+		// Every agent's chain is written under its agent:<id> slot key.
+		expect(apiMocks.updateForvenModelPolicy).toHaveBeenCalledTimes(1);
+		const payload = apiMocks.updateForvenModelPolicy.mock.calls[0][0];
+		const sonnetChain = [{ provider: 'anthropic', model_id: 'claude-sonnet-5' }];
+		expect(payload.fallback_chains['agent:brain']).toEqual(sonnetChain);
+		expect(payload.fallback_chains['agent:alpha']).toEqual(sonnetChain);
+		// Brain's primary was already Opus, so only Alpha's model row is PATCHed —
+		// the chain-only change on Brain rides in the policy write alone.
+		expect(apiMocks.updateForvenAgentModel).toHaveBeenCalledTimes(1);
+	});
 });


### PR DESCRIPTION
## Summary
- The "Set every agent to" bulk control in Routing & Fallbacks now uses the full `ModelSlotPicker`, so a primary model AND an ordered fallback chain are picked once and applied to every agent in one click.
- Safety guard: an empty bulk chain leaves each agent's existing fallbacks untouched, so a quick primary-only swap can never wipe configured chains. Toast and tooltip spell this out.
- Chains persist through the existing single Save, written under each `agent:<id>` slot key in one model-policy write.

## Testing
- New test: bulk primary + fallback applied to all agents, Save writes the chain under every `agent:<id>` slot, and an agent whose primary was already correct is not re-PATCHed.
- `npx vitest run src/tests/routingTabBulkModel.test.ts` — 3/3 pass.
- `npx svelte-check` — 0 errors (2 pre-existing warnings in untouched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)