### PR TITLE
feat(routing): remove dead compression/post_mortem aux slots + bulk apply for auxiliary tasks

### DIFF
--- a/forven/model_routing.py
+++ b/forven/model_routing.py
@@ -56,24 +56,20 @@ _ZAI_PRIMARY_PROVIDER_PRIORITY = [
 ]
 
 # Auxiliary task kinds — small/cheap helper models that run *outside* the
-# primary Brain reasoning path. Compression and recall favor a fast/cheap
-# model; skill extraction and post-mortem need stronger reasoning, so they
-# default to a Sonnet-class model.
+# primary Brain reasoning path. Recall and approval favor a fast/cheap model;
+# skill extraction needs stronger reasoning, so it defaults to a Sonnet-class
+# model. Every kind listed here MUST have a consumer that calls
+# ``get_auxiliary_routing(kind)`` — the historical "compression" and
+# "post_mortem" slots were removed because nothing ever read them (post-mortems
+# run as agent tasks on the quant-researcher's model), yet models parked there
+# still counted as SELECTED in the spend-safety gate.
 AUXILIARY_TASK_KINDS: tuple[str, ...] = (
-    "compression",
     "recall",
     "skill_extraction",
-    "post_mortem",
     "approval",
 )
 
 _DEFAULT_AUXILIARY_ROUTING: dict[str, dict[str, str | None]] = {
-    "compression": {
-        "provider": "openrouter",
-        "model_id": "openai/gpt-4o-mini",
-        "base_url": None,
-        "api_key": None,
-    },
     "recall": {
         "provider": "openrouter",
         "model_id": "openai/gpt-4o-mini",
@@ -81,12 +77,6 @@ _DEFAULT_AUXILIARY_ROUTING: dict[str, dict[str, str | None]] = {
         "api_key": None,
     },
     "skill_extraction": {
-        "provider": "openrouter",
-        "model_id": "anthropic/claude-3-5-sonnet",
-        "base_url": None,
-        "api_key": None,
-    },
-    "post_mortem": {
         "provider": "openrouter",
         "model_id": "anthropic/claude-3-5-sonnet",
         "base_url": None,

--- a/forven/routers/brain.py
+++ b/forven/routers/brain.py
@@ -416,7 +416,7 @@ class _AuxiliaryUpdateBody(BaseModel):
 
 @router.get("/auxiliary")
 def get_auxiliary_endpoint() -> dict[str, Any]:
-    """Return the four auxiliary slots (compression / recall / skill_extraction / post_mortem)."""
+    """Return the auxiliary slots (recall / skill_extraction / approval)."""
     policy = get_model_routing()
     aux = policy.get("auxiliary") or {}
     return {

--- a/frontend/src/lib/api/brain.ts
+++ b/frontend/src/lib/api/brain.ts
@@ -278,10 +278,9 @@ export async function recallSimilarSituation(
 // --------------------------------------------------------------------------- //
 
 export type BrainAuxiliaryTaskKind =
-	| 'compression'
 	| 'recall'
 	| 'skill_extraction'
-	| 'post_mortem';
+	| 'approval';
 
 export interface BrainAuxiliaryEntry {
 	provider: string | null;

--- a/frontend/src/routes/agents/components/tabs/RoutingTab.svelte
+++ b/frontend/src/routes/agents/components/tabs/RoutingTab.svelte
@@ -6,8 +6,8 @@
 	 *  - Agents — EVERY agent (core + strategy-developers, including the Brain):
 	 *    its model + ordered fallback chain. This is the only place an agent's
 	 *    model is set; the Roster shows it read-only.
-	 *  - 5 auxiliary task kinds: compression, recall, skill_extraction,
-	 *    post_mortem, approval — lightweight Brain sub-task models.
+	 *  - 3 auxiliary task kinds: recall, skill_extraction, approval —
+	 *    lightweight Brain sub-task models.
 	 *  - Backup provider — the global safety net when a slot's primary fails.
 	 *  - Per-slot fallback chains + provider priority.
 	 *
@@ -28,7 +28,7 @@
 	 *    key `agent:<id>`.
 	 *  - provider_priority + aux/backup fallback_chains (+ derived primary) → PUT
 	 *    /api/model-policy (updateForvenModelPolicy) — one call.
-	 *  - 5 auxiliary kinds → PUT /api/brain/auxiliary (updateBrainAuxiliary). The
+	 *  - 3 auxiliary kinds → PUT /api/brain/auxiliary (updateBrainAuxiliary). The
 	 *    backend stores a single {provider, model_id} per aux kind; the optional
 	 *    per-slot fallback ordering is persisted alongside in model-policy's
 	 *    fallback_chains under a slot-scoped key (`aux:<kind>` / `backup`) so the
@@ -185,29 +185,67 @@
 	$: brainModelLabel = brainKey ? labelForOptionKey(brainKey) : '';
 
 	// ---- Auxiliary --------------------------------------------------------- //
-	const AUX_KINDS: BrainAuxiliaryTaskKind[] = [
-		'compression',
-		'recall',
-		'skill_extraction',
-		'post_mortem',
-		// `approval` is requested by the spec; the BrainAuxiliaryTaskKind union
-		// in the client may not list it yet, so cast at the boundary.
-		'approval' as BrainAuxiliaryTaskKind,
-	];
+	// Only kinds with a real backend consumer are listed (the historical
+	// "compression" and "post_mortem" slots were removed — nothing read them).
+	const AUX_KINDS: BrainAuxiliaryTaskKind[] = ['recall', 'skill_extraction', 'approval'];
 	const AUX_LABELS: Record<string, string> = {
-		compression: 'Compression',
 		recall: 'Recall',
 		skill_extraction: 'Skill extraction',
-		post_mortem: 'Post-mortem',
 		approval: 'Approval classifier',
 	};
 	const AUX_DESCRIPTIONS: Record<string, string> = {
-		compression: 'Summarizes long context before it hits the primary reasoning model.',
 		recall: 'Re-ranks FTS5 hits and writes the recall summary on /brain/recall.',
 		skill_extraction: 'Distills successful trade patterns into reusable skill cards.',
-		post_mortem: 'Writes the after-action analysis for completed decisions.',
 		approval: 'Classifies pending approvals (auto-approve / escalate / hold).',
 	};
+
+	// Bulk "set every auxiliary task to" — same clone-to-all as the Agents
+	// section: primary + optional chain applied to every aux slot; an empty
+	// chain leaves each slot's existing fallbacks untouched.
+	let bulkAuxKey = '';
+	let bulkAuxFallbacks: string[] = [];
+
+	function onBulkAuxChange(e: CustomEvent<{ value: string; fallbacks: string[] }>) {
+		bulkAuxKey = e.detail.value;
+		bulkAuxFallbacks = e.detail.fallbacks;
+	}
+
+	function applyModelToAllAux() {
+		if (!bulkAuxKey) return;
+		const applyChain = bulkAuxFallbacks.length > 0;
+		const nextKey = { ...auxKey };
+		const nextFallbacks = { ...auxFallbacks };
+		const nextDirty = { ...auxDirty };
+		let changed = 0;
+		for (const kind of AUX_KINDS) {
+			const keySame = (nextKey[kind] ?? '') === bulkAuxKey;
+			const chainSame = !applyChain || sameChain(nextFallbacks[kind] ?? [], bulkAuxFallbacks);
+			if (keySame && chainSame) continue;
+			nextKey[kind] = bulkAuxKey;
+			if (applyChain) nextFallbacks[kind] = [...bulkAuxFallbacks];
+			nextDirty[kind] = true;
+			changed += 1;
+		}
+		auxKey = nextKey;
+		auxFallbacks = nextFallbacks;
+		auxDirty = nextDirty;
+		if (changed > 0) {
+			const chainNote = applyChain
+				? ` + ${bulkAuxFallbacks.length} fallback${bulkAuxFallbacks.length === 1 ? '' : 's'}`
+				: '';
+			addToast(
+				`Set ${changed} auxiliary task${changed === 1 ? '' : 's'} to ${labelForOptionKey(bulkAuxKey)}${chainNote} — review, then Save.`,
+				'success'
+			);
+		} else {
+			addToast(
+				applyChain
+					? 'Every auxiliary task already had that model and fallback chain.'
+					: 'Every auxiliary task was already on that model.',
+				'info'
+			);
+		}
+	}
 
 	let auxKey: Record<string, string> = {};
 	let auxFallbacks: Record<string, string[]> = {};
@@ -604,6 +642,33 @@
 		<p class="text-xs text-[#666]">
 			Lightweight models for specific Brain sub-tasks. Each is independent of the default model.
 		</p>
+		{#if !noneSelectable}
+			<div class="space-y-2">
+				<ul>
+					<ModelSlotPicker
+						label="Set every auxiliary task to"
+						description="Pick a primary model — and optionally a fallback chain — then apply both to every auxiliary task below. An empty chain here leaves each task's existing fallbacks untouched."
+						value={bulkAuxKey}
+						fallbacks={bulkAuxFallbacks}
+						{selectable}
+						allowUnset
+						unsetLabel="— pick a model —"
+						on:change={onBulkAuxChange}
+					/>
+				</ul>
+				<div class="flex justify-end">
+					<button
+						type="button"
+						on:click={applyModelToAllAux}
+						disabled={!bulkAuxKey}
+						class="terminal-button text-xs px-3 py-1.5 disabled:opacity-50"
+						title="Set this model (and fallback chain, if one is picked) for every auxiliary task below. An empty chain leaves existing chains as-is; nothing saves until you hit Save."
+					>
+						Apply to all {AUX_KINDS.length}
+					</button>
+				</div>
+			</div>
+		{/if}
 		<ul class="space-y-3">
 			{#each AUX_KINDS as kind (kind)}
 				<div class="space-y-2">

--- a/frontend/src/tests/routingTabBulkModel.test.ts
+++ b/frontend/src/tests/routingTabBulkModel.test.ts
@@ -102,6 +102,15 @@ function byButtonText(match: string): HTMLButtonElement {
 	return found as HTMLButtonElement;
 }
 
+// A ModelSlotPicker card, located by its <h3> label — lets a test scope
+// selects/buttons to one card instead of counting DOM order across the page.
+function cardByLabel(match: string): HTMLElement {
+	const cards = Array.from(target.querySelectorAll('li'));
+	const found = cards.find((li) => (li.querySelector('h3')?.textContent || '').includes(match));
+	if (!found) throw new Error(`no slot card labelled "${match}"`);
+	return found as HTMLElement;
+}
+
 describe('RoutingTab — set every agent to one model', () => {
 	it('renders the bulk control once agents load', async () => {
 		target = document.createElement('div');
@@ -182,5 +191,53 @@ describe('RoutingTab — set every agent to one model', () => {
 		// Brain's primary was already Opus, so only Alpha's model row is PATCHed —
 		// the chain-only change on Brain rides in the policy write alone.
 		expect(apiMocks.updateForvenAgentModel).toHaveBeenCalledTimes(1);
+	});
+
+	it('applies the bulk model + chain to every auxiliary task and saves them', async () => {
+		target = document.createElement('div');
+		document.body.appendChild(target);
+		instance = mount(RoutingTab, { target, props: {} });
+		await flush();
+
+		// Work inside the aux bulk card only — DOM order across the page is not
+		// something this test should depend on.
+		const card = cardByLabel('Set every auxiliary task to');
+		const [primary, addFallback] = Array.from(card.querySelectorAll('select'));
+		primary.value = SONNET;
+		primary.dispatchEvent(new Event('change', { bubbles: true }));
+		await flush();
+		addFallback.value = OPUS;
+		addFallback.dispatchEvent(new Event('change', { bubbles: true }));
+		await flush();
+		const addBtn = Array.from(card.querySelectorAll('button')).find(
+			(b) => (b.textContent || '').trim() === 'Add'
+		) as HTMLButtonElement;
+		addBtn.click();
+		await flush();
+
+		// The aux section has 3 slots, so its Apply button is "Apply to all 3".
+		byButtonText('Apply to all 3').click();
+		await flush();
+
+		byButtonText('Save changes').click();
+		await flush();
+
+		// All three aux kinds are saved with the bulk primary…
+		expect(apiMocks.updateBrainAuxiliary).toHaveBeenCalledTimes(1);
+		const auxPayload = apiMocks.updateBrainAuxiliary.mock.calls[0][0];
+		for (const kind of ['recall', 'skill_extraction', 'approval']) {
+			expect(auxPayload[kind]).toEqual({
+				provider: 'anthropic',
+				model_id: 'claude-sonnet-5',
+				base_url: null,
+				api_key: null,
+			});
+		}
+		// …and the bulk chain lands under each aux:<kind> slot key.
+		const policyPayload = apiMocks.updateForvenModelPolicy.mock.calls[0][0];
+		const opusChain = [{ provider: 'anthropic', model_id: 'claude-opus-4-8' }];
+		for (const kind of ['recall', 'skill_extraction', 'approval']) {
+			expect(policyPayload.fallback_chains[`aux:${kind}`]).toEqual(opusChain);
+		}
 	});
 });

--- a/tests/test_auxiliary_models.py
+++ b/tests/test_auxiliary_models.py
@@ -1,7 +1,7 @@
 """Phase 1 (P1-T11) — auxiliary model routing tests.
 
 Asserts the ``auxiliary`` block in the model-routing policy:
-- Defaults are seeded for compression, recall, skill_extraction, post_mortem.
+- Defaults are seeded for recall, skill_extraction, approval.
 - ``get_auxiliary_routing`` returns ``{provider, model_id, base_url, api_key}``.
 - Updating one auxiliary key via ``update_model_routing`` does not blow away
   the other three.
@@ -92,7 +92,7 @@ def test_update_one_auxiliary_key_preserves_others(forven_db):
     assert routing["api_key"] == "sk-test"
 
     # Other kinds still match defaults.
-    for kind in ("compression", "skill_extraction", "post_mortem"):
+    for kind in ("skill_extraction", "approval"):
         default = _DEFAULT_AUXILIARY_ROUTING[kind]
         live = get_auxiliary_routing(kind)
         assert live["provider"] == default["provider"]
@@ -129,7 +129,7 @@ def test_bad_shaped_auxiliary_entry_falls_back_to_default(forven_db):
         "fallback_chains": {},
         "auxiliary": {
             "recall": {"provider": "openrouter"},  # missing model_id
-            "compression": {"model_id": "x"},  # missing provider
+            "approval": {"model_id": "x"},  # missing provider
             "skill_extraction": {"provider": "openrouter", "model_id": "anthropic/claude-3-5-sonnet"},
         },
     }
@@ -138,23 +138,23 @@ def test_bad_shaped_auxiliary_entry_falls_back_to_default(forven_db):
     policy = get_model_routing()
     # Bad entries fell back to seeded defaults.
     recall_default = _DEFAULT_AUXILIARY_ROUTING["recall"]
-    compression_default = _DEFAULT_AUXILIARY_ROUTING["compression"]
+    approval_default = _DEFAULT_AUXILIARY_ROUTING["approval"]
     assert policy["auxiliary"]["recall"]["model_id"] == recall_default["model_id"]
-    assert policy["auxiliary"]["compression"]["provider"] == compression_default["provider"]
+    assert policy["auxiliary"]["approval"]["provider"] == approval_default["provider"]
     # Good entry survived.
     assert policy["auxiliary"]["skill_extraction"]["provider"] == "openrouter"
 
 
 def test_per_task_base_url_and_api_key_round_trip(forven_db):
     policy = get_model_routing()
-    policy["auxiliary"]["compression"] = {
+    policy["auxiliary"]["approval"] = {
         "provider": "openai",
         "model_id": "gpt-4o-mini",
         "base_url": "https://my-proxy.example.com/v1",
         "api_key": "sk-proxy",
     }
     update_model_routing(policy)
-    rt = get_auxiliary_routing("compression")
+    rt = get_auxiliary_routing("approval")
     assert rt["base_url"] == "https://my-proxy.example.com/v1"
     assert rt["api_key"] == "sk-proxy"
 
@@ -166,13 +166,13 @@ def test_unsupported_provider_in_auxiliary_is_rejected(forven_db):
         "default_models": {"openai": "gpt-5.2"},
         "fallback_chains": {},
         "auxiliary": {
-            "post_mortem": {"provider": "fakeco", "model_id": "fakeco/x1"},
+            "skill_extraction": {"provider": "fakeco", "model_id": "fakeco/x1"},
         },
     }
     kv_set(_MODEL_ROUTING_STORAGE_KEY, bad)
-    rt = get_auxiliary_routing("post_mortem")
-    assert rt["provider"] == _DEFAULT_AUXILIARY_ROUTING["post_mortem"]["provider"]
-    assert rt["model_id"] == _DEFAULT_AUXILIARY_ROUTING["post_mortem"]["model_id"]
+    rt = get_auxiliary_routing("skill_extraction")
+    assert rt["provider"] == _DEFAULT_AUXILIARY_ROUTING["skill_extraction"]["provider"]
+    assert rt["model_id"] == _DEFAULT_AUXILIARY_ROUTING["skill_extraction"]["model_id"]
 
 
 # --------------------------------------------------------------------------- #
@@ -206,7 +206,7 @@ def _connect_and_select(monkeypatch, providers: set[str]) -> None:
 
 
 def test_aux_routing_diverts_only_to_connected_and_callable_provider(forven_db, monkeypatch):
-    """All five aux kinds default to openrouter. With openrouter uncredentialed
+    """All aux kinds default to openrouter. With openrouter uncredentialed
     but openai CONNECTED + SELECTED (its default model gpt-5.2 is a routing
     selection), routing must divert to openai with its default model."""
     # openrouter (the routed provider) has no usable credentials.


### PR DESCRIPTION
## Summary
- Removes the `compression` and `post_mortem` auxiliary task kinds: nothing ever called `get_auxiliary_routing()` for them (post-mortems run as agent tasks on the quant-researcher agent's model), yet models parked in those slots still counted as SELECTED in the spend-safety gate.
- Stale persisted entries self-clean: policy coercion iterates `AUXILIARY_TASK_KINDS`, so removed kinds (and their `aux:<kind>` fallback-chain keys, via `_coerce_fallback_slot_key`) drop out on the next policy read/write — no migration needed.
- `approval` becomes a first-class member of the frontend `BrainAuxiliaryTaskKind` union (previously cast at the boundary).
- The Auxiliary section gains the same "apply to all" bulk control the Agents section got in #36: primary + optional fallback chain applied to all three aux slots at once; an empty chain leaves existing fallbacks untouched.

## Testing
- Backend: `tests/test_auxiliary_models.py` reworked off the removed kinds — 17 pass; related suites (`test_fallback_execution`, `test_recall`, `test_quant_skills_extractor`, `test_model_selection`) — 37 pass.
- Frontend: new test drives the aux bulk control end-to-end (primary + chain → all 3 slots → one Save writes `updateBrainAuxiliary` and `aux:<kind>` chains) — 4/4 pass; `svelte-check` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)