### PR TITLE
fix(optimizer): never materialize the full parameter grid (OOM on fine-grained ranges)

### DIFF
--- a/forven/strategies/optimizer.py
+++ b/forven/strategies/optimizer.py
@@ -281,7 +281,6 @@ def _sanitize_execution_axis_values(name: str, values: list) -> list:
 
 
 def _lhs_sample(
-    combos: list[tuple],
     param_ranges: list[list],
     n_samples: int,
     seed: int = _LHS_SEED,
@@ -290,12 +289,18 @@ def _lhs_sample(
 
     Divides each parameter axis into ``n_samples`` strata and picks one value
     per stratum, ensuring even coverage instead of biased first-N truncation.
+    Builds each sampled combo directly from the per-axis value lists — the full
+    cartesian product is never materialized (on fine-grained user/API ranges it
+    can be astronomically large and OOM the process).
     """
     rng = random.Random(seed)
     n_dims = len(param_ranges)
 
-    if n_dims == 0 or n_samples <= 0:
-        return combos[:n_samples]
+    if n_samples <= 0:
+        return []
+    if n_dims == 0:
+        # Zero axes → the product is the single empty combo (backtest base params as-is).
+        return [()]
 
     # For each dimension, divide into n_samples strata
     sampled_indices: list[list[int]] = []
@@ -418,8 +423,14 @@ def grid_search(
         param_ranges.append(values)
         axes.append(("execution", name))
 
-    combos = list(itertools.product(*param_ranges))
-    if not combos:
+    # Count the grid WITHOUT materializing it: fine-grained user/API ranges
+    # (e.g. {min:0, max:100, step:0.01} on a couple of axes) make the cartesian
+    # product astronomically large, and eagerly building
+    # `list(itertools.product(...))` OOMs before any trial budget applies.
+    # _lhs_sample draws combos straight from the per-axis value lists, so the
+    # full product is only ever materialized when it is already within budget.
+    total_combos = math.prod(len(values) for values in param_ranges)
+    if total_combos == 0:
         # An empty product (e.g. an inverted (low, high, step) range or an explicit empty
         # list spec) would make workers = min(N, 0) = 0 and crash ThreadPoolExecutor with
         # "max_workers must be greater than 0". No viable grid → return no results.
@@ -430,19 +441,20 @@ def grid_search(
     # combos can run in the wall-clock target; the explicit trial budget still wins
     # when the operator asked for fewer.
     _grid_workers_n, _grid_feasible, _grid_combo_timeout, _grid_overall_timeout = _grid_execution_budget(
-        strategy_type, bars, len(combos)
+        strategy_type, bars, total_combos
     )
     trial_budget = min(_trial_budget(max_trials), _grid_feasible)
-    if len(combos) > trial_budget:
+    if total_combos > trial_budget:
         # P2-4: Latin Hypercube Sampling instead of deterministic first-N truncation.
-        _total_combos = len(combos)
-        combos = _lhs_sample(combos, param_ranges, trial_budget)
+        combos = _lhs_sample(param_ranges, trial_budget)
         log.info(
             "Grid search %s: %d total combos sampled to %d via LHS (feasible=%d, workers=%d, "
             "combo_timeout=%.0fs, grid_timeout=%.0fs, est_per_backtest=%.1fs)",
-            strategy_id, _total_combos, len(combos), _grid_feasible, _grid_workers_n,
+            strategy_id, total_combos, len(combos), _grid_feasible, _grid_workers_n,
             _grid_combo_timeout, _grid_overall_timeout, _estimate_backtest_seconds(strategy_type, bars),
         )
+    else:
+        combos = list(itertools.product(*param_ranges))  # small by construction: <= trial_budget
 
     # P2-5: Parameter coverage telemetry
     coverage = {}
@@ -459,7 +471,7 @@ def grid_search(
         "Grid search %s: %d/%d combinations for %s objective=%s | coverage: %s",
         strategy_id,
         len(combos),
-        len(list(itertools.product(*param_ranges))),
+        total_combos,
         axis_names,
         normalized_objective,
         json.dumps(coverage),

--- a/tests/test_backtesting_optimize_compat.py
+++ b/tests/test_backtesting_optimize_compat.py
@@ -13,7 +13,7 @@ from forven.backtesting import BacktestingClient
 from forven.db import get_db
 from forven.routers import strategies as strategies_router
 from forven.routers import verdict as verdict_router
-from forven.strategies.optimizer import _get_param_space, grid_search, optimize_strategy
+from forven.strategies.optimizer import _get_param_space, _lhs_sample, grid_search, optimize_strategy
 
 
 def _insert_strategy(strategy_id: str, *, symbol: str = "BTC", timeframe: str = "1h") -> None:
@@ -697,6 +697,70 @@ def test_grid_search_sanitizes_legacy_leverage_axes(monkeypatch):
     assert set(captured_leverage) == {1.0, 2.0}
     assert all(result["params"] == {"rsi_length": 14} for result in results)
     assert all(result["execution_controls"]["leverage"] in {1, 2} for result in results)
+
+
+def test_lhs_sample_draws_from_axes_without_materialized_product():
+    # OOM regression: _lhs_sample must build combos straight from the per-axis
+    # value lists — it never receives (or needs) the full cartesian product.
+    param_ranges = [
+        [round(i * 0.01, 2) for i in range(10_001)],  # 10,001 values
+        list(range(5_000)),
+        [1, 2, 3, 4, 5],
+    ]  # full product = ~2.5e11 combos — materializing it would OOM
+
+    sampled = _lhs_sample(param_ranges, 16)
+
+    assert 1 <= len(sampled) <= 16
+    for combo in sampled:
+        assert len(combo) == 3
+        for dim, value in enumerate(combo):
+            assert value in param_ranges[dim]
+    # Deterministic under the fixed default seed.
+    assert sampled == _lhs_sample(param_ranges, 16)
+
+
+def test_grid_search_huge_grid_never_materializes_product(monkeypatch):
+    # OOM regression: fine-grained {min,max,step} API ranges used to be expanded
+    # into a full `list(itertools.product(...))` BEFORE the trial budget applied.
+    # This grid is ~1e12 combos; the search must sample and complete regardless.
+    evaluated: list[dict] = []
+
+    def _fake_backtest_strategy(**kwargs):
+        evaluated.append(kwargs["params"])
+        return {
+            "metrics": {
+                "total_trades": 10,
+                "sharpe": 1.0,
+                "total_return_pct": 5.0,
+                "win_rate": 50.0,
+                "profit_factor": 1.2,
+            }
+        }
+
+    def _no_candles(**_kwargs):
+        raise RuntimeError("no candle data in tests")
+
+    monkeypatch.setattr("forven.strategies.optimizer.backtest_strategy", _fake_backtest_strategy)
+    monkeypatch.setattr("forven.strategies.backtest.load_backtest_candles", _no_candles)
+
+    results = grid_search(
+        "S-huge-grid",
+        "BTC",
+        "rsi_momentum",
+        {
+            "alpha": {"min": 0.0, "max": 100.0, "step": 0.01},   # 10,001 values
+            "beta": {"min": 0.0, "max": 100.0, "step": 0.01},    # 10,001 values
+            "gamma": {"min": 0, "max": 9_999, "step": 1},        # 10,000 values
+        },
+        bars=240,
+        max_trials=8,
+    )
+
+    assert results
+    assert 1 <= len(evaluated) <= 8
+    # trials_evaluated must reflect the SAMPLED count (DSR deflation input),
+    # not the astronomical full-grid count.
+    assert all(result["trials_evaluated"] == len(evaluated) for result in results)
 
 
 def _isolate_param_space_lookups(monkeypatch, *, registry_obj=None):


### PR DESCRIPTION
## Problem

A user reported that optimization "first builds the full grid of possible combinations and then samples them, which can quickly OOM." Confirmed: `grid_search` ran `combos = list(itertools.product(*param_ranges))` **before** any trial budget applied. Fine-grained `{min,max,step}` ranges from the API/UI (e.g. `step: 0.01` over `0..100` on two axes = ~1e8 combos) materialize an astronomically large list and OOM the process. The full product was then built a **second** time just to count it for a log line.

The trial cap (`MAX_GRID_COMBOS`/LHS sampling) only ever limited how many backtests *ran* — not the memory to build the grid.

## Fix

- Count the grid arithmetically (`math.prod` of per-axis lengths); only materialize the explicit combo list when the total is already within the trial budget (small by construction).
- `_lhs_sample` now draws combos straight from the per-axis value lists — its body never used the materialized product; the `combos` parameter was dead weight.
- The coverage log reuses the precomputed total instead of rebuilding the product.

Behavior is otherwise identical: same LHS seed, same budget math, `trials_evaluated` still stamps the **sampled** count (the DSR deflation input).

## Tests

- `test_lhs_sample_draws_from_axes_without_materialized_product` — LHS over a ~2.5e11-combo space returns valid, deterministic samples.
- `test_grid_search_huge_grid_never_materializes_product` — a ~1e12-combo grid from fine-grained API ranges completes through `grid_search` (would OOM/hang before this fix).
- Full optimizer-adjacent suites green locally: `test_backtesting_optimize_compat.py`, `test_optimization_acceptance.py`, `test_deflated_sharpe.py` (68 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)