### PR TITLE
Evening bug-report triage: telemetry, risk-cap stamping, agent write_file, crucible gate, tool surfaces

### DIFF
--- a/forven/agents/providers.py
+++ b/forven/agents/providers.py
@@ -24,6 +24,15 @@ log = logging.getLogger("forven.agents.providers")
 # Shared data structures
 # ---------------------------------------------------------------------------
 
+# Output-token budget for agent turns. The previous 4096 was routinely hit
+# mid-tool-call by post-mortem / lessons writes (~4KB of write_file content
+# plus narrative plus JSON overhead), producing consistent mid-sentence
+# truncations (three strikes in the week of 2026-07-06). Raising the ceiling
+# reduces the trigger; ProviderResponse.truncated + the runner guard handle
+# the residual case honestly.
+_AGENT_MAX_TOKENS = 8192
+
+
 @dataclass
 class ToolCall:
     """A single tool invocation parsed from an AI response."""
@@ -45,6 +54,13 @@ class ProviderResponse:
     # transcript so the operator can see WHY the agent acted. None when the
     # provider/model exposes no readable reasoning.
     reasoning: str | None = None
+    # True when the provider cut this turn at the output-token limit
+    # (stop_reason "max_tokens" / finish_reason "length"). Tool calls parsed
+    # from such a turn are UNTRUSTWORTHY: some gateways repair the cut JSON
+    # into valid-but-truncated arguments, which silently wrote ~4KB-truncated
+    # files (2026-07-06 write_file reports, mid-sentence cuts). The runner
+    # refuses to execute tool calls from truncated turns.
+    truncated: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -110,7 +126,7 @@ class MiniMaxProvider(ToolCallProvider):
             "model": model_id,
             "messages": messages,
             "system": system,
-            "max_tokens": 4096,
+            "max_tokens": _AGENT_MAX_TOKENS,
             "temperature": 0.7,
             "tools": tools,
         }
@@ -147,13 +163,14 @@ class MiniMaxProvider(ToolCallProvider):
             raw_assistant_message=content_blocks,
             usage=usage,
             reasoning="\n\n".join(thinking_parts) or None,
+            truncated=(stop_reason == "max_tokens"),
         )
 
     async def stream(self, model_id, messages, system, tools, token):
         headers = {"x-api-key": token, "content-type": "application/json"}
         body = {
             "model": model_id, "messages": messages, "system": system,
-            "max_tokens": 4096, "temperature": 0.7, "tools": tools,
+            "max_tokens": _AGENT_MAX_TOKENS, "temperature": 0.7, "tools": tools,
         }
         async for ev in _stream_anthropic_messages(self.ENDPOINT, headers, body):
             yield ev
@@ -410,6 +427,7 @@ async def _stream_anthropic_messages(endpoint, headers, body):
         text=text, tool_calls=tool_calls,
         stop=(not tool_calls or stop_reason == "end_turn"),
         raw_assistant_message=content_blocks, usage=usage,
+        truncated=(stop_reason == "max_tokens"),
     )}
 
 
@@ -433,7 +451,7 @@ class OpenAIProvider(ToolCallProvider):
         body = {
             "model": model_id,
             "messages": _build_openai_messages(system, messages),
-            "max_tokens": 4096, "temperature": 0.7,
+            "max_tokens": _AGENT_MAX_TOKENS, "temperature": 0.7,
             "tools": self._openai_tools, "tool_choice": "auto",
         }
         async for ev in _stream_openai_chat(self.ENDPOINT, headers, body, include_usage=True):
@@ -452,7 +470,7 @@ class OpenAIProvider(ToolCallProvider):
         body = {
             "model": model_id,
             "messages": openai_messages,
-            "max_tokens": 4096,
+            "max_tokens": _AGENT_MAX_TOKENS,
             "temperature": 0.7,
             "tools": self._openai_tools,
             "tool_choice": "auto",
@@ -465,6 +483,7 @@ class OpenAIProvider(ToolCallProvider):
 
         choice = (data.get("choices") or [{}])[0]
         assistant = choice.get("message") or {}
+        finish_reason = str(choice.get("finish_reason") or "").strip().lower()
         assistant_text = _coerce_openai_text(assistant.get("content"))
         # Reasoning models (DeepSeek-R1, o-series via compat gateways, ...)
         # return their chain-of-thought as `reasoning_content`.
@@ -497,6 +516,7 @@ class OpenAIProvider(ToolCallProvider):
             raw_assistant_message=raw_msg,
             usage=usage,
             reasoning=reasoning,
+            truncated=(finish_reason == "length"),
         )
 
     def append_assistant(self, messages, response):
@@ -646,7 +666,7 @@ class LMStudioProvider(ToolCallProvider):
         body = {
             "model": model_id,
             "messages": _build_openai_messages(system, messages),
-            "max_tokens": 4096, "temperature": 0.7,
+            "max_tokens": _AGENT_MAX_TOKENS, "temperature": 0.7,
             "tools": self._openai_tools, "tool_choice": "auto",
         }
         endpoint = f"{self._get_base_url()}/v1/chat/completions"
@@ -666,7 +686,7 @@ class LMStudioProvider(ToolCallProvider):
         body = {
             "model": model_id,
             "messages": openai_messages,
-            "max_tokens": 4096,
+            "max_tokens": _AGENT_MAX_TOKENS,
             "temperature": 0.7,
             "tools": self._openai_tools,
             "tool_choice": "auto",
@@ -680,6 +700,7 @@ class LMStudioProvider(ToolCallProvider):
 
         choice = (data.get("choices") or [{}])[0]
         assistant = choice.get("message") or {}
+        finish_reason = str(choice.get("finish_reason") or "").strip().lower()
         assistant_text = _coerce_openai_text(assistant.get("content"))
         reasoning = str(assistant.get("reasoning_content") or "").strip() or None
         raw_tool_calls = assistant.get("tool_calls") or []
@@ -709,6 +730,7 @@ class LMStudioProvider(ToolCallProvider):
             raw_assistant_message=raw_msg,
             usage=usage,
             reasoning=reasoning,
+            truncated=(finish_reason == "length"),
         )
 
     def append_assistant(self, messages, response):
@@ -753,7 +775,7 @@ class ZAIProvider(ToolCallProvider):
             }
             body = {
                 "model": model_id, "messages": messages, "system": system,
-                "max_tokens": 4096, "temperature": 0.7, "tools": tools,
+                "max_tokens": _AGENT_MAX_TOKENS, "temperature": 0.7, "tools": tools,
             }
             async for ev in _stream_anthropic_messages(f"{base_url}/v1/messages", headers, body):
                 yield ev
@@ -764,7 +786,7 @@ class ZAIProvider(ToolCallProvider):
         body = {
             "model": model_id,
             "messages": _build_openai_messages(system, messages),
-            "max_tokens": 4096, "temperature": 0.7,
+            "max_tokens": _AGENT_MAX_TOKENS, "temperature": 0.7,
             "tools": self._openai_tools, "tool_choice": "auto",
         }
         async for ev in _stream_openai_chat(f"{base_url}/chat/completions", headers, body, include_usage=False):
@@ -785,7 +807,7 @@ class ZAIProvider(ToolCallProvider):
                 "model": model_id,
                 "messages": messages,
                 "system": system,
-                "max_tokens": 4096,
+                "max_tokens": _AGENT_MAX_TOKENS,
                 "temperature": 0.7,
                 "tools": tools,
             }
@@ -817,6 +839,7 @@ class ZAIProvider(ToolCallProvider):
                 stop=(not tool_calls or stop_reason == "end_turn"),
                 raw_assistant_message=content_blocks,
                 usage=usage,
+                truncated=(stop_reason == "max_tokens"),
             )
 
         if self._openai_tools is None:
@@ -828,7 +851,7 @@ class ZAIProvider(ToolCallProvider):
         body = {
             "model": model_id,
             "messages": openai_messages,
-            "max_tokens": 4096,
+            "max_tokens": _AGENT_MAX_TOKENS,
             "temperature": 0.7,
             "tools": self._openai_tools,
             "tool_choice": "auto",
@@ -841,6 +864,7 @@ class ZAIProvider(ToolCallProvider):
 
         choice = (data.get("choices") or [{}])[0]
         assistant = choice.get("message") or {}
+        finish_reason = str(choice.get("finish_reason") or "").strip().lower()
         assistant_text = _coerce_openai_text(assistant.get("content"))
         reasoning = str(assistant.get("reasoning_content") or "").strip() or None
         if not assistant_text and reasoning:
@@ -872,6 +896,7 @@ class ZAIProvider(ToolCallProvider):
             raw_assistant_message=raw_msg,
             usage=usage,
             reasoning=reasoning,
+            truncated=(finish_reason == "length"),
         )
 
     def append_assistant(self, messages, response):
@@ -956,7 +981,7 @@ class AnthropicProvider(ToolCallProvider):
         }
         body = {
             "model": model_id, "messages": messages, "system": system,
-            "max_tokens": 4096, "temperature": 0.7, "tools": tools,
+            "max_tokens": _AGENT_MAX_TOKENS, "temperature": 0.7, "tools": tools,
         }
         async for ev in _stream_anthropic_messages(endpoint, headers, body):
             yield ev
@@ -972,7 +997,7 @@ class AnthropicProvider(ToolCallProvider):
             "model": model_id,
             "messages": messages,
             "system": system,
-            "max_tokens": 4096,
+            "max_tokens": _AGENT_MAX_TOKENS,
             "temperature": 0.7,
             "tools": tools,
         }

--- a/forven/agents/runner.py
+++ b/forven/agents/runner.py
@@ -515,6 +515,27 @@ async def _call_with_tools_single(
                 continue
             return (response.text or last_nonempty_text, total_usage)
 
+        # NEVER execute tool calls parsed from a length-truncated turn: the
+        # arguments may have been cut mid-generation and then "repaired" into
+        # valid-but-truncated JSON by the provider/gateway — which silently
+        # wrote mid-sentence-truncated files (2026-07-06 write_file reports,
+        # consistent ~4KB cuts). Tell the model what happened so it retries
+        # with smaller content instead of trusting a phantom success.
+        if response.truncated and response.tool_calls:
+            impl.append_assistant(messages, response)
+            truncation_notice = (
+                "Error: your response hit the output-token limit and this tool call was cut "
+                "mid-generation, so it was NOT executed (its arguments may be truncated). "
+                "Retry with smaller content — for large writes, split the content across "
+                "multiple write_file append calls."
+            )
+            impl.append_tool_results(
+                messages, [(tc.id, truncation_notice) for tc in response.tool_calls]
+            )
+            if transcript is not None:
+                transcript.write("event", content=truncation_notice, tool_round=round_num)
+            continue
+
         # Append assistant message and execute tool calls.
         impl.append_assistant(messages, response)
 
@@ -809,9 +830,21 @@ def _task_tool_output_shows_success(tool_call: dict) -> bool:
     summary = str(tool_call.get("output_summary") or "").strip().lower()
     if not summary:
         return False
+    # Tool errors are returned as strings prefixed "Error:" (tools_core
+    # convention) — classify those first so a success marker inside an error
+    # message can't flip the verdict.
+    if summary.startswith("error"):
+        return False
     if '"ok": true' in summary or '"persisted": true' in summary:
         return True
     if summary.startswith("strategy created:") or "registered successfully" in summary:
+        return True
+    # write_file success phrasings ("Appended N chars to X (verified)" /
+    # "Wrote N chars to X (verified)"). Without these, EVERY successful
+    # write_file was stamped [FAILED] in the tool ledger — agents documented
+    # the tag as "bimodal/unreliable" for a week (L142) and Brain burned
+    # cycles re-verifying writes that had landed fine.
+    if summary.startswith("appended ") or summary.startswith("wrote "):
         return True
     return False
 

--- a/forven/agents/tools_assistant.py
+++ b/forven/agents/tools_assistant.py
@@ -53,21 +53,28 @@ _COMMON_FAMILIES = (
     permissions={"brain", "role:risk-manager", None},
 )
 def _tool_get_portfolio_status() -> str:
-    from forven.db import get_open_trades, kv_get
+    from forven.db import get_open_trades
+    from forven.portfolio_status import portfolio_status_snapshot
 
-    status = kv_get("status") or {}
-    equity = status.get("accountEquity", 0) or 0
-    hwm = status.get("highWaterMark", 0) or 0
-    drawdown_pct = ((hwm - equity) / hwm * 100) if hwm else 0.0
+    # Reads the daemon's REAL risk-tick snapshot (KV daemon_state) — the same
+    # numbers the kill-switch and daily-loss guard act on. The previous source
+    # (KV "status", camelCase fields) was never written by anything, so this
+    # tool reported equity=0/HWM=0 forever and risk audits ran blind.
+    snapshot = portfolio_status_snapshot()
     open_trades = get_open_trades() or []
     out = {
-        "kill_switch_active": bool(status.get("killSwitch")),
-        "account_equity": equity,
-        "high_water_mark": hwm,
-        "drawdown_pct": round(drawdown_pct, 2),
-        "daily_pnl": status.get("dailyPnl", 0),
-        "regime": status.get("regime", "unknown"),
-        "fear_greed": status.get("fng"),
+        "kill_switch_active": snapshot["kill_switch_active"],
+        "daily_halt": snapshot["daily_halt"],
+        "account_equity": snapshot["account_equity"],
+        "equity_available": snapshot["equity_available"],
+        "equity_source": snapshot["equity_source"],
+        "high_water_mark": snapshot["high_water_mark"],
+        "drawdown_pct": snapshot["drawdown_pct"],
+        "daily_pnl_pct": snapshot["daily_pnl_pct"],
+        "regime": snapshot["regime"],
+        "fear_greed": snapshot["fear_greed"],
+        "synced_at": snapshot["synced_at"],
+        "daemon_running": snapshot["daemon_running"],
         "open_position_count": len(open_trades),
         "open_positions": [
             {
@@ -488,8 +495,6 @@ def _tool_get_settings_overview() -> str:
     permissions={"brain", None},
 )
 def _tool_get_ops_overview() -> str:
-    from forven.db import kv_get
-
     out: dict = {}
     try:
         from forven.control_plane.ops import get_system_mode_status
@@ -504,11 +509,16 @@ def _tool_get_ops_overview() -> str:
         out["system_error"] = str(exc)
 
     try:
-        status = kv_get("status") or {}
+        from forven.portfolio_status import portfolio_status_snapshot
+
+        snapshot = portfolio_status_snapshot()
         out["risk"] = {
-            "kill_switch_active": bool(status.get("killSwitch")),
-            "account_equity": status.get("accountEquity"),
-            "daily_pnl": status.get("dailyPnl"),
+            "kill_switch_active": snapshot["kill_switch_active"],
+            "daily_halt": snapshot["daily_halt"],
+            "account_equity": snapshot["account_equity"],
+            "equity_available": snapshot["equity_available"],
+            "daily_pnl_pct": snapshot["daily_pnl_pct"],
+            "drawdown_pct": snapshot["drawdown_pct"],
         }
     except Exception as exc:
         out["risk_error"] = str(exc)

--- a/forven/agents/tools_backtesting.py
+++ b/forven/agents/tools_backtesting.py
@@ -309,9 +309,16 @@ def _persist_agent_verdict(strategy_id: str, verdict_result: dict) -> bool:
 @register_tool(
     name="run_backtest",
     description=(
-        "Run a strategy backtest. Any strategy family and params are accepted — composite strategies "
-        "mixing multiple indicator families work seamlessly. Returns trades and "
-        "metrics (Sharpe, win rate, profit factor, max drawdown, fitness score)."
+        # The old text promised "any strategy family ... accepted"; the engine
+        # (correctly) rejects families with no registered runtime class as
+        # orphans, and agents filed the mismatch as an infra bug (2026-07-06,
+        # oi_expansion_momentum). The contract must match the gate.
+        "Run a strategy backtest. strategy_type must be a REGISTERED runtime family: "
+        "a pre-built param family or a custom class registered under "
+        "forven/strategies/custom/. A family with no registered class is rejected as "
+        "an orphan (it would silently produce zero signals) — register the class "
+        "first, or compose from known param families. Returns trades and metrics "
+        "(Sharpe, win rate, profit factor, max drawdown, fitness score)."
     ),
     input_schema={
         "type": "object",
@@ -321,8 +328,9 @@ def _persist_agent_verdict(strategy_id: str, verdict_result: dict) -> bool:
             "strategy_type": {
                 "type": "string",
                 "description": (
-                    "Strategy family name — any pre-built or novel composite family. "
-                    "Composite strategies mixing indicators are encouraged."
+                    "Strategy family name — a pre-built param family or a registered "
+                    "custom class TYPE_NAME. Unregistered/invented family names are "
+                    "rejected (no runtime class = zero signals)."
                 ),
             },
             "params": {"type": "object", "description": "Strategy parameters dict — any params your strategy needs"},
@@ -428,6 +436,13 @@ def _tool_run_code(code: str) -> str:
                 if validation["lint_issues"]:
                     output += f"Lint issues: {'; '.join(validation['lint_issues'][:5])}\n"
                 exec_r = validation["execution_result"]
+                # The harness prints its diagnostics (incl. the full exception
+                # from generate_signal/instantiation) to STDOUT before exiting
+                # non-zero; dropping stdout here left agents staring at a
+                # truncated mystery ("type obje...") across five consecutive
+                # register failures (2026-07-06 H01614 report).
+                if exec_r.get("stdout"):
+                    output += f"Harness output: {str(exec_r['stdout']).strip()[:1200]}\n"
                 if exec_r["stderr"]:
                     output += f"Error: {exec_r['stderr'][:500]}\n"
                 if validation["code"] != code:

--- a/forven/agents/tools_core.py
+++ b/forven/agents/tools_core.py
@@ -391,13 +391,32 @@ def _tool_write_file(path: str, content: str, append: bool = True) -> str:
             "memory/, agents/, narratives/, post_mortems/, lessons/, notes/ "
             "with extension .md/.txt/.json."
         )
+    # Post-write verification via the SAME read path agents use: the tool's
+    # return value is ground truth, not an assumption. Agents spent a week
+    # cross-checking unreliable success/FAILED signals against re-reads
+    # (2026-07-06 reports: appends that "succeeded" but never showed up on
+    # re-read because the divergent-roots resolution hid them).
+    from forven.workspace import read_workspace
+
     if append:
         append_workspace(path, content)
-        return f"Appended to {path}"
+        after = read_workspace(path, optional=True) or ""
+        if content and content.strip() and content.strip() not in after:
+            return (
+                f"Error: append to {path} did not persist "
+                "(post-write verification could not find the content on re-read)"
+            )
+        return f"Appended {len(content)} chars to {path} (file now {len(after)} chars, verified)"
     else:
         from forven.workspace import write_workspace
         write_workspace(path, content)
-        return f"Wrote {path}"
+        after = read_workspace(path, optional=True) or ""
+        if after != content:
+            return (
+                f"Error: write to {path} did not persist "
+                f"(post-write verification read {len(after)} chars, expected {len(content)})"
+            )
+        return f"Wrote {len(content)} chars to {path} (verified)"
 
 @register_tool(
     name="list_local_datasets",

--- a/forven/agents/tools_core.py
+++ b/forven/agents/tools_core.py
@@ -508,19 +508,40 @@ def _tool_fetch_exchange_data(params: dict) -> str:
 
 @register_tool(
     name="get_local_ohlcv",
-    description="Read OHLCV bars from a local dataset. Use for data analysis and strategy ideation.",
+    description=(
+        "Read OHLCV bars from a local dataset. Use for data analysis and strategy "
+        "ideation. Set include_enrichment=true to join the derivative streams the "
+        "strategy engine sees (funding_rate, open_interest, taker_buy_sell_ratio, "
+        "ls_ratio, basis, iv_btc/iv_eth, liquidation columns) — plain calls return "
+        "OHLCV only, which does NOT mean the enrichment data is missing."
+    ),
     input_schema={
         "type": "object",
         "properties": {
             "symbol": {"type": "string", "description": "Symbol e.g. 'BTC/USDT' or 'BTC-USDT'"},
             "timeframe": {"type": "string", "description": "Timeframe e.g. '1h', '4h', '1d'"},
             "limit": {"type": "integer", "description": "Number of bars to retrieve (default 100, max 1000)"},
+            "include_enrichment": {
+                "type": "boolean",
+                "description": (
+                    "Join derivative enrichment columns (funding/OI/flow/basis/IV) "
+                    "onto the bars, as the strategy engine does. Default false."
+                ),
+            },
         },
         "required": ["symbol", "timeframe"],
     },
 )
-def _tool_get_local_ohlcv(symbol: str, timeframe: str, limit: int = 100) -> str:
-    """Read OHLCV bars from a local dataset."""
+def _tool_get_local_ohlcv(
+    symbol: str, timeframe: str, limit: int = 100, include_enrichment: bool = False
+) -> str:
+    """Read OHLCV bars from a local dataset, optionally enriched.
+
+    Agents refused to mint OI/funding-keyed strategies because this tool's
+    bare OHLCV response read as "enrichment columns don't exist" (2026-07-06
+    H01622 report + data gap) — the columns join at ENGINE time via
+    DataManager.enrich, they were just never surfaced on this read tool.
+    """
     from forven.data import dataset_ohlcv
     try:
         # Max limit 1000 for safety
@@ -529,13 +550,31 @@ def _tool_get_local_ohlcv(symbol: str, timeframe: str, limit: int = 100) -> str:
         data = result.get("data", [])
         if not data:
             return f"No data found for {symbol} {timeframe}"
-        
-        return json.dumps({
+
+        enrichment_error = None
+        if include_enrichment:
+            try:
+                import pandas as pd
+
+                from forven.data_manager import data_manager
+
+                frame = pd.DataFrame(data)
+                enriched = data_manager.enrich(frame, symbol, timeframe)
+                data = json.loads(enriched.to_json(orient="records", date_format="iso"))
+            except Exception as exc:
+                enrichment_error = str(exc)
+
+        payload = {
             "symbol": result["symbol"],
             "timeframe": result["timeframe"],
             "row_count": result["row_count"],
             "bars": data,
-        }, indent=2)
+        }
+        if include_enrichment:
+            payload["enriched"] = enrichment_error is None
+            if enrichment_error:
+                payload["enrichment_error"] = enrichment_error
+        return json.dumps(payload, indent=2)
     except FileNotFoundError:
         return f"Dataset not found: {symbol} {timeframe}. Use list_local_datasets to see what is available."
     except Exception as e:

--- a/forven/brain.py
+++ b/forven/brain.py
@@ -3757,7 +3757,11 @@ def assign_risk_audit():
     # Exclude Bot Factory paper trades — the live risk audit must not count them
     # as portfolio exposure.
     open_trades = get_open_trades(exclude_bots=True)
-    status = kv_get("status") or {}
+    # Real risk snapshot (KV daemon_state) — the legacy "status" key was never
+    # written, so the audit prompt always claimed the kill switch was inactive.
+    from forven.portfolio_status import portfolio_status_snapshot
+
+    snapshot = portfolio_status_snapshot()
     
     settings = kv_get("forven:settings", {})
     pipeline = kv_get("forven:pipeline_thresholds", {})
@@ -3776,7 +3780,11 @@ def assign_risk_audit():
     prompt = (
         "RISK AUDIT ÃÂÃÂ¢ÃÂÃÂÃÂÃÂ Review portfolio health and exposure.\n\n"
         f"Open positions: {len(open_trades)}\n"
-        f"Kill switch: {'ACTIVE' if status.get('killSwitch') else 'inactive'}\n\n"
+        f"Kill switch: {'ACTIVE' if snapshot['kill_switch_active'] else 'inactive'}\n"
+        f"Account equity: ${snapshot['account_equity']:,.2f}"
+        f" (HWM ${snapshot['high_water_mark']:,.2f},"
+        f" drawdown {snapshot['drawdown_pct']:.1f}%,"
+        f" daily PnL {snapshot['daily_pnl_pct']:+.2f}%)\n\n"
         "Your tasks:\n"
         "1. Review all open positions ÃÂÃÂ¢ÃÂÃÂÃÂÃÂ check if any are approaching stop-loss levels\n"
         "2. Calculate total portfolio exposure and correlation between positions\n"

--- a/forven/context.py
+++ b/forven/context.py
@@ -472,27 +472,36 @@ def _format_recent_trades(limit: int = 20) -> str:
 
 
 def _format_portfolio_status() -> str:
-    """Format portfolio status for context."""
-    status = kv_get("status")
-    if not status:
+    """Format portfolio status for context.
+
+    Reads the daemon's real risk-tick snapshot (KV daemon_state via
+    portfolio_status_snapshot). The previous source (KV "status") was never
+    written by anything, so this section silently vanished from every Brain
+    prompt while the ledger accrued real losses.
+    """
+    from forven.portfolio_status import portfolio_status_snapshot
+
+    snapshot = portfolio_status_snapshot()
+    if not snapshot["equity_available"] and not snapshot["daemon_running"]:
         return ""
 
     lines = ["# PORTFOLIO STATUS"]
 
-    if status.get("killSwitch"):
+    if snapshot["kill_switch_active"]:
         lines.append("**KILL SWITCH ACTIVE**")
+    if snapshot["daily_halt"]:
+        lines.append("**DAILY LOSS HALT ACTIVE**")
 
-    equity = status.get("accountEquity", 0)
-    hwm = status.get("highWaterMark", 0)
-    daily_pnl = status.get("dailyPnl", 0)
-    drawdown = ((hwm - equity) / hwm * 100) if hwm > 0 else 0
+    equity = snapshot["account_equity"]
+    hwm = snapshot["high_water_mark"]
+    lines.append(
+        f"- Equity: ${equity:,.2f} | HWM: ${hwm:,.2f} | Drawdown: {snapshot['drawdown_pct']:.1f}%"
+    )
+    lines.append(f"- Daily PnL: {snapshot['daily_pnl_pct']:+.2f}% of equity")
+    lines.append(f"- Regime: {snapshot['regime']}")
 
-    lines.append(f"- Equity: ${equity:,.2f} | HWM: ${hwm:,.2f} | Drawdown: {drawdown:.1f}%")
-    lines.append(f"- Daily PnL: ${daily_pnl:,.2f}")
-    lines.append(f"- Regime: {status.get('regime', 'unknown')}")
-
-    if status.get("fng"):
-        fng = status["fng"]
+    if snapshot["fear_greed"]:
+        fng = snapshot["fear_greed"]
         lines.append(f"- Fear & Greed: {fng.get('score', '?')} ({fng.get('label', '?')})")
 
     open_trades = get_open_trades(exclude_bots=True)

--- a/forven/context.py
+++ b/forven/context.py
@@ -6,7 +6,7 @@ from datetime import date, datetime, timedelta, timezone
 
 log = logging.getLogger("forven.context")
 
-from forven.db import get_open_trades, get_recent_trades, get_strategies, kv_get, list_approvals
+from forven.db import get_open_trades, get_recent_trades, get_strategies, list_approvals
 from forven.strategy_diversity import render_failure_taxonomy, render_strategy_diversity_guard
 from forven.workspace import (
     read_operator_profile,

--- a/forven/crucible_tasks.py
+++ b/forven/crucible_tasks.py
@@ -106,6 +106,16 @@ def _task_payload_matches_candidate_request(
     payload_hypothesis_id = str(payload.get("hypothesis_id") or "").strip()
     if not payload_crucible_id and not payload_hypothesis_id:
         return False
+    # Agents legitimately hold the DISPLAY id (H01619) where the payload
+    # carries the actual id (HYP-57edc49af1f2) — task prompts reference the
+    # display form. Translate before matching; without this, agents flailed
+    # through id permutations against the same rejection (2026-07-06 reports).
+    payload_display_id = str(payload.get("hypothesis_display_id") or "").strip()
+    if payload_display_id:
+        if normalized_crucible_id == payload_display_id:
+            normalized_crucible_id = payload_hypothesis_id or payload_crucible_id
+        if normalized_hypothesis_id == payload_display_id:
+            normalized_hypothesis_id = payload_hypothesis_id or payload_crucible_id
     payload_ids = {payload_id for payload_id in (payload_crucible_id, payload_hypothesis_id) if payload_id}
     if (
         normalized_hypothesis_id
@@ -153,6 +163,58 @@ def _find_matching_running_candidate_task(
     return {}
 
 
+# Repair/follow-up mints happen AFTER the original develop_candidate task
+# leaves 'running' (Brain reviews the output, then asks the same agent to fix
+# an invalid candidate in a follow-up task that has no trusted payload of its
+# own). Trust keyed strictly to RUNNING tasks deadlocked every such flow —
+# four reports on 2026-07-06 alone (H01619 repair, H-CAND3, H01622 sanitized
+# v2), with agents retrying id permutations against an unexplained rejection.
+# The grace match is bounded: same agent, same crucible payload contract, the
+# task ended recently, and the per-hypothesis strategy spawn cap independently
+# limits mint volume. 'cancelled' stays excluded — the operator said stop.
+CANDIDATE_REPAIR_GRACE_HOURS = 24
+_RECENT_CANDIDATE_STATUSES = ("done", "reviewed", "failed")
+
+
+def _find_matching_recent_candidate_task(
+    normalized_agent_id: str,
+    normalized_crucible_id: str,
+    normalized_hypothesis_id: str,
+) -> dict[str, Any]:
+    if not normalized_agent_id or not normalized_crucible_id:
+        return {}
+    placeholders = ",".join("?" * len(_RECENT_CANDIDATE_STATUSES))
+    with get_db() as conn:
+        rows = conn.execute(
+            f"""
+            SELECT agent_id, status, input_data
+            FROM agent_tasks
+            WHERE agent_id = ?
+              AND status IN ({placeholders})
+              AND type = 'develop_candidate'
+              AND datetime(COALESCE(completed_at, started_at, created_at))
+                  >= datetime('now', ?)
+            ORDER BY id DESC
+            LIMIT 40
+            """,
+            (
+                normalized_agent_id,
+                *_RECENT_CANDIDATE_STATUSES,
+                f"-{int(CANDIDATE_REPAIR_GRACE_HOURS)} hours",
+            ),
+        ).fetchall()
+    for row in rows:
+        task = dict(row)
+        payload = _parse_json_object(task.get("input_data"))
+        if _task_payload_matches_candidate_request(
+            payload,
+            normalized_crucible_id,
+            normalized_hypothesis_id,
+        ):
+            return task
+    return {}
+
+
 def validate_candidate_strategy_creation(
     crucible_id: str | None,
     agent_id: str | None,
@@ -184,16 +246,30 @@ def validate_candidate_strategy_creation(
             normalized_agent_id,
             normalized_crucible_id,
             normalized_hypothesis_id,
+        ) or _find_matching_recent_candidate_task(
+            normalized_agent_id,
+            normalized_crucible_id,
+            normalized_hypothesis_id,
         )
         task_agent_id = str(task.get("agent_id") or "").strip()
         task_status = str(task.get("status") or "").strip()
-        if task_status != "running":
+        if not task:
             return CandidateStrategyCreationValidation(
                 False,
-                "Agent-created strategy candidates require a planner-approved running crucible task.",
+                "Agent-created strategy candidates require a planner-approved crucible task: "
+                f"no running or recently-completed (<= {CANDIDATE_REPAIR_GRACE_HOURS}h) "
+                f"develop_candidate task for agent '{normalized_agent_id}' matches "
+                f"crucible_id/hypothesis_id '{normalized_crucible_id}'. Pass the ACTUAL "
+                "hypothesis id (HYP-...) or its display id (Hxxxxx) from the dispatched "
+                "task payload; ad-hoc creation outside a dispatched candidate task is "
+                "not permitted.",
             )
     if task_agent_id != normalized_agent_id:
         fallback_task = _find_matching_running_candidate_task(
+            normalized_agent_id,
+            normalized_crucible_id,
+            normalized_hypothesis_id,
+        ) or _find_matching_recent_candidate_task(
             normalized_agent_id,
             normalized_crucible_id,
             normalized_hypothesis_id,
@@ -223,19 +299,28 @@ def validate_candidate_strategy_creation(
         payload_crucible_id = str(payload.get("crucible_id") or "").strip()
         payload_hypothesis_id = str(payload.get("hypothesis_id") or "").strip()
         if origin_mode not in TRUSTED_CANDIDATE_ORIGINS:
+            # Diagnostic detail: agents burned whole task budgets retrying id
+            # permutations against the bare one-liner (2026-07-06 reports) —
+            # say WHAT the current task carries and what would satisfy the gate.
             return CandidateStrategyCreationValidation(
                 False,
-                "Agent-created strategy candidates require a trusted crucible candidate task.",
+                "Agent-created strategy candidates require a trusted crucible candidate task. "
+                f"Your current task's origin_mode is '{origin_mode or '(none)'}' which is not a "
+                "trusted origin — creation is only permitted inside a dispatched "
+                "develop_candidate task (running, or completed within "
+                f"{CANDIDATE_REPAIR_GRACE_HOURS}h for repairs) for this crucible.",
             )
         if origin_mode == "crucible_planner" and action_kind not in CANDIDATE_ACTION_KINDS:
             return CandidateStrategyCreationValidation(
                 False,
-                "Agent-created strategy candidates require a planner-approved candidate task.",
+                "Agent-created strategy candidates require a planner-approved candidate task "
+                f"(this task's action_kind is '{action_kind or '(none)'}').",
             )
         if origin_mode != "crucible_planner" and action_kind and action_kind not in CANDIDATE_ACTION_KINDS:
             return CandidateStrategyCreationValidation(
                 False,
-                "Agent-created strategy candidates require a trusted candidate task kind.",
+                "Agent-created strategy candidates require a trusted candidate task kind "
+                f"(this task's action_kind is '{action_kind}').",
             )
         if not payload_crucible_id and not payload_hypothesis_id:
             return CandidateStrategyCreationValidation(
@@ -254,11 +339,15 @@ def validate_candidate_strategy_creation(
         ):
             return CandidateStrategyCreationValidation(
                 False,
-                "Agent-created strategy candidates must use the planner-approved crucible_id and hypothesis_id pair.",
+                "Agent-created strategy candidates must use the planner-approved crucible_id and "
+                f"hypothesis_id pair (the dispatched task carries crucible_id="
+                f"'{payload_crucible_id or '(none)'}', hypothesis_id='{payload_hypothesis_id or '(none)'}').",
             )
         return CandidateStrategyCreationValidation(
             False,
-            "Agent-created strategy candidates require a planner-approved matching crucible task.",
+            "Agent-created strategy candidates require a planner-approved matching crucible task "
+            f"(requested '{normalized_crucible_id}'; the dispatched task carries "
+            f"'{payload_crucible_id or payload_hypothesis_id or '(none)'}').",
         )
 
     payload_crucible_id = str(payload.get("crucible_id") or "").strip()

--- a/forven/exchange/risk.py
+++ b/forven/exchange/risk.py
@@ -147,6 +147,21 @@ def _get_risk_limits() -> dict[str, float]:
     return base_limits
 
 
+def max_risk_per_trade_limit() -> float:
+    """The ACTIVE per-trade risk cap as an equity fraction (0.02 = 2%).
+
+    Mode-aware (testnet vs mainnet profile) and honoring the operator's
+    max_risk_per_trade_pct / legacy max_position_size_pct override. This is
+    the same number can_open's Rule 0b enforces; exposed so profile SELECTION
+    (gauntlet execution-profile stamping) can constrain its search grid to
+    policy — kernel-parity callers legitimately skip the order-time cap
+    (enforce_risk_caps=False mirrors the frozen profile), so a profile above
+    the cap must never be stamped in the first place (S05215 shipped to paper
+    at 3% against a 2% cap, 2026-07-06).
+    """
+    return float(_get_risk_limits()["max_risk_per_trade"])
+
+
 def _load_risk_settings() -> dict:
     """Return persisted settings as a plain dict."""
     try:

--- a/forven/gauntlet/tasks.py
+++ b/forven/gauntlet/tasks.py
@@ -1386,6 +1386,19 @@ def _select_and_persist_execution_profile(workflow: dict[str, Any], strategy_id:
     ):
         return {"skipped": True, "reason": "execution profile already selected"}
 
+    # Constrain the sizing grid to the ACTIVE per-trade risk cap. The stamped
+    # profile is executed with enforce_risk_caps=False (parity: paper/live
+    # mirror the frozen engine), so the order-time cap never re-checks it —
+    # a profile above policy must not be selectable here at all. Without this,
+    # the grid's 0.05 default stamped 3% profiles against a 2% testnet cap
+    # (S05215/S06127, 2026-07-06 risk-audit reports).
+    try:
+        from forven.exchange.risk import max_risk_per_trade_limit
+
+        risk_cap = max_risk_per_trade_limit()
+    except Exception:
+        risk_cap = 0.02
+
     selection = select_execution_profile(
         strategy_id=strategy_id,
         asset=str(row.get("symbol") or "BTC"),
@@ -1393,6 +1406,7 @@ def _select_and_persist_execution_profile(workflow: dict[str, Any], strategy_id:
         params=params,
         timeframe=str(row.get("timeframe") or "1h"),
         regime_gate=False,  # match the paper scanner's kernel call (the parity reference)
+        max_risk=risk_cap,
         lean=True,          # bounded grid for promotion-time latency
     )
 

--- a/forven/portfolio_status.py
+++ b/forven/portfolio_status.py
@@ -1,0 +1,89 @@
+"""Canonical portfolio-status snapshot for agent tools and Brain context.
+
+The agent tools (`get_portfolio_status`, `get_ops_overview`) and the Brain
+context formatter previously read KV key ``status`` with camelCase fields
+(``accountEquity``/``highWaterMark``/``dailyPnl``/``killSwitch``) — a key
+NOTHING writes (there is no ``kv_set("status")`` anywhere), so every consumer
+saw equity=0/HWM=0/daily_pnl=0 while the ledger accrued real losses. The risk
+agents audited a null book for weeks; on 2026-07-06 this escalated to a
+CRITICAL report ("hiding a daily-loss breach — kill-switch unverifiable").
+
+The daemon's REAL snapshot lives in KV ``daemon_state``: ``account_equity``
+plus the risk tick's ``risk`` block (``high_water_mark``, ``daily_pnl_pct``,
+``drawdown_pct``, ``kill_switch``, ``daily_halt`` — daemon.py risk cycle).
+This module is the single assembler over that source; the numbers surfaced
+here are the SAME numbers the enforcement layer (kill-switch, daily-loss
+guard) acts on, so an agent audit reads the truth the guards see rather than
+a parallel reconstruction.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _as_float(value: object, default: float = 0.0) -> float:
+    try:
+        result = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+    return result if result == result else default  # NaN guard
+
+
+def portfolio_status_snapshot() -> dict[str, Any]:
+    """Assemble the portfolio/risk snapshot from the daemon's real KV state.
+
+    Returns a dict with snake_case fields; zeros only when the daemon has
+    genuinely never populated the state (fresh install / daemon down), in
+    which case ``equity_available`` is False so consumers can distinguish
+    "flat book" from "no telemetry".
+    """
+    from forven.db import kv_get
+
+    raw = kv_get("daemon_state", {}) or {}
+    state: dict[str, Any] = raw if isinstance(raw, dict) else {}
+    risk_raw = state.get("risk")
+    risk: dict[str, Any] = risk_raw if isinstance(risk_raw, dict) else {}
+
+    equity = _as_float(state.get("account_equity"))
+    hwm = _as_float(risk.get("high_water_mark"))
+    drawdown_pct = _as_float(risk.get("drawdown_pct"))
+    if drawdown_pct == 0.0 and hwm > 0 and 0 < equity < hwm:
+        drawdown_pct = (hwm - equity) / hwm * 100.0
+
+    exch_raw = state.get("exchange_account")
+    exch: dict[str, Any] = exch_raw if isinstance(exch_raw, dict) else {}
+    equity_source = str(exch.get("source") or "").strip().lower() or None
+    if equity_source is None and equity > 0:
+        equity_source = "daemon"
+
+    regime = None
+    try:
+        # Cache-only read (no fetch): this feeds agent prompts and must not
+        # block on network or DB writes.
+        from forven.regime import peek_cached_regime
+
+        cached = peek_cached_regime("BTC")
+        regime = getattr(cached, "regime", None) if cached else None
+    except Exception:
+        regime = None
+
+    fng = state.get("fng") or state.get("fear_greed")
+
+    return {
+        "equity_available": bool(equity > 0),
+        "account_equity": equity,
+        "high_water_mark": hwm,
+        "drawdown_pct": round(drawdown_pct, 2),
+        # PERCENT of equity, from the risk engine's own daily check — the same
+        # number the daily-loss guard reads. (The legacy field was a dollar
+        # figure from a source that never existed.)
+        "daily_pnl_pct": _as_float(risk.get("daily_pnl_pct")),
+        "kill_switch_active": bool(risk.get("kill_switch")),
+        "daily_halt": bool(risk.get("daily_halt")),
+        "equity_source": equity_source,
+        "regime": regime or "unknown",
+        "fear_greed": fng if isinstance(fng, dict) else None,
+        "synced_at": state.get("exchange_positions_synced_at") or state.get("last_scan"),
+        "daemon_running": bool(state.get("running")),
+    }

--- a/forven/workspace.py
+++ b/forven/workspace.py
@@ -2,6 +2,7 @@
 
 import logging
 import shutil
+import threading
 from dataclasses import dataclass, field
 from datetime import date, timedelta
 from pathlib import Path
@@ -157,19 +158,25 @@ def write_workspace(filename: str, content: str):
             pass
 
 
-def append_workspace(filename: str, content: str):
-    """Append to a workspace file."""
-    def _append(path: Path):
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "a", encoding="utf-8") as f:
-            f.write(content)
+_APPEND_LOCK = threading.Lock()
 
-    _append(WORKSPACE_DIR / filename)
-    if LEGACY_WORKSPACE_DIR and LEGACY_WORKSPACE_DIR != WORKSPACE_DIR:
-        try:
-            _append(LEGACY_WORKSPACE_DIR / filename)
-        except Exception:
-            pass
+
+def append_workspace(filename: str, content: str):
+    """Append to a workspace file.
+
+    Reconciles the divergent-roots trap: ``read_workspace`` returns the
+    LONGEST copy across the canonical and legacy roots, while appends
+    previously hit each root independently (legacy failures silently
+    swallowed). Once the roots diverged with the legacy copy ahead, an append
+    landed on the shorter canonical copy and every subsequent read returned
+    the stale legacy copy WITHOUT it — "write_file returned success, the file
+    did not grow" (2026-07-06 agent reports on memory/*.md). Now the append
+    bases on the same best copy the reader resolves, and the RESULT is
+    written to both roots atomically, so reader and writer always agree.
+    """
+    with _APPEND_LOCK:
+        base = read_workspace(filename, optional=True) or ""
+        write_workspace(filename, base + content)
 
 
 def today_memory_path() -> str:

--- a/tests/test_agent_write_file_reliability.py
+++ b/tests/test_agent_write_file_reliability.py
@@ -1,0 +1,88 @@
+"""Agent write_file reliability pack (2026-07-06 reports).
+
+Three failure modes reported by agents in one week:
+1. Appends "returned success, file did not grow" — read_workspace resolves
+   the LONGEST copy across canonical+legacy roots while appends hit each root
+   independently (legacy failures swallowed); once diverged, appends landed on
+   the shorter copy and reads returned the stale longer one.
+2. ~4KB mid-sentence truncations — agent turns capped at 4096 output tokens;
+   gateway-repaired JSON turned cut tool calls into valid-but-truncated
+   content. The runner must refuse tool calls from truncated turns.
+3. Bimodal [FAILED] ledger tags — the ledger classifier had no success
+   marker for write_file, so EVERY successful write was stamped FAILED.
+"""
+
+from __future__ import annotations
+
+from forven.agents.runner import _task_tool_output_shows_success
+from forven.workspace import append_workspace, read_workspace
+
+
+def test_append_lands_even_when_legacy_copy_was_longer(tmp_path, monkeypatch):
+    import forven.workspace as ws
+
+    canonical = tmp_path / "workspace"
+    legacy = tmp_path / "legacy"
+    canonical.mkdir()
+    legacy.mkdir()
+    monkeypatch.setattr(ws, "WORKSPACE_DIR", canonical)
+    monkeypatch.setattr(ws, "LEGACY_WORKSPACE_DIR", legacy)
+    monkeypatch.setattr(ws, "ensure_dirs", lambda: None)
+
+    # Diverged roots: legacy is LONGER (the exact trap — reads resolved to it)
+    (canonical / "memory").mkdir()
+    (legacy / "memory").mkdir()
+    (canonical / "memory" / "2026-07-06.md").write_text("short canonical\n", encoding="utf-8")
+    (legacy / "memory" / "2026-07-06.md").write_text(
+        "much longer legacy copy with historical content\n", encoding="utf-8"
+    )
+
+    append_workspace("memory/2026-07-06.md", "## H01608 review entry\n")
+
+    # The append must be visible through the SAME resolution the reader uses
+    after = read_workspace("memory/2026-07-06.md")
+    assert "## H01608 review entry" in after
+    # and it based on the best (longest) copy, so nothing was lost
+    assert "much longer legacy copy" in after
+    # both roots converged to identical content
+    a = (canonical / "memory" / "2026-07-06.md").read_text(encoding="utf-8")
+    b = (legacy / "memory" / "2026-07-06.md").read_text(encoding="utf-8")
+    assert a == b == after
+
+
+def test_write_file_tool_verifies_and_reports_lengths(tmp_path, monkeypatch):
+    import forven.workspace as ws
+
+    canonical = tmp_path / "workspace"
+    canonical.mkdir()
+    monkeypatch.setattr(ws, "WORKSPACE_DIR", canonical)
+    monkeypatch.setattr(ws, "LEGACY_WORKSPACE_DIR", canonical)
+    monkeypatch.setattr(ws, "ensure_dirs", lambda: None)
+
+    from forven.agents.tools_core import _tool_write_file
+
+    out = _tool_write_file("notes/probe.md", "hello ledger\n", append=True)
+    assert out.startswith("Appended 13 chars to notes/probe.md")
+    assert "verified" in out
+
+    out2 = _tool_write_file("notes/probe.md", "fresh content\n", append=False)
+    assert out2.startswith("Wrote 14 chars to notes/probe.md")
+    assert "verified" in out2
+
+
+def test_ledger_classifies_write_file_outputs_correctly():
+    ok = {"output_summary": "Appended 3500 chars to LESSONS.md (file now 91000 chars, verified)"}
+    assert _task_tool_output_shows_success(ok) is True
+    ok2 = {"output_summary": "Wrote 240 chars to notes/x.md (verified)"}
+    assert _task_tool_output_shows_success(ok2) is True
+    bad = {"output_summary": "Error: append to memory/x.md did not persist (post-write verification ...)"}
+    assert _task_tool_output_shows_success(bad) is False
+    denied = {"output_summary": "Error: SOUL.md is protected. Only the Brain can edit it."}
+    assert _task_tool_output_shows_success(denied) is False
+
+
+def test_truncated_turns_are_flagged_by_providers():
+    from forven.agents.providers import ProviderResponse
+
+    assert ProviderResponse().truncated is False
+    assert ProviderResponse(truncated=True).truncated is True

--- a/tests/test_crucible_strategy_creation_gate.py
+++ b/tests/test_crucible_strategy_creation_gate.py
@@ -50,6 +50,36 @@ def _insert_running_planner_task(
         )
 
 
+def _insert_completed_candidate_task(
+    *,
+    display_id: str,
+    agent_id: str,
+    crucible_id: str,
+    status: str = "reviewed",
+    completed_at: str = None,
+    hypothesis_display_id: str | None = None,
+    origin_mode: str = "hypothesis_promotion_loop",
+) -> None:
+    payload = {
+        "origin_mode": origin_mode,
+        "action_kind": "develop_candidate",
+        "crucible_id": crucible_id,
+        "hypothesis_id": crucible_id,
+    }
+    if hypothesis_display_id:
+        payload["hypothesis_display_id"] = hypothesis_display_id
+    with get_db() as conn:
+        conn.execute(
+            """
+            INSERT INTO agent_tasks
+                (agent_id, type, title, description, input_data, display_id, status, completed_at)
+            VALUES (?, 'develop_candidate', 'Develop candidate', 'Build a candidate strategy', ?, ?, ?,
+                    COALESCE(?, strftime('%Y-%m-%dT%H:%M:%S+00:00', 'now')))
+            """,
+            (agent_id, json.dumps(payload), display_id, status, completed_at),
+        )
+
+
 def test_validate_candidate_strategy_creation_rejects_agent_without_planner_task(forven_db):
     from forven.crucible_tasks import validate_candidate_strategy_creation
 
@@ -61,6 +91,129 @@ def test_validate_candidate_strategy_creation_rejects_agent_without_planner_task
 
     assert result.allowed is False
     assert "planner-approved" in result.reason
+
+
+# --- repair grace window (2026-07-06: H01619/H-CAND3/H01622 deadlock) ------------
+# Brain reviews a develop_candidate output and asks the SAME agent to repair the
+# candidate in a follow-up task. The original task is no longer 'running', so
+# trust keyed strictly to running tasks rejected every repair; the grace window
+# accepts a recently-ended matching task (spawn caps still bound mint volume).
+
+
+def test_repair_after_reviewed_task_is_allowed_within_grace_window(forven_db):
+    from forven.crucible_tasks import validate_candidate_strategy_creation
+
+    _insert_completed_candidate_task(
+        display_id="T9001",
+        agent_id="strategy-developer",
+        crucible_id="HYP-57edc49af1f2",
+        status="reviewed",
+    )
+
+    result = validate_candidate_strategy_creation(
+        crucible_id="HYP-57edc49af1f2",
+        agent_id="strategy-developer",
+        task_display_id="T9999",  # the follow-up repair task, no trusted payload
+    )
+
+    assert result.allowed is True, result.reason
+    assert result.hypothesis_id == "HYP-57edc49af1f2"
+
+
+def test_repair_grace_window_expires(forven_db):
+    from forven.crucible_tasks import validate_candidate_strategy_creation
+
+    _insert_completed_candidate_task(
+        display_id="T9002",
+        agent_id="strategy-developer",
+        crucible_id="HYP-old",
+        status="reviewed",
+        completed_at="2026-01-01T00:00:00+00:00",
+    )
+
+    result = validate_candidate_strategy_creation(
+        crucible_id="HYP-old",
+        agent_id="strategy-developer",
+        task_display_id="T9999",
+    )
+
+    assert result.allowed is False
+    assert "recently-completed" in result.reason
+
+
+def test_repair_grace_window_rejects_other_agents_tasks(forven_db):
+    from forven.crucible_tasks import validate_candidate_strategy_creation
+
+    _insert_completed_candidate_task(
+        display_id="T9003",
+        agent_id="other-agent",
+        crucible_id="HYP-not-yours",
+        status="reviewed",
+    )
+
+    result = validate_candidate_strategy_creation(
+        crucible_id="HYP-not-yours",
+        agent_id="strategy-developer",
+        task_display_id="T9999",
+    )
+
+    assert result.allowed is False
+
+
+def test_display_id_matches_dispatched_task_payload(forven_db):
+    from forven.crucible_tasks import validate_candidate_strategy_creation
+
+    _insert_completed_candidate_task(
+        display_id="T9004",
+        agent_id="strategy-developer",
+        crucible_id="HYP-57edc49af1f2",
+        hypothesis_display_id="H01619",
+        status="done",
+    )
+
+    # agents legitimately hold the display id from the task prompt
+    result = validate_candidate_strategy_creation(
+        crucible_id="H01619",
+        agent_id="strategy-developer",
+        task_display_id="T9999",
+    )
+
+    assert result.allowed is True, result.reason
+    assert result.hypothesis_id == "HYP-57edc49af1f2"
+
+
+def test_untrusted_origin_rejection_names_the_origin(forven_db):
+    from forven.crucible_tasks import validate_candidate_strategy_creation
+
+    with get_db() as conn:
+        conn.execute(
+            """
+            INSERT INTO agent_tasks
+                (agent_id, type, title, description, input_data, display_id, status)
+            VALUES (?, 'develop_candidate', 'Ad hoc', 'x', ?, ?, 'running')
+            """,
+            (
+                "strategy-developer",
+                json.dumps(
+                    {
+                        "origin_mode": "chat",
+                        "action_kind": "develop_candidate",
+                        "crucible_id": "HYP-abc",
+                        "hypothesis_id": "HYP-abc",
+                    }
+                ),
+                "T9005",
+            ),
+        )
+
+    result = validate_candidate_strategy_creation(
+        crucible_id="HYP-abc",
+        agent_id="strategy-developer",
+        task_display_id="T9005",
+    )
+
+    assert result.allowed is False
+    assert "'chat'" in result.reason
 
 
 def test_validate_candidate_strategy_creation_allows_running_planner_candidate_task(forven_db):

--- a/tests/test_execution_profile_risk_cap.py
+++ b/tests/test_execution_profile_risk_cap.py
@@ -1,0 +1,70 @@
+"""Execution-profile selection must respect the active per-trade risk cap (2026-07-06).
+
+Stamped profiles run with enforce_risk_caps=False (kernel parity: paper/live
+mirror the frozen engine), so can_open's Rule 0b never re-checks them. The
+selection grid defaulted to max_risk=0.05 and the promotion stamp site passed
+nothing, so 3% profiles were frozen onto paper strategies against a 2%
+testnet cap (S05215 open paper trade at risk_per_trade=0.03; two risk-audit
+bug reports in one cycle).
+"""
+
+from __future__ import annotations
+
+import json
+
+from forven.db import get_db, kv_set
+from forven.exchange.risk import max_risk_per_trade_limit
+from forven.strategies.execution_selection import candidate_profiles
+
+
+def test_candidate_grid_honors_max_risk():
+    for lean in (False, True):
+        grid = candidate_profiles(max_risk=0.02, lean=lean)
+        risks = {p.get("risk_per_trade") for p in grid if isinstance(p, dict) and "risk_per_trade" in p}
+        assert risks, "grid should include risk-based profiles"
+        assert max(risks) <= 0.02, risks
+
+
+def test_max_risk_per_trade_limit_honors_operator_override(forven_db):
+    # default testnet profile
+    assert max_risk_per_trade_limit() == 0.02
+    kv_set("forven:settings", {"max_risk_per_trade_pct": 1.5})
+    assert max_risk_per_trade_limit() == 0.015
+
+
+def test_promotion_stamp_site_passes_the_active_cap(forven_db, monkeypatch):
+    from forven.gauntlet import tasks as gauntlet_tasks
+
+    with get_db() as conn:
+        conn.execute(
+            "INSERT INTO strategies (id, name, type, status, stage, owner, symbol, timeframe, params, metrics) "
+            "VALUES ('s-cap-stamp', 's-cap-stamp', 'rsi_momentum', 'gauntlet', 'gauntlet', 'brain', 'BTC', '1h', '{}', '{}')",
+        )
+    kv_set("forven:settings", {"max_risk_per_trade_pct": 1.5})
+
+    captured: dict = {}
+
+    def _fake_select(**kwargs):
+        captured.update(kwargs)
+        return {
+            "chosen": None,
+            "chosen_label": "default",
+            "chosen_score": 0.0,
+            "objective": "sharpe",
+            "n_candidates": 1,
+            "n_eligible": 1,
+        }
+
+    monkeypatch.setattr(
+        "forven.strategies.execution_selection.select_execution_profile", _fake_select
+    )
+
+    result = gauntlet_tasks._select_and_persist_execution_profile({}, "s-cap-stamp")
+    assert result.get("skipped") is False
+    assert captured.get("max_risk") == 0.015
+
+    # marker persisted so retries skip the sweep
+    with get_db() as conn:
+        row = conn.execute("SELECT metrics FROM strategies WHERE id = 's-cap-stamp'").fetchone()
+    metrics = json.loads(row["metrics"])
+    assert "gauntlet_selected_execution_profile" in metrics

--- a/tests/test_portfolio_status_snapshot.py
+++ b/tests/test_portfolio_status_snapshot.py
@@ -1,0 +1,90 @@
+"""Portfolio telemetry must read the daemon's REAL risk snapshot (2026-07-06).
+
+The agent tools (get_portfolio_status / get_ops_overview), the Brain context
+formatter, and the risk-audit prompt all read KV key "status" with camelCase
+fields that NOTHING ever writes — so every consumer reported
+equity=0/HWM=0/daily_pnl=0 while the ledger accrued real losses (7 bug reports
+in one evening, incl. a CRITICAL "hiding a daily-loss breach"). They now read
+the daemon_state risk tick via forven.portfolio_status.
+"""
+
+from __future__ import annotations
+
+import json
+
+from forven.db import kv_set
+from forven.portfolio_status import portfolio_status_snapshot
+
+
+def _seed_daemon_state():
+    kv_set(
+        "daemon_state",
+        {
+            "running": True,
+            "account_equity": 987.65,
+            "exchange_account": {"source": "books_only", "accountValue": 987.65},
+            "risk": {
+                "high_water_mark": 1100.0,
+                "daily_pnl_pct": -5.88,
+                "drawdown_pct": 10.13,
+                "kill_switch": True,
+                "daily_halt": True,
+            },
+            "last_scan": "2026-07-06T22:00:00+00:00",
+        },
+    )
+
+
+def test_snapshot_reads_daemon_state(forven_db):
+    _seed_daemon_state()
+    snap = portfolio_status_snapshot()
+    assert snap["equity_available"] is True
+    assert snap["account_equity"] == 987.65
+    assert snap["high_water_mark"] == 1100.0
+    assert snap["drawdown_pct"] == 10.13
+    assert snap["daily_pnl_pct"] == -5.88
+    assert snap["kill_switch_active"] is True
+    assert snap["daily_halt"] is True
+    assert snap["equity_source"] == "books_only"
+
+
+def test_snapshot_distinguishes_no_telemetry_from_flat_book(forven_db):
+    snap = portfolio_status_snapshot()
+    assert snap["equity_available"] is False
+    assert snap["account_equity"] == 0.0
+    assert snap["kill_switch_active"] is False
+
+
+def test_agent_tool_surfaces_real_values(forven_db):
+    _seed_daemon_state()
+    from forven.agents.tools_assistant import _tool_get_portfolio_status
+
+    out = json.loads(_tool_get_portfolio_status())
+    assert out["account_equity"] == 987.65
+    assert out["high_water_mark"] == 1100.0
+    assert out["kill_switch_active"] is True
+    assert out["daily_halt"] is True
+    # the dead camelCase-sourced fields must be gone
+    assert "daily_pnl" not in out
+    assert out["daily_pnl_pct"] == -5.88
+
+
+def test_ops_overview_risk_block_uses_snapshot(forven_db):
+    _seed_daemon_state()
+    from forven.agents.tools_assistant import _tool_get_ops_overview
+
+    out = json.loads(_tool_get_ops_overview())
+    risk = out.get("risk") or {}
+    assert risk.get("account_equity") == 987.65
+    assert risk.get("kill_switch_active") is True
+    assert risk.get("daily_pnl_pct") == -5.88
+
+
+def test_brain_context_section_renders_real_values(forven_db):
+    _seed_daemon_state()
+    from forven.context import _format_portfolio_status
+
+    text = _format_portfolio_status()
+    assert "KILL SWITCH ACTIVE" in text
+    assert "$987.65" in text
+    assert "10.1%" in text


### PR DESCRIPTION
## Summary

6 fixes from the 2026-07-06 evening bug-report triage (20 reports, incl. a CRITICAL risk-manager escalation). Each verified against the live instance and covered by tests.

- **TELEM-1** — `get_portfolio_status` / `get_ops_overview` / Brain context / risk-audit prompt read KV `status` (camelCase) which NOTHING writes → equity=0/HWM=0 forever, risk audits blind, a real daily-loss breach invisible. New `forven.portfolio_status.portfolio_status_snapshot()` reads the daemon risk tick (the same numbers the kill-switch acts on); all four sites repointed; `equity_available` distinguishes no-telemetry from flat-book.
- **RISKCAP-1** — execution-profile selection searched risk levels up to a hardcoded 0.05 and the promotion stamp site passed no cap, freezing 3% `risk_per_trade` profiles onto paper strategies against a 2% policy (order-time cap is deliberately parity-skipped). New `risk.max_risk_per_trade_limit()`; the stamp chokepoint constrains its grid to it.
- **WRITEFILE-1** — agent write_file reliability: appends now reconcile the divergent workspace roots (reads resolve longest copy; appends were landing on the shorter one), results are post-write verified with honest lengths, the tool ledger recognizes write_file successes (every success was stamped FAILED), and the runner refuses tool calls from output-token-truncated turns (gateway-repaired JSON silently wrote ~4KB-truncated files); agent turn ceiling 4096→8192.
- **TRUST-GATE-1** — candidate-creation gate: 24h repair grace window (same agent + same crucible, spawn caps still bound volume), hypothesis display-id translation, diagnostic rejection messages. Unblocks Brain-ordered repairs without weakening the ad-hoc-mint block.
- **TOOL-SURFACE-1** — `run_backtest` contract no longer promises "any family" (orphan rejection is correct behavior); strategy-validation failures include harness stdout (where the real exception prints); `get_local_ohlcv` gains `include_enrichment` joining the engine-visible funding/OI/flow/basis/IV columns (verified live) so agents stop recording false data gaps.

Not code-fixed (operator decisions, documented in triage): H01613 strategy-row cleanup, paper-level correlation-group budget, pair-trade family request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)