### PR TITLE
feat(portfolio): venue-aware basket reset + HL book reset button

### DIFF
--- a/forven/routers/ops.py
+++ b/forven/routers/ops.py
@@ -98,11 +98,15 @@ def post_portfolio_basket_tick():
 
 
 @router.post("/api/portfolio/basket/reset")
-def post_portfolio_basket_reset(body: ConfirmBody):
+def post_portfolio_basket_reset(body: ConfirmBody, venue: str = "binance"):
     _require_portfolio_layer()
+    from fastapi import HTTPException
+
     from forven.basket_runtime import reset_basket_state
 
-    return {"ok": reset_basket_state()}
+    if venue not in ("binance", "hyperliquid"):
+        raise HTTPException(status_code=400, detail=f"unknown basket venue: {venue}")
+    return {"ok": reset_basket_state(venue), "venue": venue}
 
 
 # PORT-LIVE-1: live basket execution arming. Mirrors GO-LIVE-1: typed

--- a/frontend/src/lib/api/portfolio.ts
+++ b/frontend/src/lib/api/portfolio.ts
@@ -134,8 +134,10 @@ export async function tickPortfolioBasket(): Promise<{ ok: boolean; report: unkn
 	return fetchApi('/api/portfolio/basket/tick', { method: 'POST' });
 }
 
-export async function resetPortfolioBasket(): Promise<{ ok: boolean }> {
-	return fetchApi('/api/portfolio/basket/reset', {
+export async function resetPortfolioBasket(
+	venue: 'binance' | 'hyperliquid' = 'binance'
+): Promise<{ ok: boolean }> {
+	return fetchApi(`/api/portfolio/basket/reset?venue=${venue}`, {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		body: JSON.stringify({ confirm: true }),

--- a/frontend/src/routes/portfolio/+page.svelte
+++ b/frontend/src/routes/portfolio/+page.svelte
@@ -143,6 +143,27 @@
 		}
 	}
 
+	let confirmingHlReset = false;
+	let hlResetBusy = false;
+	async function doHlReset() {
+		if (!confirmingHlReset) {
+			confirmingHlReset = true;
+			return;
+		}
+		confirmingHlReset = false;
+		hlResetBusy = true;
+		actionMessage = '';
+		try {
+			await resetPortfolioBasket('hyperliquid');
+			actionMessage = 'HL-native book reset — it re-initializes on the next tick.';
+			await load();
+		} catch (e) {
+			actionMessage = `HL reset failed: ${e instanceof Error ? e.message : e}`;
+		} finally {
+			hlResetBusy = false;
+		}
+	}
+
 	async function refreshAllocation() {
 		refreshBusy = true;
 		actionMessage = '';
@@ -595,7 +616,19 @@
 						<span class="ml-2 text-[10px] font-normal normal-case text-[#667]">ranks HL's own funding — live execution follows THIS book, never the Binance one</span>
 					</h3>
 					{#if hlBook?.exists}
-						<span class="text-[10px] text-[#667]">{hlBook.positions?.count ?? 0} positions · {hlBook.rebalances ?? 0} rebalances</span>
+						<span class="flex items-center gap-2 text-[10px] text-[#667]">
+							{hlBook.positions?.count ?? 0} positions · {hlBook.rebalances ?? 0} rebalances
+							<button
+								class={`border px-1.5 py-0.5 uppercase tracking-wider ${confirmingHlReset ? 'border-red-800 text-red-400' : 'border-[#1a2438] text-[#667] hover:text-[#99a]'}`}
+								disabled={hlResetBusy}
+								on:click={doHlReset}
+							>
+								{confirmingHlReset ? 'Confirm reset' : 'Reset'}
+							</button>
+							{#if confirmingHlReset}
+								<button class="text-[#666] hover:text-[#888]" on:click={() => (confirmingHlReset = false)}>cancel</button>
+							{/if}
+						</span>
 					{/if}
 				</div>
 				{#if hlBook?.exists}


### PR DESCRIPTION
The HL-native book panel had no reset control — only the Binance book did. After FUND-SCALE-1 (PR #42) both paper books need a fresh start post-restart, so:

- `POST /api/portfolio/basket/reset` now takes `?venue=binance|hyperliquid` (default `binance`, 400 on unknown venue)
- the HL panel header gets its own two-step-confirm Reset button
- typed client passes the venue through

svelte-check clean, 39 basket tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWwtDrs9xV9vAkmTGRyLfT