### PR TITLE
docs(basket): fix stale venue caveat in basket_live docstring

### DIFF
--- a/forven/basket_live.py
+++ b/forven/basket_live.py
@@ -29,11 +29,11 @@ Safety architecture (each layer independent):
   the venue doesn't list), so paper-vs-live divergence is visible, never
   silent.
 
-Venue caveat, stated where it belongs: the paper book ranks BINANCE funding
-(the lake's series); live fills happen on Hyperliquid, whose listings and
-funding rates differ. The executor mirrors the paper book's POSITIONS —
-unlistable legs are skipped and reported. A future revision can rank
-venue-native funding.
+Venue note (PORT-HLFUND-1): live fills happen on Hyperliquid, so the
+executor mirrors the HL-NATIVE paper book — the one ranked on Hyperliquid's
+own funding snapshots — never the Binance-ranked research book (cross-venue
+funding diverges: sign agreement ~74%, correlation ~0.5). Legs the venue
+doesn't list are skipped and reported in the ledger.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
The module docstring still described the pre-PORT-HLFUND-1 design (executor mirrors the Binance-ranked paper book). Since PR #42 live execution follows the HL-native book; the docstring now says so. Docstring-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWwtDrs9xV9vAkmTGRyLfT