### PR TITLE
fix(brain): park demotion tasks aimed at dethrone-protected strategies (DISPATCH-BRAKE-1)

### DIFF
--- a/forven/agents/tools_brain.py
+++ b/forven/agents/tools_brain.py
@@ -156,6 +156,20 @@ def _tool_assign_agent_task(params: dict) -> str:
         agent_id, task_type, title, description, input_data=input_data, strategy_id=strategy_id
     )
 
+    # Assignment guards (terminal-stage / dethrone-protection) cancel a task at
+    # creation; saying "Task assigned" for those teaches the Brain to re-dispatch
+    # the same impossible goal every cycle. Report the refusal and its reason.
+    try:
+        with get_db() as conn:
+            row = conn.execute(
+                "SELECT status, error FROM agent_tasks WHERE id = ?", (task_id,)
+            ).fetchone()
+        if row and str(row["status"] or "").strip().lower() == "cancelled":
+            reason = str(row["error"] or "").strip() or "cancelled by an assignment guard"
+            return f"Task NOT dispatched: {reason}"
+    except Exception:
+        pass
+
     # Link the created task to the Brain decision that spawned it (when the
     # runtime worker recorded one for this cycle) so decision → task → outcome
     # joins work.

--- a/forven/brain.py
+++ b/forven/brain.py
@@ -1392,6 +1392,73 @@ def _terminal_task_strategy_stage(conn, strategy_id: str | None) -> str | None:
     return stage if stage in _TERMINAL_TASK_STAGES else None
 
 
+_DETHRONE_TASK_INTENT_RE = re.compile(
+    r"\b(demote|demotion|dethrone|retire|retirement|archive|close[-\s]?out|scrub|flip\s+stage)\b"
+    r"|\bclose\b[^\n]{0,60}\b(trade|position|E\d{3,})\b",
+    re.IGNORECASE,
+)
+
+
+def _dethrone_protected_task_block(
+    conn, strategy_id: str | None, title: str, description: str
+) -> str | None:
+    """Refuse demotion/close-out tasks aimed at a dethrone-protected strategy.
+
+    The soak/cooldown guards block the stage transition itself, but the Brain
+    re-dispatches agents at the same blocked goal every cycle (observed: 4+
+    agent tasks in a day against one soak-protected strategy, each burning a
+    full agent run on a transition that cannot succeed). Park the goal at
+    assignment time with the same reason the transition gate gives.
+
+    The strategy id is re-resolved from the task text here because demotion
+    tasks arrive under task types (execution, risk_audit, ...) that
+    _resolve_task_strategy_id deliberately excludes from text inference.
+    Fail-open: resolution/config errors allow the assignment.
+    """
+    text = f"{title or ''}\n{description or ''}"
+    if not _DETHRONE_TASK_INTENT_RE.search(text):
+        return None
+    try:
+        sid = str(strategy_id or "").strip().upper()
+        if not sid:
+            for candidate in re.findall(r"\bS\d{3,}\b", text.upper()):
+                if conn.execute(
+                    "SELECT 1 FROM strategies WHERE id = ? LIMIT 1", (candidate,)
+                ).fetchone():
+                    sid = candidate
+                    break
+        if not sid:
+            return None
+        row = conn.execute(
+            "SELECT stage, status, stage_changed_at FROM strategies WHERE id = ? LIMIT 1",
+            (sid,),
+        ).fetchone()
+        if not row:
+            return None
+        current_stage = str(row["stage"] or row["status"] or "").strip().lower()
+        try:
+            cooldown_until = dethrone_cooldown_active_until(sid, conn=conn)
+        except Exception:
+            cooldown_until = None
+        if cooldown_until:
+            block = f"operator deny cooldown until {cooldown_until}"
+        else:
+            block = _paper_dethrone_soak_block(conn, sid, current_stage)
+        if not block:
+            return None
+        return (
+            f"{sid} is dethrone-protected ({block}). Its current stage is "
+            f"'{current_stage}' as of {row['stage_changed_at']} — earned through the "
+            f"normal pipeline, so any earlier archival you remember is stale. Do not "
+            f"re-assign demotion/close-out tasks for it; the protection expires on its "
+            f"own, and only the operator can demote sooner (manual demotions execute "
+            f"directly)."
+        )
+    except Exception:
+        log.warning("dethrone-protected task check failed", exc_info=True)
+        return None
+
+
 def transition_stage(
     strategy_id: str,
     target_stage: str,
@@ -3170,6 +3237,24 @@ def assign_task_direct(
                 resolved_strategy_id,
                 terminal_stage,
             )
+        elif str(task_type or "").strip().lower() not in ("post_mortem", "manual"):
+            dethrone_block = _dethrone_protected_task_block(
+                conn, resolved_strategy_id, title, description
+            )
+            if dethrone_block:
+                conn.execute(
+                    """UPDATE agent_tasks
+                       SET status = 'cancelled',
+                           completed_at = ?,
+                           error = ?
+                       WHERE id = ?""",
+                    (
+                        datetime.now(timezone.utc).isoformat(),
+                        dethrone_block,
+                        task_id,
+                    ),
+                )
+                log.info("Cancelled task %s: %s", display_id, dethrone_block)
 
         if needs_approval:
             conn.execute(

--- a/tests/test_dethrone_cooldown.py
+++ b/tests/test_dethrone_cooldown.py
@@ -443,3 +443,114 @@ def test_approval_context_fail_soft_missing_strategy(forven_db):
 
     assert context["strategy_context"] is None
     assert context["approval"]["id"] == approval_id
+
+
+# --- dethrone-protected task dispatch brake ----------------------------------
+#
+# The 2026-07-07 E0113/S05799 loop: the Brain re-dispatched close-out/demotion
+# agent tasks every cycle against a soak-protected strategy (the transition
+# gate blocked each attempt, so the goal could never complete). Demotion-intent
+# tasks aimed at a dethrone-protected strategy are now cancelled at assignment
+# with the same reason the gate gives.
+
+
+def _assigned_task_state(task_id):
+    with get_db() as conn:
+        row = conn.execute(
+            "SELECT status, error FROM agent_tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+    return str(row["status"] or ""), str(row["error"] or "")
+
+
+def test_close_out_task_for_soak_protected_strategy_is_cancelled(forven_db):
+    from forven.brain import assign_task_direct
+
+    sid = _seed_strategy("S77790", stage_age_days=1.0)
+    task_id = assign_task_direct(
+        "risk-manager",
+        "execution",
+        f"R-1-01: close E0999 ({sid} SOL long, archived container)",
+        f"Close trade E0999 and flip {sid} stage to archived.",
+    )
+    status, error = _assigned_task_state(task_id)
+    assert status == "cancelled"
+    assert "dethrone-protected" in error
+    assert sid in error
+
+
+def test_non_demotion_task_for_soak_protected_strategy_dispatches(forven_db):
+    from forven.brain import assign_task_direct
+
+    sid = _seed_strategy("S77791", stage_age_days=1.0)
+    task_id = assign_task_direct(
+        "quant-researcher",
+        "analysis",
+        f"Review {sid} paper performance",
+        f"Summarize {sid} open-trade PnL and regime fit. No lifecycle action.",
+    )
+    status, _ = _assigned_task_state(task_id)
+    assert status != "cancelled"
+
+
+def test_close_out_task_after_soak_window_dispatches(forven_db):
+    from forven.brain import assign_task_direct
+
+    sid = _seed_strategy("S77792", stage_age_days=30.0)
+    task_id = assign_task_direct(
+        "risk-manager",
+        "execution",
+        f"Demote {sid}",
+        f"Demote {sid} to archived after repeated WFA failures.",
+    )
+    status, _ = _assigned_task_state(task_id)
+    assert status != "cancelled"
+
+
+def test_close_out_task_during_deny_cooldown_is_cancelled(forven_db):
+    from forven.brain import assign_task_direct
+
+    sid = _seed_strategy("S77793", stage_age_days=30.0)
+    record_dethrone_deny(sid)
+    task_id = assign_task_direct(
+        "risk-manager",
+        "risk_audit",
+        f"Retire {sid}",
+        f"Retire {sid}; the operator denied the last recommendation but metrics look bad.",
+    )
+    status, error = _assigned_task_state(task_id)
+    assert status == "cancelled"
+    assert "cooldown" in error.lower()
+
+
+def test_manual_close_out_task_for_protected_strategy_dispatches(forven_db):
+    from forven.brain import assign_task_direct
+
+    sid = _seed_strategy("S77794", stage_age_days=1.0)
+    task_id = assign_task_direct(
+        "full-stack-engineer",
+        "manual",
+        f"Operator: demote {sid}",
+        f"The operator asked via Discord to demote {sid}.",
+    )
+    status, _ = _assigned_task_state(task_id)
+    assert status != "cancelled"
+
+
+def test_assign_agent_task_tool_reports_cancelled_dispatch(forven_db):
+    from forven.agents import tools_brain
+
+    sid = _seed_strategy("S77795", stage_age_days=1.0)
+    with get_db() as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO agents (id, name, role) VALUES ('risk-manager', 'Risk Manager', 'risk')"
+        )
+    result = tools_brain._tool_assign_agent_task(
+        {
+            "agent_id": "risk-manager",
+            "task_type": "execution",
+            "title": f"Close E0998 on {sid}",
+            "description": f"Close trade E0998 and archive {sid}.",
+        }
+    )
+    assert result.startswith("Task NOT dispatched:"), result
+    assert "dethrone-protected" in result


### PR DESCRIPTION
## Problem

Observed live 2026-07-07: the Brain dispatched close-out/demotion agent tasks against S05799 every cycle (cycles 344+, tasks T61381/61384/61388/61391 in one day). S05799 had legitimately re-earned paper through the full gauntlet 20h earlier (engine-v2 re-baseline revival -> backtest gate -> gauntlet pass), but the Brain's memos still called it an "archived strategy still trading paper". Every attempt was correctly blocked by the paper-soak dethrone guard — yet nothing stopped the next dispatch, and each dispatched agent burned a full tool-loop run before failing (agents have no close tools by design). The Brain filed 2 bug reports about its own loop.

Two gaps compounded:
1. No brake between "transition blocked" and "assign another agent at the same goal".
2. `assign_agent_task` answered **"Task assigned"** even when the task was cancelled at creation (same silent-success problem as the pre-existing terminal-stage guard), so the Brain never learned the goal was impossible.

## Fix

- `assign_task_direct` cancels demotion/close-out-intent tasks targeting a dethrone-protected strategy (paper-soak or deny-cooldown), reusing the transition gate's own reason and adding the strategy's current stage + recency so stale premises are refuted in-band. `manual` (operator) and `post_mortem` tasks are exempt. Fail-open on errors.
- The strategy id is re-resolved from task text because demotion tasks arrive under task types (`execution`, `risk_audit`, ...) that `_resolve_task_strategy_id` deliberately excludes from text inference.
- `assign_agent_task` now reports `Task NOT dispatched: <reason>` for any task cancelled at creation — covers both the new guard and the terminal-stage guard.

## Tests

6 new tests in `tests/test_dethrone_cooldown.py` (soak-protected close-out cancelled; non-demotion task dispatches; post-soak demotion dispatches; deny-cooldown demotion cancelled; operator manual task exempt; tool reports NOT-dispatched). Full file 30/30 green; `test_pipeline_hardening.py` 117 passed with 1 pre-existing failure (fails identically on unmodified main); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)