### PR TITLE
Forge: prev/next navigation between strategy containers

### DIFF
--- a/frontend/src/lib/stores/forgeNav.ts
+++ b/frontend/src/lib/stores/forgeNav.ts
@@ -1,0 +1,65 @@
+/**
+ * Forge container navigation context.
+ *
+ * When the operator opens a strategy container from The Forge list, the list
+ * page stores its CURRENT filtered+sorted order here (all pages, not just the
+ * visible one). The container detail page reads it back to offer prev/next
+ * arrows that walk the exact order the operator was looking at — filters,
+ * search, and sort included.
+ *
+ * sessionStorage (not a Svelte store) so the context survives a detail-page
+ * reload but never leaks across browser tabs or sessions. Deep links that
+ * did not come through the list simply get no arrows.
+ */
+
+const STORAGE_KEY = 'forven:forge:nav-list';
+
+export type ForgeNavEntry = { id: string; label: string };
+
+export type ForgeNavPosition = {
+	index: number; // 0-based position of the current container
+	total: number;
+	prev: ForgeNavEntry | null;
+	next: ForgeNavEntry | null;
+};
+
+export function setForgeNavList(entries: ForgeNavEntry[]): void {
+	try {
+		const cleaned = entries
+			.filter((e) => e && typeof e.id === 'string' && e.id.trim())
+			.map((e) => ({ id: e.id, label: typeof e.label === 'string' ? e.label : '' }));
+		sessionStorage.setItem(STORAGE_KEY, JSON.stringify(cleaned));
+	} catch {
+		// Storage unavailable/full — navigation arrows just won't render.
+	}
+}
+
+function readList(): ForgeNavEntry[] {
+	try {
+		const raw = sessionStorage.getItem(STORAGE_KEY);
+		if (!raw) return [];
+		const parsed = JSON.parse(raw);
+		if (!Array.isArray(parsed)) return [];
+		return parsed
+			.filter((e): e is ForgeNavEntry => !!e && typeof e.id === 'string' && e.id.trim().length > 0)
+			.map((e) => ({ id: e.id, label: typeof e.label === 'string' ? e.label : '' }));
+	} catch {
+		return [];
+	}
+}
+
+/** Position of `currentId` in the stored list, or null when the container was
+ *  not opened from the list (deep link) or the context is gone. */
+export function getForgeNavPosition(currentId: string): ForgeNavPosition | null {
+	const id = String(currentId || '').trim();
+	if (!id) return null;
+	const list = readList();
+	const index = list.findIndex((e) => e.id === id);
+	if (index === -1) return null;
+	return {
+		index,
+		total: list.length,
+		prev: index > 0 ? list[index - 1] : null,
+		next: index < list.length - 1 ? list[index + 1] : null,
+	};
+}

--- a/frontend/src/routes/lab/+page.svelte
+++ b/frontend/src/routes/lab/+page.svelte
@@ -23,6 +23,7 @@
 		type ManagerRow,
 	} from '$lib/utils/strategy';
 	import { createRealtimeRefresh, type RealtimeRefreshController } from '$lib/utils/realtime';
+	import { setForgeNavList } from '$lib/stores/forgeNav';
 	import StrategyLink from '$lib/components/ui/StrategyLink.svelte';
 	import SortableTh from '$lib/components/ui/SortableTh.svelte';
 	import StrategyExportMenu from '$lib/components/strategy/StrategyExportMenu.svelte';
@@ -371,6 +372,9 @@
 	function goNextPage() { currentPage = Math.min(pageCount, currentPage + 1); }
 
 	function openContainer(row: ManagerRow) {
+		// Hand the detail page the FULL filtered+sorted order (not just the visible
+		// page) so its prev/next arrows walk exactly what this view shows.
+		setForgeNavList(rowsInView.map((r) => ({ id: r.id, label: r.display_name || r.name })));
 		goto(`/lab/strategy/${encodeURIComponent(row.id)}?returnTo=${encodeURIComponent('/lab')}`);
 	}
 

--- a/frontend/src/routes/lab/strategy/[id]/+page.svelte
+++ b/frontend/src/routes/lab/strategy/[id]/+page.svelte
@@ -80,6 +80,7 @@
 	import StrategyExportMenu from '$lib/components/strategy/StrategyExportMenu.svelte';
 	import StrategyImportDialog from '$lib/components/strategy/StrategyImportDialog.svelte';
 	import StageControl from '$lib/components/strategy/StageControl.svelte';
+	import { getForgeNavPosition, type ForgeNavEntry } from '$lib/stores/forgeNav';
 	import type { StrategyImportResult } from '$lib/api';
 	import { openDeepdive } from '$lib/stores/deepdiveStore';
 
@@ -3245,6 +3246,16 @@
 		goto(returnTo);
 	}
 
+	// ── Prev/next container navigation ──────────────────────────────────────────
+	// Walks the Forge list order captured when this container was opened (filters,
+	// search, and sort included). Deep links without that context get no arrows.
+	$: forgeNav = getForgeNavPosition(strategyId);
+
+	function goToNeighbor(entry: ForgeNavEntry | null): void {
+		if (!entry) return;
+		goto(`/lab/strategy/${encodeURIComponent(entry.id)}?returnTo=${encodeURIComponent(returnTo)}`);
+	}
+
 	function exportToTradingView(): void {
 		if (!container) return;
 		try {
@@ -4085,6 +4096,36 @@
 		>
 			Back
 		</button>
+		{#if forgeNav}
+			<span class="text-gray-700">|</span>
+			<div class="flex items-center gap-1" data-testid="forge-nav">
+				<button
+					type="button"
+					data-testid="forge-nav-prev"
+					class="border border-[#2b2b2b] bg-black px-2 py-0.5 text-xs text-[#888] transition hover:text-white disabled:cursor-default disabled:opacity-30 disabled:hover:text-[#888]"
+					disabled={!forgeNav.prev}
+					title={forgeNav.prev ? `Previous: ${forgeNav.prev.label || forgeNav.prev.id}` : 'First container in the list'}
+					aria-label="Previous strategy container"
+					on:click={() => goToNeighbor(forgeNav?.prev ?? null)}
+				>
+					‹
+				</button>
+				<span class="font-mono text-[10px] text-[#555]" title="Position in the Forge list you came from">
+					{forgeNav.index + 1}/{forgeNav.total}
+				</span>
+				<button
+					type="button"
+					data-testid="forge-nav-next"
+					class="border border-[#2b2b2b] bg-black px-2 py-0.5 text-xs text-[#888] transition hover:text-white disabled:cursor-default disabled:opacity-30 disabled:hover:text-[#888]"
+					disabled={!forgeNav.next}
+					title={forgeNav.next ? `Next: ${forgeNav.next.label || forgeNav.next.id}` : 'Last container in the list'}
+					aria-label="Next strategy container"
+					on:click={() => goToNeighbor(forgeNav?.next ?? null)}
+				>
+					›
+				</button>
+			</div>
+		{/if}
 		<span class="text-gray-700">|</span>
 		{#if container}
 			{#if editingName}

--- a/frontend/src/tests/forgeNav.test.ts
+++ b/frontend/src/tests/forgeNav.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setForgeNavList, getForgeNavPosition } from '$lib/stores/forgeNav';
+
+const LIST = [
+	{ id: 's-1', label: 'Alpha' },
+	{ id: 's-2', label: 'Bravo' },
+	{ id: 's-3', label: 'Charlie' },
+];
+
+describe('forge container navigation context', () => {
+	beforeEach(() => {
+		sessionStorage.clear();
+	});
+
+	it('walks the stored list order', () => {
+		setForgeNavList(LIST);
+		const pos = getForgeNavPosition('s-2');
+		expect(pos).not.toBeNull();
+		expect(pos?.index).toBe(1);
+		expect(pos?.total).toBe(3);
+		expect(pos?.prev?.id).toBe('s-1');
+		expect(pos?.next?.id).toBe('s-3');
+	});
+
+	it('clamps at the ends instead of wrapping', () => {
+		setForgeNavList(LIST);
+		expect(getForgeNavPosition('s-1')?.prev).toBeNull();
+		expect(getForgeNavPosition('s-1')?.next?.id).toBe('s-2');
+		expect(getForgeNavPosition('s-3')?.next).toBeNull();
+	});
+
+	it('returns null for a container not opened from the list (deep link)', () => {
+		setForgeNavList(LIST);
+		expect(getForgeNavPosition('s-elsewhere')).toBeNull();
+	});
+
+	it('returns null with no stored context at all', () => {
+		expect(getForgeNavPosition('s-1')).toBeNull();
+	});
+
+	it('drops malformed entries and survives corrupted storage', () => {
+		setForgeNavList([
+			{ id: 's-1', label: 'Alpha' },
+			{ id: '', label: 'no id' },
+			// @ts-expect-error deliberately malformed
+			null,
+			// @ts-expect-error label of the wrong type must be coerced, not crash
+			{ id: 's-2', label: 42 },
+		]);
+		const pos = getForgeNavPosition('s-2');
+		expect(pos?.total).toBe(2);
+		expect(pos?.prev?.label).toBe('Alpha');
+
+		sessionStorage.setItem('forven:forge:nav-list', '{not json');
+		expect(getForgeNavPosition('s-1')).toBeNull();
+	});
+
+	it('a later capture replaces the earlier one', () => {
+		setForgeNavList(LIST);
+		setForgeNavList([{ id: 's-9', label: 'Zulu' }]);
+		expect(getForgeNavPosition('s-2')).toBeNull();
+		expect(getForgeNavPosition('s-9')?.total).toBe(1);
+	});
+});


### PR DESCRIPTION
Opening a container from The Forge list captures the list's current filtered+sorted order (all pages) into sessionStorage; the container detail header gains prev/next arrow buttons plus an X/N position chip that walk that exact order, preserving returnTo. Tooltips name the neighboring container; arrows clamp at the ends. Deep links that never came through the list get no arrows (no context to walk).

Tests: 6 on the nav-context store; svelte-check 0 errors; full frontend suite green (409).

🤖 Generated with [Claude Code](https://claude.com/claude-code)