### PR TITLE
fix(backtest): windowed re-slice of pre-loaded candles stripped enrichment columns (OPT-WINDOW-1)

### DIFF
--- a/forven/strategies/backtest.py
+++ b/forven/strategies/backtest.py
@@ -1118,7 +1118,7 @@ def _validate_backtest_execution_parity(
 
 
 
-def _normalize_backtest_frame(df: pd.DataFrame | None) -> pd.DataFrame:
+def _normalize_backtest_frame(df: pd.DataFrame | None, *, keep_extra_columns: bool = False) -> pd.DataFrame:
 
 
     columns = ["open", "high", "low", "close", "volume"]
@@ -1178,7 +1178,14 @@ def _normalize_backtest_frame(df: pd.DataFrame | None) -> pd.DataFrame:
     frame = frame.dropna(subset=columns)
 
 
-    frame = frame[columns]
+    if keep_extra_columns:
+        # Enrichment columns (iv_btc/iv_eth, funding_rate, taker flow, basis,
+        # liquidations, ...) must survive: aux-data strategies silently emit
+        # zero signals when their column is absent, so stripping here turns a
+        # windowed re-slice of an already-enriched frame into an all-zero run.
+        frame = frame[columns + [c for c in frame.columns if c not in columns]]
+    else:
+        frame = frame[columns]
 
 
     frame = frame[~frame.index.duplicated(keep="last")]
@@ -1457,7 +1464,10 @@ def _filter_backtest_frame_to_window(
 ) -> pd.DataFrame:
 
 
-    working = _normalize_backtest_frame(frame)
+    # keep_extra_columns: the caller may hand us an ALREADY-ENRICHED frame
+    # (grid_search pre-loads candles once and re-windows them per trial);
+    # normalizing must not strip the enrichment columns strategies key on.
+    working = _normalize_backtest_frame(frame, keep_extra_columns=True)
 
 
     if working.empty:

--- a/tests/test_enrich_backtest_frame.py
+++ b/tests/test_enrich_backtest_frame.py
@@ -250,6 +250,51 @@ def test_enrich_stream_failure_logged_at_warning(tmp_path, caplog):
 
 
 # ---------------------------------------------------------------------------
+# _filter_backtest_frame_to_window must not strip enrichment columns
+# ---------------------------------------------------------------------------
+
+def test_window_filter_preserves_enrichment_columns():
+    """Optimizer repro (2026-07-07): grid_search pre-loads ENRICHED candles once
+    and re-windows them per trial via _filter_backtest_frame_to_window. The
+    filter used to route through _normalize_backtest_frame's OHLCV-only
+    projection, silently dropping iv_btc/taker/basis/... — aux-data strategies
+    then emitted zero signals and every trial 'Succeeded' with all-zero
+    metrics."""
+    from forven.strategies.backtest import _filter_backtest_frame_to_window
+
+    frame = _backtest_frame(n=500)
+    frame["iv_btc"] = np.linspace(30.0, 80.0, len(frame))
+    frame["taker_buy_sell_ratio"] = 1.0
+
+    out = _filter_backtest_frame_to_window(
+        frame,
+        start_date="2026-01-05",
+        end_date="2026-01-15",
+        warmup_bars=24,
+    )
+
+    assert not out.empty
+    assert "iv_btc" in out.columns, "enrichment column stripped by the window filter"
+    assert "taker_buy_sell_ratio" in out.columns
+    assert out["iv_btc"].notna().all()
+    # Window semantics unchanged: warmup before start, nothing after end.
+    assert out.index[-1] <= pd.Timestamp("2026-01-15", tz="UTC")
+    assert list(out.columns[:5]) == ["open", "high", "low", "close", "volume"]
+
+
+def test_normalize_backtest_frame_default_still_ohlcv_only():
+    """The default projection contract is unchanged for every other caller."""
+    from forven.strategies.backtest import _normalize_backtest_frame
+
+    frame = _backtest_frame()
+    frame["iv_btc"] = 40.0
+
+    out = _normalize_backtest_frame(frame)
+
+    assert list(out.columns) == ["open", "high", "low", "close", "volume"]
+
+
+# ---------------------------------------------------------------------------
 # load_backtest_candles end to end (dataset path)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

Optimization runs launched from the UI started returning **all-zero results** (fitness 0.00, sharpe 0.00, return 0.00%, every top candidate 0.00) on strategies that optimized fine the night before (e.g. S06151 `iv_expansion_break`, run `opt-S06151-btc-1783443488162`).

## Root cause

`grid_search` pre-loads enriched candles once and every trial re-windows them via `backtest_strategy(candles_df=..., start_date/end_date=...)`. That path routes the frame through `_filter_backtest_frame_to_window` → `_normalize_backtest_frame`, whose OHLCV-only projection (`frame = frame[["open","high","low","close","volume"]]`) **silently drops every enrichment column** — `iv_btc`/`iv_eth`, `taker_buy_sell_ratio`, `ls_ratio`, `basis`, liquidations, `funding_rate`.

Aux-data strategies guard with `if col not in df.columns: return empty`, so every trial "succeeds" with zero trades and the run reports Succeeded with all-zero metrics — no error anywhere.

Why it looked like a sudden breakage: the UI optimization form always sends an explicit ~1y window (`start`/`end`), which takes the windowed path; pipeline/background-launched optimizations send no dates and take the `.tail(bars)` path, which preserves enrichment. The "successful" earlier runs were the latter (log-verified: 7/6 runs pre-loaded exactly 8760 bars, the failing 7/7 run pre-loaded 8971 = window + warmup).

## Fix

`_filter_backtest_frame_to_window` now normalizes with a new `keep_extra_columns=True` mode: identical index/dedup/sort/OHLCV-validity semantics, but extra columns survive (OHLCV kept first). The default OHLCV-only projection is unchanged for every other `_normalize_backtest_frame` caller, and both loader-internal call sites pass already-projected frames — no behavior change there.

## Verification

- Exact failing repro (S06151 best params, 2025-07-05→2026-07-05 window, container execution profile, pre-loaded candles): **0 trades → 18 trades / +26.4% return**.
- New regression tests: window filter preserves enrichment columns + default projection contract unchanged.
- `tests/test_enrich_backtest_frame.py`, `tests/test_backtesting_optimize_compat.py`, `tests/test_manual_backtest_execution_controls.py`, `tests/test_execution_profile_parity.py` — 60 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWwtDrs9xV9vAkmTGRyLfT