### PR TITLE
Forge: DSR column (persisted snapshot, dash when never computed)

### DIFF
--- a/forven/db.py
+++ b/forven/db.py
@@ -1952,6 +1952,10 @@ def _run_migrations(conn: sqlite3.Connection):
     _ensure_column(conn, "strategies", "stage_changed_at", "TEXT")
     _ensure_column(conn, "strategies", "compatible_regimes", "JSON")
     _ensure_column(conn, "strategies", "hypothesis_id", "TEXT")
+    # Write-through snapshot of the last computed Deflated Sharpe (advisory;
+    # list views display it without paying the per-strategy computation).
+    _ensure_column(conn, "strategies", "deflated_sharpe", "REAL")
+    _ensure_column(conn, "strategies", "deflated_sharpe_at", "TEXT")
     _ensure_column(conn, "hypotheses", "display_id", "TEXT")
     _ensure_column(conn, "hypotheses", "manager_state", "TEXT NOT NULL DEFAULT 'active'")
     _ensure_column(conn, "hypotheses", "archived_at", "TEXT")

--- a/forven/gauntlet/deflated_sharpe.py
+++ b/forven/gauntlet/deflated_sharpe.py
@@ -333,6 +333,21 @@ def compute_strategy_dsr(strategy_id: str, *, default_trials: int | None = None)
         )
         result["n_trials_base"] = int(n_trials_base)
         result["swarm_cluster_attempts"] = int(swarm_attempts)
+        # Write-through snapshot: list views display the last computed DSR
+        # without ever paying this function's cost per row. Strategies whose
+        # DSR was never computed have no value to show.
+        try:
+            dsr_value = result.get("dsr")
+            if dsr_value is not None:
+                from datetime import datetime, timezone
+
+                with get_db() as conn:
+                    conn.execute(
+                        "UPDATE strategies SET deflated_sharpe = ?, deflated_sharpe_at = ? WHERE id = ?",
+                        (float(dsr_value), datetime.now(timezone.utc).isoformat(), strategy_id),
+                    )
+        except Exception:
+            pass
         return result
     except Exception:
         return None

--- a/frontend/src/lib/utils/strategy.ts
+++ b/frontend/src/lib/utils/strategy.ts
@@ -29,6 +29,8 @@ export interface ManagerRow {
 	in_sample_sharpe: number | null;
 	out_of_sample_sharpe: number | null;
 	robustness_score: number | null;
+	// Last computed Deflated Sharpe snapshot (0-1); null = never computed.
+	deflated_sharpe: number | null;
 	total_return: number | null;
 	max_drawdown: number | null;
 	win_rate: number | null;
@@ -296,6 +298,7 @@ export function parseManagerRow(raw: any, deletedAt?: string): ManagerRow {
 		in_sample_sharpe: inSampleSharpe,
 		out_of_sample_sharpe: outOfSampleSharpe,
 		robustness_score: robustness,
+		deflated_sharpe: readMetricFromSources(row, metricSources, ['deflated_sharpe']),
 		total_return: ret,
 		max_drawdown: dd,
 		win_rate: wr,

--- a/frontend/src/routes/lab/+page.svelte
+++ b/frontend/src/routes/lab/+page.svelte
@@ -33,7 +33,7 @@
 	import type { StrategyImportResult } from '$lib/api';
 
 	type Bucket = 'active' | 'parked' | 'trash';
-	type SortField = 'created' | 'cagr' | 'in_sample_cagr' | 'out_of_sample_cagr' | 'return' | 'sharpe' | 'in_sample_sharpe' | 'out_of_sample_sharpe' | 'robustness' | 'drawdown' | 'win_rate' | 'trades' | 'profit_factor';
+	type SortField = 'created' | 'cagr' | 'in_sample_cagr' | 'out_of_sample_cagr' | 'return' | 'sharpe' | 'in_sample_sharpe' | 'out_of_sample_sharpe' | 'robustness' | 'dsr' | 'drawdown' | 'win_rate' | 'trades' | 'profit_factor';
 	type SortDirection = 'asc' | 'desc';
 	type GraveyardStrategyLimitMode = 'capped' | 'unlimited';
 	const STRATEGY_FETCH_PAGE_SIZE = 1000;
@@ -253,6 +253,15 @@
 		return value.toFixed(decimals);
 	}
 
+	function dsrClass(value: number | null): string {
+		// Same informational thresholds as the Gauntlet Status card: ~0.95 is the
+		// conventional significance bar for the Deflated Sharpe probability.
+		if (value === null || !Number.isFinite(value)) return 'text-[#555]';
+		if (value >= 0.95) return 'text-emerald-400';
+		if (value >= 0.8) return 'text-yellow-400';
+		return 'text-red-400';
+	}
+
 	function metricClass(kind: 'return' | 'sharpe' | 'robustness' | 'drawdown' | 'win_rate' | 'profit_factor', value: number | null): string {
 		if (value === null || !Number.isFinite(value)) return 'text-[#555]';
 		switch (kind) {
@@ -349,6 +358,9 @@
 			case 'in_sample_sharpe': return row.in_sample_sharpe ?? Number.NEGATIVE_INFINITY;
 			case 'out_of_sample_sharpe': return row.out_of_sample_sharpe ?? Number.NEGATIVE_INFINITY;
 			case 'robustness': return row.robustness_score ?? Number.NEGATIVE_INFINITY;
+			// Never-computed DSR sinks below genuinely low probabilities on a
+			// descending sort (same treatment as missing Sharpe above).
+			case 'dsr': return row.deflated_sharpe ?? Number.NEGATIVE_INFINITY;
 			// Drawdown is a positive magnitude where lower is better, so unmeasured rows
 			// must sort to the worst (highest) end rather than masquerade as a perfect 0%.
 			case 'drawdown': return row.max_drawdown ?? Number.POSITIVE_INFINITY;
@@ -1239,6 +1251,7 @@
 								<SortableTh field="trades" label="Trades" active={sortBy === 'trades'} direction={sortDirection} on:sort={(e) => toggleSort(e.detail as SortField)} title="Total completed trades across IS + OOS." />
 								<SortableTh field="profit_factor" label="PF" active={sortBy === 'profit_factor'} direction={sortDirection} on:sort={(e) => toggleSort(e.detail as SortField)} title="Full-window profit factor = combined gross profit / combined gross loss. ≥1.5 good, ≥1.0 marginal. ∞ if no losing trades." />
 								<SortableTh field="robustness" label="Rob%" active={sortBy === 'robustness'} direction={sortDirection} on:sort={(e) => toggleSort(e.detail as SortField)} title="Gauntlet robustness score; below 70 fails gate." />
+								<SortableTh field="dsr" label="DSR" active={sortBy === 'dsr'} direction={sortDirection} on:sort={(e) => toggleSort(e.detail as SortField)} title="Deflated Sharpe (0-1): probability the edge survives optimizer selection bias. ≥0.95 significant, ≥0.80 marginal. Shows the last computed value; '-' means it has not been computed yet." />
 								<SortableTh field="out_of_sample_cagr" label="OOS CAGR" active={sortBy === 'out_of_sample_cagr'} direction={sortDirection} on:sort={(e) => toggleSort(e.detail as SortField)} thClass="border-l border-[#222] pl-3" title="Out-of-sample CAGR (annualized). Short windows are shown with muted styling." />
 								<SortableTh field="out_of_sample_sharpe" label="OOS Sharpe" active={sortBy === 'out_of_sample_sharpe'} direction={sortDirection} on:sort={(e) => toggleSort(e.detail as SortField)} title="Out-of-sample annualized Sharpe. Low-trade samples are shown with muted styling." />
 								<SortableTh field="created" label="Created" active={sortBy === 'created'} direction={sortDirection} on:sort={(e) => toggleSort(e.detail as SortField)} />
@@ -1247,9 +1260,9 @@
 						</thead>
 						<tbody>
 							{#if loading}
-								<tr><td colspan="15" class="py-8 text-center text-[#555]">Loading containers...</td></tr>
+								<tr><td colspan="16" class="py-8 text-center text-[#555]">Loading containers...</td></tr>
 							{:else if activeFiltered.length === 0}
-								<tr><td colspan="15" class="py-8 text-center text-[#555]">No active containers match this view.</td></tr>
+								<tr><td colspan="16" class="py-8 text-center text-[#555]">No active containers match this view.</td></tr>
 							{:else}
 								{#each activePageRows as row (row.id)}
 									{@const recovery = recoveryBadge(row)}
@@ -1299,6 +1312,7 @@
 										<td class="py-2 px-2 font-mono text-[#888]">{formatNumber(row.total_trades, 0)}</td>
 										<td class={`py-2 px-2 font-mono ${row.profit_factor_is_infinite ? 'text-emerald-400' : metricClass('profit_factor', row.profit_factor)}`} title={row.profit_factor_is_infinite ? 'No losing trades — profit factor is mathematically infinite' : 'Full-window profit factor'}>{row.profit_factor_is_infinite ? '∞' : formatNumber(row.profit_factor, 2)}</td>
 										<td class={`py-2 px-2 font-mono ${metricClass('robustness', row.robustness_score)}`}>{formatPercent(row.robustness_score, 1)}</td>
+										<td class={`py-2 px-2 font-mono ${dsrClass(row.deflated_sharpe)}`} title="Deflated Sharpe (last computed value)">{formatNumber(row.deflated_sharpe, 2)}</td>
 										<td class={`py-2 px-2 font-mono border-l border-[#222] pl-3 ${row.cagr_is_reliable ? metricClass('return', row.out_of_sample_cagr) : 'text-[#666] italic'}`} title={row.cagr_is_reliable ? 'Out-of-sample CAGR (annualized)' : 'OOS window too short (<1 month) — annualized value may be unreliable'}>{formatPercent(row.out_of_sample_cagr, 2)}</td>
 										<td class={`py-2 px-2 font-mono ${row.sharpe_is_reliable ? metricClass('sharpe', row.out_of_sample_sharpe) : 'text-[#666]'}`} title={row.sharpe_is_reliable ? 'Out-of-sample annualized Sharpe' : 'Low trade count (<20) — Sharpe may be noisy'}>{formatNumber(row.out_of_sample_sharpe, 2)}</td>
 										<td class="py-2 px-2 text-[#666]">{formatDateTime(row.created_at)}</td>
@@ -1342,6 +1356,7 @@
 								<SortableTh field="trades" label="Trades" active={sortBy === 'trades'} direction={sortDirection} on:sort={(e) => toggleSort(e.detail as SortField)} title="Total completed trades across IS + OOS." />
 								<SortableTh field="profit_factor" label="PF" active={sortBy === 'profit_factor'} direction={sortDirection} on:sort={(e) => toggleSort(e.detail as SortField)} title="Full-window profit factor. ≥1.5 good, ≥1.0 marginal. ∞ if no losing trades." />
 								<SortableTh field="robustness" label="Rob%" active={sortBy === 'robustness'} direction={sortDirection} on:sort={(e) => toggleSort(e.detail as SortField)} title="Gauntlet robustness score; below 70 fails gate." />
+								<SortableTh field="dsr" label="DSR" active={sortBy === 'dsr'} direction={sortDirection} on:sort={(e) => toggleSort(e.detail as SortField)} title="Deflated Sharpe (0-1): probability the edge survives optimizer selection bias. ≥0.95 significant, ≥0.80 marginal. Shows the last computed value; '-' means it has not been computed yet." />
 								<SortableTh field="out_of_sample_cagr" label="OOS CAGR" active={sortBy === 'out_of_sample_cagr'} direction={sortDirection} on:sort={(e) => toggleSort(e.detail as SortField)} thClass="border-l border-[#222] pl-3" title="Out-of-sample CAGR (annualized). Short windows are shown with muted styling." />
 								<SortableTh field="out_of_sample_sharpe" label="OOS Sharpe" active={sortBy === 'out_of_sample_sharpe'} direction={sortDirection} on:sort={(e) => toggleSort(e.detail as SortField)} title="Out-of-sample annualized Sharpe. Low-trade samples are shown with muted styling." />
 								<SortableTh field="created" label="Created" active={sortBy === 'created'} direction={sortDirection} on:sort={(e) => toggleSort(e.detail as SortField)} />
@@ -1350,9 +1365,9 @@
 						</thead>
 						<tbody>
 							{#if loading}
-								<tr><td colspan="15" class="py-8 text-center text-[#555]">Loading parked containers...</td></tr>
+								<tr><td colspan="16" class="py-8 text-center text-[#555]">Loading parked containers...</td></tr>
 							{:else if parkedFiltered.length === 0}
-								<tr><td colspan="15" class="py-8 text-center text-[#555]">No parked strategies.</td></tr>
+								<tr><td colspan="16" class="py-8 text-center text-[#555]">No parked strategies.</td></tr>
 							{:else}
 								{#each parkedPageRows as row (row.id)}
 									<tr class="border-t border-[#181818] hover:bg-[#0f0f0f]">
@@ -1382,6 +1397,7 @@
 										<td class="py-2 px-2 font-mono text-[#888]">{formatNumber(row.total_trades, 0)}</td>
 										<td class={`py-2 px-2 font-mono ${row.profit_factor_is_infinite ? 'text-emerald-400' : metricClass('profit_factor', row.profit_factor)}`} title={row.profit_factor_is_infinite ? 'No losing trades — profit factor is mathematically infinite' : 'Full-window profit factor'}>{row.profit_factor_is_infinite ? '∞' : formatNumber(row.profit_factor, 2)}</td>
 										<td class={`py-2 px-2 font-mono ${metricClass('robustness', row.robustness_score)}`}>{formatPercent(row.robustness_score, 1)}</td>
+										<td class={`py-2 px-2 font-mono ${dsrClass(row.deflated_sharpe)}`} title="Deflated Sharpe (last computed value)">{formatNumber(row.deflated_sharpe, 2)}</td>
 										<td class={`py-2 px-2 font-mono border-l border-[#222] pl-3 ${row.cagr_is_reliable ? metricClass('return', row.out_of_sample_cagr) : 'text-[#666] italic'}`} title={row.cagr_is_reliable ? 'Out-of-sample CAGR (annualized)' : 'OOS window too short (<1 month) — annualized value may be unreliable'}>{formatPercent(row.out_of_sample_cagr, 2)}</td>
 										<td class={`py-2 px-2 font-mono ${row.sharpe_is_reliable ? metricClass('sharpe', row.out_of_sample_sharpe) : 'text-[#666]'}`} title={row.sharpe_is_reliable ? 'Out-of-sample annualized Sharpe' : 'Low trade count (<20) — Sharpe may be noisy'}>{formatNumber(row.out_of_sample_sharpe, 2)}</td>
 										<td class="py-2 px-2 text-[#666]">{formatDateTime(row.created_at)}</td>
@@ -1416,6 +1432,7 @@
 								<SortableTh field="trades" label="Trades" active={sortBy === 'trades'} direction={sortDirection} on:sort={(e) => toggleSort(e.detail as SortField)} title="Total completed trades across IS + OOS." />
 								<SortableTh field="profit_factor" label="PF" active={sortBy === 'profit_factor'} direction={sortDirection} on:sort={(e) => toggleSort(e.detail as SortField)} title="Full-window profit factor = combined gross profit / combined gross loss. ≥1.5 good, ≥1.0 marginal. ∞ if no losing trades." />
 								<SortableTh field="robustness" label="Rob%" active={sortBy === 'robustness'} direction={sortDirection} on:sort={(e) => toggleSort(e.detail as SortField)} title="Gauntlet robustness score; below 70 fails gate." />
+								<SortableTh field="dsr" label="DSR" active={sortBy === 'dsr'} direction={sortDirection} on:sort={(e) => toggleSort(e.detail as SortField)} title="Deflated Sharpe (0-1): probability the edge survives optimizer selection bias. ≥0.95 significant, ≥0.80 marginal. Shows the last computed value; '-' means it has not been computed yet." />
 								<SortableTh field="out_of_sample_cagr" label="OOS CAGR" active={sortBy === 'out_of_sample_cagr'} direction={sortDirection} on:sort={(e) => toggleSort(e.detail as SortField)} thClass="border-l border-[#222] pl-3" title="Out-of-sample CAGR (annualized). Short windows are shown with muted styling." />
 								<SortableTh field="out_of_sample_sharpe" label="OOS Sharpe" active={sortBy === 'out_of_sample_sharpe'} direction={sortDirection} on:sort={(e) => toggleSort(e.detail as SortField)} title="Out-of-sample annualized Sharpe. Low-trade samples are shown with muted styling." />
 								<SortableTh field="created" label="Created" active={sortBy === 'created'} direction={sortDirection} on:sort={(e) => toggleSort(e.detail as SortField)} />
@@ -1424,9 +1441,9 @@
 						</thead>
 						<tbody>
 							{#if loading || graveyardLoading}
-								<tr><td colspan="15" class="py-8 text-center text-[#555]">Loading graveyard...</td></tr>
+								<tr><td colspan="16" class="py-8 text-center text-[#555]">Loading graveyard...</td></tr>
 							{:else if trashFiltered.length === 0}
-								<tr><td colspan="15" class="py-8 text-center text-[#555]">Graveyard is empty.</td></tr>
+								<tr><td colspan="16" class="py-8 text-center text-[#555]">Graveyard is empty.</td></tr>
 							{:else}
 								{#each trashPageRows as row (row.id)}
 									<tr class="border-t border-[#181818] hover:bg-[#0f0f0f]">
@@ -1468,6 +1485,7 @@
 										<td class="py-2 px-2 font-mono text-[#888]">{formatNumber(row.total_trades, 0)}</td>
 										<td class={`py-2 px-2 font-mono ${row.profit_factor_is_infinite ? 'text-emerald-400' : metricClass('profit_factor', row.profit_factor)}`} title={row.profit_factor_is_infinite ? 'No losing trades — profit factor is mathematically infinite' : 'Full-window profit factor'}>{row.profit_factor_is_infinite ? '∞' : formatNumber(row.profit_factor, 2)}</td>
 										<td class={`py-2 px-2 font-mono ${metricClass('robustness', row.robustness_score)}`}>{formatPercent(row.robustness_score, 1)}</td>
+										<td class={`py-2 px-2 font-mono ${dsrClass(row.deflated_sharpe)}`} title="Deflated Sharpe (last computed value)">{formatNumber(row.deflated_sharpe, 2)}</td>
 										<td class={`py-2 px-2 font-mono border-l border-[#222] pl-3 ${row.cagr_is_reliable ? metricClass('return', row.out_of_sample_cagr) : 'text-[#666] italic'}`} title={row.cagr_is_reliable ? 'Out-of-sample CAGR (annualized)' : 'OOS window too short (<1 month) — annualized value may be unreliable'}>{formatPercent(row.out_of_sample_cagr, 2)}</td>
 										<td class={`py-2 px-2 font-mono ${row.sharpe_is_reliable ? metricClass('sharpe', row.out_of_sample_sharpe) : 'text-[#666]'}`} title={row.sharpe_is_reliable ? 'Out-of-sample annualized Sharpe' : 'Low trade count (<20) — Sharpe may be noisy'}>{formatNumber(row.out_of_sample_sharpe, 2)}</td>
 										<td class="py-2 px-2 text-[#666]">

--- a/tests/test_dsr_list_column.py
+++ b/tests/test_dsr_list_column.py
@@ -1,0 +1,40 @@
+"""Forge-list DSR column contract (2026-07-07).
+
+The Deflated Sharpe is expensive to compute (per-trade returns + optimizer
+trials per strategy), so the list NEVER computes it. compute_strategy_dsr
+write-throughs its result onto the strategies row; the list endpoint just
+reads the snapshot. Rows never computed carry NULL and render as '-'.
+"""
+
+from __future__ import annotations
+
+from forven.db import get_db
+
+
+def _insert_strategy(sid: str, *, dsr: float | None):
+    with get_db() as conn:
+        conn.execute(
+            "INSERT INTO strategies (id, display_id, name, type, status, stage, owner, "
+            "symbol, timeframe, deflated_sharpe) "
+            "VALUES (?, ?, ?, 'keltner_coil_x', 'gauntlet', 'gauntlet', 'brain', 'BTC', '1h', ?)",
+            (sid, sid, sid, dsr),
+        )
+
+
+def test_migration_adds_snapshot_columns(forven_db):
+    with get_db() as conn:
+        cols = {r["name"] for r in conn.execute("PRAGMA table_info(strategies)").fetchall()}
+    assert "deflated_sharpe" in cols
+    assert "deflated_sharpe_at" in cols
+
+
+def test_list_payload_carries_dsr_snapshot(forven_db):
+    from forven.strategy_lifecycle import read_strategies
+
+    _insert_strategy("s-with-dsr", dsr=0.9321)
+    _insert_strategy("s-without-dsr", dsr=None)
+
+    rows = {r["id"]: r for r in read_strategies(status="gauntlet")}
+    assert rows["s-with-dsr"]["deflated_sharpe"] == 0.9321
+    # never-computed stays null — the UI renders '-' rather than a fake 0
+    assert rows["s-without-dsr"]["deflated_sharpe"] is None


### PR DESCRIPTION
Adds a sortable DSR (Deflated Sharpe) column to all three Forge strategy tables, per the operator rule: if it has been calculated, display it; if not, show "-".

- DSR stays expensive to compute, so the list NEVER computes it: `compute_strategy_dsr` (called by the detail-page Gauntlet card and the opt-in DSR gate) now write-throughs its result onto the strategies row (`deflated_sharpe` + `deflated_sharpe_at`, best-effort).
- The strategies list payload carries the snapshot for free (`SELECT s.*`); the column renders it with the same thresholds as the Gauntlet card (>=0.95 green, >=0.80 yellow, else red), "-"/sink-to-bottom when never computed.
- Column migration runs at next backend start; values fill in as DSRs get computed.

Tests: 2 backend contract tests (migration columns, list payload carries snapshot + null stays null); frontend suite green (409); svelte-check 0 errors; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)