### PR TITLE
fix(basket): live-path audit fix set — position blindness, funding accrual, cap erosion (BASKET-AUDIT-1)

### DIFF
--- a/forven/basket_live.py
+++ b/forven/basket_live.py
@@ -78,6 +78,40 @@ def lake_symbol_to_exchange_asset(symbol: str) -> str:
     return _HL_ASSET_ALIASES.get(base, base)
 
 
+# Hard bound on the paper book's summed |weights| the executor will mirror —
+# a corrupted/mis-set gross_leverage must never scale a live wallet unbounded.
+MAX_LIVE_GROSS_WEIGHT = 3.0
+
+
+def _signed_positions(snap: dict | None) -> dict[str, float]:
+    """Wallet positions as ``{ASSET: signed units}`` from a get_positions snapshot.
+
+    ``get_positions`` returns Hyperliquid's raw ``assetPositions`` wrappers —
+    ``{"position": {"coin": ..., "szi": ...}}`` (the shape the kill-switch
+    flatten unwraps at risk.close_all_positions). A flat ``{"asset"/"coin",
+    "size", "direction"}`` row is accepted too so an upstream normalization
+    can't silently blind this module again.
+    """
+    held: dict[str, float] = {}
+    for pos in (snap.get("positions", []) if isinstance(snap, dict) else []):
+        if not isinstance(pos, dict):
+            continue
+        info = pos.get("position", pos)
+        if not isinstance(info, dict):
+            continue
+        asset = str(info.get("coin") or info.get("asset") or "").strip().upper()
+        raw_size = info.get("szi", info.get("size"))
+        try:
+            size = float(raw_size or 0.0)
+        except (TypeError, ValueError):
+            continue
+        if str(info.get("direction") or "").strip().lower() == "short":
+            size = -abs(size)
+        if asset and size != 0.0 and math.isfinite(size):
+            held[asset] = held.get(asset, 0.0) + size
+    return held
+
+
 # ------------------------------------------------------------------- arming
 
 
@@ -212,13 +246,13 @@ def _flatten_wallet(address: str) -> list[dict]:
     except Exception as exc:
         _ledger_append({"event": "flatten_failed", "error": str(exc)})
         return out
-    for pos in snap.get("positions", []) if isinstance(snap, dict) else []:
-        asset = str(pos.get("asset") or pos.get("coin") or "").strip()
-        size = abs(float(pos.get("size") or 0.0))
-        direction = str(pos.get("direction") or ("long" if float(pos.get("size") or 0) > 0 else "short"))
-        if not asset or size <= 0:
-            continue
-        side = "sell" if direction == "long" else "buy"
+    held = _signed_positions(snap)
+    if not held:
+        _ledger_append({"event": "flatten_noop", "reason": "no open positions found in wallet snapshot"})
+        return out
+    for asset, units in sorted(held.items()):
+        size = abs(units)
+        side = "sell" if units > 0 else "buy"
         try:
             result = close_position(asset, size, side, testnet=testnet, vault_address=address)
             ok = not (isinstance(result, dict) and result.get("error"))
@@ -249,19 +283,36 @@ def reconcile_basket_live() -> dict | None:
         _ledger_append({"event": "reconcile_skipped", "reason": "layer or basket disabled"})
         return {"skipped": "layer or basket disabled"}
 
-    from forven.exchange.risk import check_live_strategy_ceiling, is_trading_allowed
+    from forven.exchange.risk import (
+        check_live_strategy_ceiling,
+        get_live_notional_ceilings,
+        is_trading_allowed,
+    )
 
     allowed, why = is_trading_allowed()
     if not allowed:
         _ledger_append({"event": "reconcile_skipped", "reason": f"trading halted: {why}"})
         return {"skipped": f"trading halted: {why}"}
 
+    # Fail CLOSED if the arming ceiling vanished (check_live_strategy_ceiling
+    # alone fails OPEN with no entry) — an armed basket must never trade capless.
+    if not isinstance(get_live_notional_ceilings().get(CEILING_ID), dict):
+        _ledger_append({"event": "reconcile_skipped",
+                        "reason": "arming ceiling missing — disarm and re-arm to restore it"})
+        return {"skipped": "arming ceiling missing"}
+
     state = get_basket_state("hyperliquid") or {}
     weights: dict[str, float] = state.get("weights") or {}
     capital = float(arming.get("capital_usd") or 0.0)
     address = str(arming.get("wallet_address") or "")
-    if not weights or capital <= 0 or not address:
+    if not weights or capital <= 0 or not math.isfinite(capital) or not address:
         return {"skipped": "no targets or malformed arming"}
+    gross_weight = sum(abs(float(w or 0.0)) for w in weights.values())
+    if not math.isfinite(gross_weight) or gross_weight > MAX_LIVE_GROSS_WEIGHT:
+        _ledger_append({"event": "reconcile_skipped",
+                        "reason": f"paper book gross weight {gross_weight:.2f} exceeds the "
+                                  f"{MAX_LIVE_GROSS_WEIGHT}x live bound — refusing to mirror it"})
+        return {"skipped": "gross weight bound exceeded"}
 
     from forven.exchange.hyperliquid import (
         close_position,
@@ -279,30 +330,24 @@ def reconcile_basket_live() -> dict | None:
         _ledger_append({"event": "reconcile_failed", "error": f"snapshot: {exc}"})
         return {"skipped": f"exchange snapshot failed: {exc}"}
 
-    held: dict[str, float] = {}  # asset -> signed units
-    for pos in snap.get("positions", []) if isinstance(snap, dict) else []:
-        asset = str(pos.get("asset") or pos.get("coin") or "").strip().upper()
-        try:
-            size = float(pos.get("size") or 0.0)
-        except (TypeError, ValueError):
-            continue
-        sign = -1.0 if str(pos.get("direction") or "").lower() == "short" else 1.0
-        if asset:
-            held[asset] = held.get(asset, 0.0) + math.copysign(abs(size), sign * (size or 1.0))
+    held = _signed_positions(snap)  # asset -> signed units
 
     targets: dict[str, float] = {}  # asset -> signed target units
     unlistable: list[str] = []
     for symbol, weight in weights.items():
-        asset = lake_symbol_to_exchange_asset(symbol)
-        mid = None
+        # get_all_mids uppercases its keys, so alias assets ("kPEPE") must be
+        # looked up (and keyed) uppercase or every 1000x leg reads as unlisted.
+        asset = lake_symbol_to_exchange_asset(symbol).upper()
         try:
+            weight = float(weight or 0.0)
             mid = float((mids or {}).get(asset) or 0.0)
         except (TypeError, ValueError):
-            mid = 0.0
-        if not mid or mid <= 0:
             unlistable.append(symbol)
             continue
-        targets[asset] = float(weight) * capital / mid
+        if not math.isfinite(weight) or weight == 0.0 or not math.isfinite(mid) or mid <= 0:
+            unlistable.append(symbol)
+            continue
+        targets[asset] = weight * capital / mid
 
     orders: list[dict] = []
     for asset in sorted(set(targets) | set(held)):
@@ -343,9 +388,13 @@ def reconcile_basket_live() -> dict | None:
             continue
         side = "buy" if delta_units > 0 else "sell"
         try:
+            # Hour-bucketed key: a doubled reconcile (scheduler + manual tick)
+            # re-sends the SAME delta with the same key and dedupes; a genuine
+            # new delta within the hour differs in units and passes.
+            dedupe_hour = get_now().strftime("%Y-%m-%dT%H")
             result = market_order(
                 asset, side, abs(delta_units), testnet=testnet, vault_address=address,
-                idempotency_key=f"basket:{asset}:{get_now().isoformat()}",
+                idempotency_key=f"basket:{asset}:{side}:{round(abs(delta_units), 6)}:{dedupe_hour}",
             )
             ok = not (isinstance(result, dict) and result.get("error"))
             orders.append({
@@ -366,13 +415,21 @@ def reconcile_basket_live() -> dict | None:
         "orders_failed": sum(1 for o in orders if not o.get("ok")),
         "unlistable_symbols": unlistable,
     }
-    arming["last_reconcile"] = {
-        "t": report["t"],
-        "orders_ok": report["orders_ok"],
-        "orders_failed": report["orders_failed"],
-        "unlistable": len(unlistable),
-    }
-    kv_set_best_effort(ARMING_KV_KEY, arming)
+    # Re-read the arming record before writing telemetry back: a disarm issued
+    # while this reconcile was placing orders must win — writing the stale
+    # armed=True dict captured at entry would silently re-arm a capless basket.
+    fresh_arming = get_arming()
+    if fresh_arming.get("armed"):
+        fresh_arming["last_reconcile"] = {
+            "t": report["t"],
+            "orders_ok": report["orders_ok"],
+            "orders_failed": report["orders_failed"],
+            "unlistable": len(unlistable),
+        }
+        kv_set_best_effort(ARMING_KV_KEY, fresh_arming)
+    else:
+        _ledger_append({"event": "reconcile_note",
+                        "reason": "disarmed while reconcile was in flight — disarm preserved"})
     if unlistable:
         log.warning("basket live: %d paper legs unlistable on venue: %s", len(unlistable), unlistable)
     return report

--- a/forven/basket_runtime.py
+++ b/forven/basket_runtime.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import logging
 import math
+import threading
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -77,7 +78,10 @@ MAX_HISTORY_POINTS = 2400  # ~100 days of hourly ticks
 def _float_setting(settings: dict, key: str, default: float) -> float:
     try:
         raw = settings.get(key)
-        return float(raw) if raw is not None else float(default)
+        value = float(raw) if raw is not None else float(default)
+        # float("nan")/inf parse fine but poison every downstream comparison
+        # (deadbands, ceilings, and quantize guards are all False-on-NaN).
+        return value if math.isfinite(value) else float(default)
     except (TypeError, ValueError):
         return float(default)
 
@@ -109,7 +113,10 @@ def _basket_config(settings: dict) -> dict:
         "rebalance_hours": max(_float_setting(settings, "basket_rebalance_hours", DEFAULT_REBALANCE_HOURS), 1.0),
         "n_legs": max(int(_float_setting(settings, "basket_n_legs", DEFAULT_N_LEGS)), 1),
         "rank_buffer": max(int(_float_setting(settings, "basket_rank_buffer", DEFAULT_RANK_BUFFER)), 0),
-        "gross_leverage": max(_float_setting(settings, "basket_gross_leverage", DEFAULT_GROSS_LEVERAGE), 0.01),
+        # Clamped [0.01, 3.0]: the live executor mirrors these weights into a
+        # real wallet, so a fat-fingered knob must not scale gross unbounded
+        # (basket_live enforces the same 3x bound independently).
+        "gross_leverage": min(max(_float_setting(settings, "basket_gross_leverage", DEFAULT_GROSS_LEVERAGE), 0.01), 3.0),
         "universe_min_bars": max(int(_float_setting(settings, "basket_universe_min_bars", DEFAULT_UNIVERSE_MIN_BARS)), 720),
         "trade_cost": (fee_bps + slippage_bps) / 10_000.0,
         "fee_bps": fee_bps,
@@ -225,11 +232,16 @@ def tick_basket(state: dict, panel, now: datetime, config: dict) -> tuple[dict, 
         return state, report
     now_iso = now.isoformat()
 
-    # --- mark-to-market the held weights since the previous tick
+    # --- mark-to-market the held weights since the previous tick.
+    # Funding accrues OUTSIDE the weights guard so the label anchor advances
+    # even while the book holds nothing (a flat spell must not back-accrue).
     price_pnl = 0.0
-    funding_pnl = 0.0
+    funding_pnl, accrued_label = _accrue_funding(
+        state["weights"], panel, state.get("last_accrued_label"), now
+    )
+    if accrued_label:
+        state["last_accrued_label"] = accrued_label
     if state["weights"]:
-        prev_tick_at = state.get("last_tick_at")
         for symbol, weight in state["weights"].items():
             current = closes.get(symbol)
             prev_mark = state["marks"].get(symbol)
@@ -239,7 +251,6 @@ def tick_basket(state: dict, panel, now: datetime, config: dict) -> tuple[dict, 
             if prev_mark and float(prev_mark) > 0:
                 price_pnl += float(weight) * (current / float(prev_mark) - 1.0)
             state["marks"][symbol] = current
-        funding_pnl = _accrue_funding(state["weights"], panel, prev_tick_at, now)
         state["equity"] = float(state["equity"]) * (1.0 + price_pnl + funding_pnl)
         state["cum_price_pnl"] = float(state.get("cum_price_pnl", 0.0)) + price_pnl
         state["cum_funding_pnl"] = float(state.get("cum_funding_pnl", 0.0)) + funding_pnl
@@ -360,35 +371,52 @@ def _check_beta_drift(state: dict) -> None:
         log.debug("beta-drift check failed", exc_info=True)
 
 
-def _accrue_funding(weights: dict, panel, prev_tick_iso: str | None, now: datetime) -> float:
-    """Funding accrued on held weights over the bars since the previous tick.
+def _accrue_funding(
+    weights: dict, panel, last_accrued_iso: str | None, now: datetime
+) -> tuple[float, str | None]:
+    """Funding accrued on held weights, anchored on PANEL LABELS, not tick clocks.
 
-    Sums −w·funding_rate·bar_hours across the elapsed panel bars — the exact
-    accrual run_basket books per bar. Falls back to zero when the window is
-    empty (first tick after a rebalance-only initialization)."""
-    if not weights:
-        return 0.0
+    Sums −w·funding_rate·bar_hours across the not-yet-accrued panel bars — the
+    exact accrual run_basket books per bar. The window must anchor on the last
+    ACCRUED LABEL: funding rows carry bar-open labels that reach the lake 1-4h
+    after their label time, so a wall-clock window (prev_tick, now] can never
+    contain them under steady hourly ticking — the book booked zero funding
+    forever (confirmed on 9/9 production ticks, 2026-07-07). With a label
+    anchor, each late-arriving bar is accrued exactly once, whenever it lands.
+
+    First call initializes the anchor to the panel's freshest label without
+    accruing history (a new book must not book funding from before it held
+    anything). Returns (funding_pnl, new_anchor_iso); the anchor also advances
+    while the book holds nothing, so a flat spell never back-accrues later.
+    """
     try:
-        if prev_tick_iso:
-            since = datetime.fromisoformat(str(prev_tick_iso))
-        else:
-            return 0.0
+        if panel.funding is None or panel.funding.empty:
+            return 0.0, last_accrued_iso
+        if not last_accrued_iso:
+            # Initialize to the freshest label ALREADY ELAPSED at this tick —
+            # never the panel's absolute last row, which a sim/backdated tick
+            # may not have reached yet.
+            eligible = panel.funding.index[panel.funding.index <= now]
+            if not len(eligible):
+                return 0.0, None
+            return 0.0, eligible[-1].isoformat()
+        since = datetime.fromisoformat(str(last_accrued_iso))
         window = panel.funding.loc[panel.funding.index > since]
         window = window.loc[window.index <= now]
         if window.empty:
-            return 0.0
+            return 0.0, last_accrued_iso
         total = 0.0
-        for symbol, weight in weights.items():
+        for symbol, weight in (weights or {}).items():
             if symbol not in window.columns:
                 continue
             rates = window[symbol].dropna()
             if rates.empty:
                 continue
             total += -float(weight) * float(rates.sum()) * float(panel.bar_hours)
-        return total
+        return total, window.index.max().isoformat()
     except Exception:
         log.warning("basket funding accrual failed — booking 0 this tick", exc_info=True)
-        return 0.0
+        return 0.0, last_accrued_iso
 
 
 def _rebalance_due(last_rebalance_iso: str | None, now: datetime, rebalance_hours: float) -> bool:
@@ -459,6 +487,12 @@ def _target_weights(
 # ------------------------------------------------------------ persisted entry
 
 
+# One tick at a time: the hourly scheduler job and the manual /tick endpoint
+# would otherwise read the same exchange snapshot, compute identical deltas,
+# and double-place every live order.
+_TICK_LOCK = threading.Lock()
+
+
 def run_basket_tick(force: bool = False) -> dict | None:
     """Load the universe, tick the basket, persist. The scheduler entry point.
 
@@ -467,6 +501,9 @@ def run_basket_tick(force: bool = False) -> dict | None:
     """
     settings = _load_settings()
     if not force and not basket_enabled(settings):
+        return None
+    if not _TICK_LOCK.acquire(blocking=False):
+        log.warning("basket tick already in flight — skipping the overlapping run")
         return None
     try:
         from forven.basket_lab import build_panel
@@ -523,6 +560,8 @@ def run_basket_tick(force: bool = False) -> dict | None:
     except Exception:
         log.warning("basket tick failed", exc_info=True)
         return None
+    finally:
+        _TICK_LOCK.release()
 
 
 def _hl_funding_matrix(panel):

--- a/forven/exchange/risk.py
+++ b/forven/exchange/risk.py
@@ -1099,7 +1099,11 @@ def revoke_dead_strategy_ceilings() -> list[str]:
     Bot ceilings (``bot:{id}`` keys) are managed by the Bot Factory and skipped.
     """
     ceilings = get_live_notional_ceilings()
-    sids = [s for s in ceilings if not str(s).startswith("bot:")]
+    # Bot ceilings are managed by the Bot Factory; basket ceilings by the
+    # basket arming/disarm lifecycle. Neither id exists in the strategies
+    # table, so sweeping them here would revoke a LIVE armed cap — after
+    # which check_live_strategy_ceiling fails open.
+    sids = [s for s in ceilings if not str(s).startswith(("bot:", "basket:"))]
     if not sids:
         return []
     stages = _ceiling_stage_map(sids)
@@ -4039,13 +4043,17 @@ def close_all_positions() -> list[dict]:
         close_accounts: list[str | None] = [None]
         try:
             from forven.exchange import books as _books_mod
-            if _books_mod.books_enabled():
-                seen_acc: set[str] = set()
-                for _lbl, _addr in _books_mod.active_book_addresses():
-                    key = str(_addr).strip().lower() if _addr else ""
-                    if key and key not in seen_acc:
-                        seen_acc.add(key)
-                        close_accounts.append(_addr)
+            # active_book_addresses covers direction books (when enabled) AND
+            # named wallets, which hold real positions (live bots, the armed
+            # basket) regardless of the direction-books switch — an emergency
+            # flatten that only empties the master with books off would leave
+            # every named-wallet position running. Sweep it unconditionally.
+            seen_acc: set[str] = set()
+            for _lbl, _addr in _books_mod.active_book_addresses():
+                key = str(_addr).strip().lower() if _addr else ""
+                if key and key not in seen_acc:
+                    seen_acc.add(key)
+                    close_accounts.append(_addr)
         except Exception:
             pass
 

--- a/forven/routers/ops.py
+++ b/forven/routers/ops.py
@@ -104,8 +104,19 @@ def post_portfolio_basket_reset(body: ConfirmBody, venue: str = "binance"):
 
     from forven.basket_runtime import reset_basket_state
 
+    if not bool(body.confirm):
+        raise HTTPException(status_code=400, detail="confirmation required to reset the basket book")
     if venue not in ("binance", "hyperliquid"):
         raise HTTPException(status_code=400, detail=f"unknown basket venue: {venue}")
+    # Live execution follows the HL book: resetting it while armed would strand
+    # the wallet's open positions unmanaged, then trade against a 1-tick book.
+    from forven.basket_live import basket_live_armed
+
+    if venue == "hyperliquid" and basket_live_armed():
+        raise HTTPException(
+            status_code=409,
+            detail="basket live execution is ARMED and follows the HL book — disarm (and flatten) first",
+        )
     return {"ok": reset_basket_state(venue), "venue": venue}
 
 

--- a/frontend/src/routes/portfolio/+page.svelte
+++ b/frontend/src/routes/portfolio/+page.svelte
@@ -412,12 +412,10 @@
 					</div>
 					<div
 						class="border border-[#222] bg-[#0a0a0a] p-2"
-						title="What the book earns per year if funding rates and prices hold — the fees it collects for taking the unpopular side. The reason this basket exists."
+						title="This tick's funding rates extrapolated to a year, BEFORE trading costs — historically costs consumed the whole gross carry (clean-data re-validation: net −24% to −42%/yr). Judge the book by its realized equity curve, not this number."
 					>
-						<div class="text-[10px] uppercase tracking-wider text-[#666]">Expected income /yr</div>
-						<div
-							class={`text-base font-bold ${(basket.expected_carry_annualized ?? 0) >= 0 ? 'text-emerald-400' : 'text-red-400'}`}
-						>
+						<div class="text-[10px] uppercase tracking-wider text-[#666]">Gross carry /yr (excl. costs)</div>
+						<div class="text-base font-bold text-[#999]">
 							{fmtUsd(basket.expected_carry_annualized)}
 							<span class="block text-[10px] font-normal text-[#666]">{fmtPct(basket.expected_carry_annualized, 1)}</span>
 						</div>

--- a/tests/test_basket_live.py
+++ b/tests/test_basket_live.py
@@ -60,10 +60,26 @@ class _Exchange:
         import forven.exchange.hyperliquid as hl
 
         monkeypatch.setattr(hl, "resolve_configured_testnet", lambda *a, **k: True)
-        monkeypatch.setattr(hl, "get_all_mids", lambda testnet=True: dict(self.mids))
+        # get_all_mids uppercases keys in production — mirror that here.
+        monkeypatch.setattr(
+            hl, "get_all_mids",
+            lambda testnet=True: {str(k).upper(): v for k, v in self.mids.items()},
+        )
+
+        def _wrap(p):
+            # Tests author flat {asset, size, direction}; the wire returns
+            # Hyperliquid's raw assetPositions wrapper with a STRING szi —
+            # feed production code the real shape (the original flat mock is
+            # exactly how the schema-blindness bug survived its tests).
+            szi = abs(float(p.get("size") or 0.0))
+            if str(p.get("direction") or "").lower() == "short":
+                szi = -szi
+            return {"position": {"coin": p.get("asset"), "szi": str(szi), "entryPx": "1.0"},
+                    "type": "oneWay"}
+
         monkeypatch.setattr(
             hl, "get_positions",
-            lambda testnet=True, account_address=None: {"positions": list(self.positions)},
+            lambda testnet=True, account_address=None: {"positions": [_wrap(p) for p in self.positions]},
         )
 
         def _market_order(asset, side, size, **kw):
@@ -252,3 +268,106 @@ def test_alias_mapping():
     assert lake_symbol_to_exchange_asset("1000PEPE-USDT") == "kPEPE"
     assert lake_symbol_to_exchange_asset("BTC-USDT") == "BTC"
     assert lake_symbol_to_exchange_asset("ETH/USDT") == "ETH"
+
+
+# ------------------------------------------- audit fixes (2026-07-07)
+
+
+def test_reconcile_noop_when_wallet_matches_targets(forven_db, monkeypatch):
+    """The runaway scenario: a wallet already AT target must produce zero
+    orders — the schema-blindness bug made every tick re-open the full book."""
+    _settings()
+    _paper_book({"AAA-USDT": 0.1, "BBB-USDT": -0.1})
+    _arm(10_000.0)
+    venue = _Exchange(
+        mids={"AAA": 10.0, "BBB": 20.0},
+        positions=[{"asset": "AAA", "size": 100.0, "direction": "long"},
+                   {"asset": "BBB", "size": 50.0, "direction": "short"}],
+    ).install(monkeypatch)
+    report = reconcile_basket_live()
+    assert report["orders"] == []
+    assert venue.market_orders == [] and venue.closes == []
+
+
+def test_reconcile_closes_leg_no_longer_in_targets(forven_db, monkeypatch):
+    _settings()
+    _paper_book({"AAA-USDT": 0.1})
+    _arm(10_000.0)
+    venue = _Exchange(
+        mids={"AAA": 10.0, "BBB": 20.0},
+        positions=[{"asset": "BBB", "size": 50.0, "direction": "long"}],
+    ).install(monkeypatch)
+    report = reconcile_basket_live()
+    assert len(venue.closes) == 1 and venue.closes[0]["asset"] == "BBB"
+    assert venue.closes[0]["side"] == "sell"
+
+
+def test_reconcile_fails_closed_when_ceiling_missing(forven_db, monkeypatch):
+    """check_live_strategy_ceiling fails OPEN with no entry; an armed basket
+    whose ceiling was revoked (the reaper bug) must refuse to trade instead."""
+    from forven.exchange.risk import set_live_notional_ceiling
+
+    _settings()
+    _paper_book({"AAA-USDT": 0.1})
+    _arm(10_000.0)
+    set_live_notional_ceiling(CEILING_ID, None, actor="test-reaper")
+    venue = _Exchange(mids={"AAA": 10.0}).install(monkeypatch)
+    report = reconcile_basket_live()
+    assert report["skipped"] == "arming ceiling missing"
+    assert venue.market_orders == []
+
+
+def test_reconcile_refuses_excessive_gross_weight(forven_db, monkeypatch):
+    _settings()
+    _paper_book({"AAA-USDT": 2.0, "BBB-USDT": -1.5})  # gross 3.5 > 3.0 bound
+    _arm(10_000.0)
+    venue = _Exchange(mids={"AAA": 10.0, "BBB": 20.0}).install(monkeypatch)
+    report = reconcile_basket_live()
+    assert report["skipped"] == "gross weight bound exceeded"
+    assert venue.market_orders == []
+
+
+def test_reconcile_preserves_midflight_disarm(forven_db, monkeypatch):
+    """A disarm landing while orders are in flight must win — the stale
+    armed=True dict captured at reconcile entry must not clobber it."""
+    import forven.exchange.hyperliquid as hl
+
+    _settings()
+    _paper_book({"AAA-USDT": 0.1})
+    _arm(10_000.0)
+    _Exchange(mids={"AAA": 10.0}).install(monkeypatch)
+
+    def disarming_market_order(asset, side, size, **kw):
+        kv_set(ARMING_KV_KEY, {**kv_get(ARMING_KV_KEY, {}), "armed": False})
+        return {"order_id": "X1"}
+
+    monkeypatch.setattr(hl, "market_order", disarming_market_order)
+    report = reconcile_basket_live()
+    assert report["orders_ok"] >= 1
+    assert kv_get(ARMING_KV_KEY, {}).get("armed") is False  # disarm preserved
+
+
+def test_reconcile_prices_alias_assets(forven_db, monkeypatch):
+    """get_all_mids uppercases keys; alias legs (kPEPE) must still price."""
+    _settings()
+    _paper_book({"1000PEPE-USDT": -0.1})
+    _arm(10_000.0)
+    venue = _Exchange(mids={"kPEPE": 0.01}).install(monkeypatch)
+    report = reconcile_basket_live()
+    assert report["unlistable_symbols"] == []
+    assert len(venue.market_orders) == 1
+    assert venue.market_orders[0]["asset"] == "KPEPE"
+    assert venue.market_orders[0]["side"] == "sell"
+
+
+def test_dead_strategy_reaper_spares_basket_ceiling(forven_db):
+    from forven.exchange.risk import (
+        get_live_notional_ceilings,
+        revoke_dead_strategy_ceilings,
+        set_live_notional_ceiling,
+    )
+
+    set_live_notional_ceiling(CEILING_ID, 2000.0, actor="test")
+    revoked = revoke_dead_strategy_ceilings()
+    assert CEILING_ID not in revoked
+    assert CEILING_ID in get_live_notional_ceilings()

--- a/tests/test_basket_runtime.py
+++ b/tests/test_basket_runtime.py
@@ -486,3 +486,33 @@ def test_hl_funding_snapshot_writes_and_dedupes(forven_db, monkeypatch, tmp_path
     assert second["rows_added"] == 0
     series = venue.load_hl_funding_series("BBB")
     assert series is not None and series.iloc[-1] == pytest.approx(-0.00005)
+
+
+def test_funding_accrues_when_labels_lag_wall_clock():
+    """Production timing: bar labels reach the lake 1-4h after their label time
+    and ticks run hourly. Funding must accrue when the label ARRIVES (label
+    anchor), not when a wall-clock window happens to contain it — it never
+    does (the 2026-07-07 audit found 9/9 production ticks at funding 0.0)."""
+    import pandas as pd
+
+    cfg = _config(rebalance_hours=1000, max_stale_hours=100)
+    panel_t0 = _panel(end=pd.Timestamp("2026-07-01T00:00:00Z"))
+    # Tick 1 runs 2h after the freshest label (the lake lags the clock).
+    t1 = _now(panel_t0) + timedelta(hours=2)
+    state, _ = tick_basket(_fresh_state("x"), panel_t0, t1, _config(max_stale_hours=100))
+    assert state["weights"]
+    assert state["last_accrued_label"] == "2026-07-01T00:00:00+00:00"
+    # Tick 2, one hour later, same panel: no new bar landed -> nothing accrues.
+    t2 = t1 + timedelta(hours=1)
+    state, report = tick_basket(state, panel_t0, t2, cfg)
+    assert report["funding_pnl"] == pytest.approx(0.0, abs=1e-12)
+    # Tick 3: ONE new bar landed whose label is still hours older than tick 2 —
+    # the old wall-clock window could never contain it; the anchor books it.
+    panel_t1 = _panel(n_bars=101, end=pd.Timestamp("2026-07-01T01:00:00Z"))
+    t3 = t2 + timedelta(hours=1)
+    state, report = tick_basket(state, panel_t1, t3, cfg)
+    assert report["funding_pnl"] == pytest.approx(0.001, rel=1e-9)
+    assert state["last_accrued_label"] == "2026-07-01T01:00:00+00:00"
+    # Tick 4, same panel again: the bar must accrue exactly once.
+    state, report = tick_basket(state, panel_t1, t3 + timedelta(hours=1), cfg)
+    assert report["funding_pnl"] == pytest.approx(0.0, abs=1e-12)


### PR DESCRIPTION
## Context

A four-lens hostile audit of the basket live path (2026-07-07) found three CRITICAL defects, all independently verified at the cited lines and against production data. This PR fixes every confirmed CRITICAL/HIGH finding. **The basket was never armed live** — nothing was at risk in production, but none of this code was safe to arm.

## CRITICAL fixes

1. **Position-schema blindness** (`basket_live.py`): the reconciler and `_flatten_wallet` parsed positions as flat `{asset, size, direction}` rows, but `get_positions` returns Hyperliquid's raw `assetPositions` wrappers (`{"position": {"coin", "szi"}}`, string `szi`). `held` was always empty, so an armed basket would re-open its FULL target book every hourly tick (unbounded accumulation), disarm+flatten silently closed nothing, and the close/reduce/flip branches were unreachable. Now parsed via `_signed_positions()` mirroring the kill-switch's unwrap, and **the test mock emits the real wire shape** — the flat fake shape is exactly how this bug survived its own tests.

2. **Zero funding accrual, both paper books** (`basket_runtime.py`): the accrual window was anchored on wall-clock tick times, but funding rows carry bar-open labels that reach the lake 1–4h late — with hourly ticks the window (prev_tick, now] is structurally empty and 9/9 production ticks booked `funding_pnl: 0.0`. The carry books measured everything except carry, and the ≥24-tick arming evidence gate gated on meaningless history. Accrual is now anchored on the last **accrued panel label**: late bars book exactly once when they land, the anchor advances through flat spells, and initialization clamps to already-elapsed labels.

## HIGH fixes

- **Ceiling erosion**: the nightly dead-strategy reaper revoked `basket:funding_carry`'s arming ceiling (only `bot:` was exempt), after which the ceiling check failed OPEN. The reaper now spares `basket:` ids, and reconcile independently **fails closed** if the arming ceiling is missing.
- **Kill-switch gap**: `close_all_positions` skipped named wallets unless direction books were enabled — an emergency halt with books off flattened only the master while basket/bot wallets kept running. Named wallets are now swept unconditionally.
- **Disarm race**: reconcile wrote its entry-time `armed: true` dict back after placing orders, clobbering a mid-flight disarm whose ceiling was already cleared. It now re-reads the arming record and lets the disarm win.
- **Unbounded gross**: hard 3× gross-weight bound before mirroring the paper book; `basket_gross_leverage` clamped [0.01, 3.0]; `_float_setting` rejects NaN/inf.
- **Reset safety** (`ops.py`): `/basket/reset` now honors its `confirm` flag (was parsed and ignored) and refuses to reset the HL book while live execution is armed.
- **Tick concurrency**: non-blocking lock so the hourly job and a manual `/tick` can't double-place the same deltas; hour-bucketed idempotency keys dedupe identical orders.

## MED fixes

- Alias legs (kPEPE-class 1000x tickers) always read as unlisted because `get_all_mids` uppercases its keys — the short side of a carry book under-filled systematically. Mids lookups now uppercase.
- The green "+10.2%/yr Expected income" headline was a gross, costs-excluded instantaneous extrapolation displayed against a recorded net −24..−42%/yr verdict. Now "Gross carry /yr (excl. costs)", neutral color, honest tooltip.

## Tests

8 new tests: runaway no-op (wallet at target → zero orders), departed-leg close, fail-closed missing ceiling, gross bound, mid-flight disarm preserved, alias pricing, reaper exemption, and label-lag funding accrual (the production timing that the old window could never book). Suites: 47 basket + 50 kill-switch/ceiling/books green; ruff clean.

## Operator notes

- The paper books restart their carry evidence honestly from this deploy — the pre-fix curves contain no funding and should not count toward the "weeks of evidence" bar.
- The existing HL/Binance book histories are unaffected structurally; only accrual behavior changes going forward (first post-deploy tick initializes the label anchor).
- Arming remains inadvisable until the fixed close path is proven against the testnet harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2wv5NajW8AKnACTPa1uS5