### PR TITLE
fix(basket): expire the final funding print instead of forward-filling it forever (FUND-STALE-1)

### DIFF
--- a/forven/basket_lab.py
+++ b/forven/basket_lab.py
@@ -154,7 +154,18 @@ def _per_hour_funding_series(symbol: str, index: pd.DatetimeIndex) -> pd.Series 
             (frame["rate"] / hours).values,
             index=pd.DatetimeIndex(frame["ts"]).as_unit("ns"),
         )
-        return per_hour.reindex(pd.DatetimeIndex(index).as_unit("ns"), method="ffill")
+        aligned = per_hour.reindex(pd.DatetimeIndex(index).as_unit("ns"), method="ffill")
+        # A print is only CURRENT for its own interval (+1h collection grace).
+        # Interior prints self-terminate at the next print, but the FINAL one
+        # would otherwise carry forward unbounded — a dead/delisted feed reads
+        # as "fresh" forever, and the downstream staleness mask cannot catch it
+        # because it measures this already-filled matrix (its last_valid_index
+        # is just the symbol's last OHLCV bar). Expire the tail instead
+        # (2026-07-07: TON-USDT's June-23 print was still being ranked as the
+        # current rate two weeks later).
+        expiry = frame["ts"].iloc[-1] + pd.Timedelta(hours=float(hours.iloc[-1]) + 1.0)
+        aligned[aligned.index > expiry] = float("nan")
+        return aligned
     except Exception:
         log.debug("per-print funding conversion failed for %s", symbol, exc_info=True)
         return None

--- a/tests/test_basket_lab.py
+++ b/tests/test_basket_lab.py
@@ -121,3 +121,32 @@ def test_funding_interval_hours_from_observed_grid(tmp_path, monkeypatch):
     assert basket_lab._funding_interval_hours("AAA-USDT") == 8.0
     assert basket_lab._funding_interval_hours("BBB-USDT") == 4.0
     assert basket_lab._funding_interval_hours("ZZZ-USDT") == 8.0  # no history -> default
+
+
+def test_per_hour_funding_expires_after_final_print(tmp_path, monkeypatch):
+    """A dead feed must go NaN one interval (+1h grace) past its final print —
+    unbounded forward-fill let a delisted symbol's weeks-old rate rank as
+    current forever (2026-07-07: TON-USDT, last print two weeks stale), and
+    the runtime's 9h staleness mask measures this matrix, so it never saw it.
+    Interior prints still fill normally up to the next print."""
+    import forven.basket_lab as basket_lab
+    import forven.data_manager as data_manager
+
+    monkeypatch.setattr(data_manager, "FUNDING_DIR", tmp_path)
+    d = tmp_path / "AAA-USDT"
+    d.mkdir()
+    prints = pd.date_range("2026-01-01", periods=4, freq="8h", tz="UTC")  # last: 01-02 00:00
+    pd.DataFrame({"timestamp": prints, "funding_rate": [0.0008] * 4}).to_parquet(
+        d / "history.parquet"
+    )
+    # Panel keeps ticking hourly for 3 more days after the feed dies.
+    index = pd.date_range("2026-01-01", "2026-01-05", freq="1h", tz="UTC")
+    series = basket_lab._per_hour_funding_series("AAA-USDT", index)
+
+    # Backed bars: per-print conversion (0.0008 / 8h) up to expiry.
+    assert series.loc["2026-01-01T12:00:00Z"] == pytest.approx(0.0001)
+    # Still current through final print + 8h interval + 1h grace...
+    assert series.loc["2026-01-02T09:00:00Z"] == pytest.approx(0.0001)
+    # ...and NaN after the final print expires.
+    assert pd.isna(series.loc["2026-01-02T10:00:00Z"])
+    assert series.loc["2026-01-02T10:00:00Z":].isna().all()


### PR DESCRIPTION
## Problem

The 9-hour funding staleness guard was structurally blind for the Binance book: `_per_hour_funding_series` forward-filled the **final** print onto the symbol's entire OHLCV index at panel build, so the runtime mask — which reads `last_valid_index()` of that already-filled matrix — always saw "fresh" as long as OHLCV kept ticking. A stalled collector or a dead/delisted market would be ranked and accrued at its fossil rate indefinitely.

Live example, found today: **TON-USDT's final funding print is June 23** — the basket has been treating a two-week-old rate as current carry.

## Fix

Interior prints already self-terminate at the next print; only the final one carried forward unbounded. It now expires **one own-interval + 1h collection grace** past its timestamp (for an 8h-grid file: exactly the designed 9h currency window). Past expiry the matrix is NaN, so:

- the eligibility mask excludes the symbol from ranking (the guard finally has teeth),
- runtime accrual books nothing rather than a fossil rate,
- research sims stop ranking dead feeds mid-run (audit finding 6, cured by the same change).

The HL-native book was already immune (exact reindex, no ffill).

## Diagnosis note (the companion follow-up)

`forven-data-funding-collect` itself is **healthy**: 8h interval, last run `ok` at 20:12 UTC today, 79/82 symbols printed today. The earlier "never ran" observation sampled the scheduler inside its first post-restart interval. The 3 stale series (TON-USDT, MATIC-USDT, ETH-BTC) are dead markets — precisely the case this guard now handles.

## Tests

New regression test (dead feed: backed bars convert per-print, current through interval+grace, NaN after expiry). All 61 basket tests green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2wv5NajW8AKnACTPa1uS5