### PR TITLE
fix(registration): self-documenting validator + AST-guard rejection errors (DX-REG-1)

### DIFF
--- a/forven/sandbox/ast_guard.py
+++ b/forven/sandbox/ast_guard.py
@@ -192,6 +192,24 @@ def _module_import_allowed(dotted: str) -> bool:
             return False
     return True
 
+
+def _forbidden_import_message(dotted: str, *, from_import: bool = False) -> str:
+    """Rejection message for a blocked import, self-documenting for forven paths.
+
+    Agents guessing a nonexistent internal module (e.g. ``forven.strategies.signals``
+    for a Signal enum that doesn't exist) burn registration attempts against a bare
+    "not on the allowlist" — name the real strategy-facing surface instead.
+    """
+    shown = f"'from {dotted} import ...'" if from_import else f"'{dotted}'"
+    message = f"Import not on the allowlist: {shown}"
+    if (dotted or "").strip().split(".")[0] == "forven":
+        message += (
+            "; the only strategy-facing forven imports are "
+            + ", ".join(ALLOWED_FORVEN_PREFIXES)
+            + " (BaseStrategy and Signal live in forven.strategies.base)"
+        )
+    return message
+
 FORBIDDEN_CALLS: frozenset[str] = frozenset(
     {
         "eval",
@@ -517,7 +535,7 @@ class _GuardVisitor(ast.NodeVisitor):
                         kind="forbidden_import",
                         lineno=node.lineno,
                         col=node.col_offset,
-                        message=f"Import not on the allowlist: '{alias.name}'",
+                        message=_forbidden_import_message(alias.name),
                         node_repr=ast.dump(node),
                     )
                 )
@@ -544,7 +562,7 @@ class _GuardVisitor(ast.NodeVisitor):
                     kind="forbidden_import",
                     lineno=node.lineno,
                     col=node.col_offset,
-                    message=f"Import not on the allowlist: 'from {module} import ...'",
+                    message=_forbidden_import_message(module, from_import=True),
                     node_repr=ast.dump(node),
                 )
             )

--- a/forven/selfheal.py
+++ b/forven/selfheal.py
@@ -179,7 +179,11 @@ for name, obj in list(globals().items()):
         continue
 
 if not strategy_classes:
-    print("ERROR: No BaseStrategy subclass found")
+    print(
+        "ERROR: No BaseStrategy subclass found. The module must define a class extending "
+        "BaseStrategy (`from forven.strategies.base import BaseStrategy, Signal`) and "
+        "export STRATEGY_CLASS = <that class>."
+    )
     sys.exit(1)
 
 for cls_name, cls in strategy_classes:
@@ -208,13 +212,28 @@ for cls_name, cls in strategy_classes:
     elif isinstance(signal, dict):
         signal_payload = dict(signal)
     else:
-        print(f"ERROR: generate_signal returned invalid type for {{cls_name}}: {{type(signal).__name__}}")
+        # Name the full contract: agents have burned 4+ registration attempts
+        # cycling float/int/np.int64/Series against the bare "invalid type"
+        # message and then guessing a nonexistent Signal-enum module (2026-07-07
+        # S06308 hollow-mint cluster).
+        print(
+            f"ERROR: generate_signal returned invalid type for {{cls_name}}: {{type(signal).__name__}}. "
+            "Return the Signal DATACLASS (`from forven.strategies.base import Signal` -- the only "
+            "allowlisted import path; there is no forven.strategies.signals module) or a dict with "
+            "entry_signal/exit_signal keys. Signal is not an enum (no BUY/SELL/NEUTRAL members): "
+            "no-trade is Signal(), an entry is Signal(entry_signal=True, direction='long', "
+            "price=float(df['close'].iloc[-1])). Never return float/int/numpy scalars/Series."
+        )
         sys.exit(1)
 
     required_signal_keys = {{"entry_signal", "exit_signal"}}
     missing_signal_keys = sorted(required_signal_keys.difference(signal_payload))
     if missing_signal_keys:
-        print(f"ERROR: Missing signal keys for {{cls_name}}: {{', '.join(missing_signal_keys)}}")
+        print(
+            f"ERROR: Missing signal keys for {{cls_name}}: {{', '.join(missing_signal_keys)}}. "
+            "Dict signals need boolean entry_signal AND exit_signal keys; simpler is to return "
+            "Signal(entry_signal=..., exit_signal=...) from forven.strategies.base."
+        )
         sys.exit(1)
 
     for key in ("entry_signal", "exit_signal", "price", "confidence", "direction"):


### PR DESCRIPTION
## Problem
The strategy-developer agent burned 4+ registration attempts on 2026-07-07 (S06300/S06303/S06308 hollow-mint cluster) cycling `float` / `int` / `np.int64` / `pd.Series` returns against the bare error `generate_signal returned invalid type`, then hallucinated a `forven.strategies.signals` enum module and hit an equally bare `Import not on the allowlist` reject. Neither message said what the contract actually is.

## Fix
**`forven/selfheal.py`** (validation harness — the `register_strategy` path):
- invalid-return-type error now states: return the `Signal` **dataclass** from `forven.strategies.base` (the only allowlisted path; `forven.strategies.signals` does not exist) or a dict with `entry_signal`/`exit_signal`; no BUY/SELL/NEUTRAL enum; no-trade = `Signal()`; never float/int/numpy scalars/Series.
- missing-signal-keys and no-BaseStrategy-subclass errors similarly name the contract.

**`forven/sandbox/ast_guard.py`**:
- new `_forbidden_import_message()` used by both import visitors — a blocked `forven.*` import now appends the allowlisted strategy-facing prefixes and where `BaseStrategy`/`Signal` live. Non-forven rejects unchanged.

## Verification
- Replayed both S06308 failure modes end-to-end through `validate_strategy_code` / `scan_source` — both now emit the self-documenting messages.
- `pytest tests/test_sandbox_ast_guard.py tests/test_ast_guard_bypasses.py tests/test_intake_ast_guard.py tests/test_selfheal.py tests/test_selfheal_encoding.py` → **131 passed**.
- Message text kept ASCII-only (em-dash mojibaked through the sandbox console encoding on Windows).

DX polish, not a gate change — validation semantics are untouched; only the rejection text changed. Backend restart required to activate (modules are import-cached in-process).

🤖 Generated with [Claude Code](https://claude.com/claude-code)