### PR TITLE
fix(engine): adx_min gates without a cap + donchian channel_period alias (ADX-GATE-1)

### DIFF
--- a/forven/engine_provenance.py
+++ b/forven/engine_provenance.py
@@ -46,7 +46,7 @@ import json
 # data-substrate rebuild that invalidates comparisons against prior verdicts
 # (verdicts are only evidence relative to the data they were scored on) — and
 # add a matching ENGINE_VERSION_LOG entry (test-enforced).
-BACKTEST_ENGINE_VERSION = 2
+BACKTEST_ENGINE_VERSION = 3
 
 # Append-only changelog: one entry per version, newest last. The unit test
 # asserts the newest entry matches BACKTEST_ENGINE_VERSION so a bump can never
@@ -70,6 +70,17 @@ ENGINE_VERSION_LOG: tuple[dict, ...] = (
             "seed, DVOL backfill to 2021-03, and coverage-aware liquidation "
             "fill (pre-capture bars NaN, not fake zeros). Verdicts scored on "
             "the pre-rebuild data are stale evidence against the current lake."
+        ),
+    },
+    {
+        "version": 3,
+        "date": "2026-07-08",
+        "summary": (
+            "Regime-gate adx_min fix: adx_min was only enforced when an adx_cap "
+            "was also present, so trend strategies setting adx_min alone ran "
+            "unfiltered (user report: Donchian +adx_min:25 backtested identical "
+            "to no filter). It now gates entries and forces exits on its own. "
+            "Any strategy stamping adx_min without adx_max scores differently."
         ),
     },
 )

--- a/forven/scanner.py
+++ b/forven/scanner.py
@@ -7197,16 +7197,19 @@ def _scan_asset_group(
                         )
                         continue
 
-                    # T01099 FIX: Apply BOTH adx_min AND adx_cap bounds (matching backtest.py)
-                    adx_min_val = adx_min if adx_min is not None else float(strategy_params.get("adx_min", 0))
-                    if adx_cap is not None and live_adx is not None:
-                        if live_adx >= adx_cap or live_adx < adx_min_val:
+                    # T01099 FIX: Apply BOTH adx_min AND adx_cap bounds (matching backtest.py).
+                    # adx_min must gate even WITHOUT a cap — trend strategies set adx_min
+                    # alone, and nesting it under the cap check silently dropped it.
+                    adx_min_val = adx_min if adx_min is not None else float(strategy_params.get("adx_min", 0) or 0)
+                    if live_adx is not None and (adx_cap is not None or adx_min_val > 0):
+                        if (adx_cap is not None and live_adx >= adx_cap) or live_adx < adx_min_val:
+                            cap_label = f"{adx_cap:.1f}" if adx_cap is not None else "none"
                             log.info(
-                                "[%s] SKIPPED — regime ADX bounds (ADX=%.1f, min=%.1f, max=%.1f)",
+                                "[%s] SKIPPED — regime ADX bounds (ADX=%.1f, min=%.1f, max=%s)",
                                 strat_id,
                                 live_adx,
                                 adx_min_val,
-                                adx_cap,
+                                cap_label,
                             )
                             results.append(
                                 _blocked_scan_row(
@@ -7214,7 +7217,7 @@ def _scan_asset_group(
                                     strategy_for_signal,
                                     (
                                         f"regime ADX bounds: ADX={live_adx:.1f}, "
-                                        f"min={adx_min_val:.1f}, max={adx_cap:.1f}"
+                                        f"min={adx_min_val:.1f}, max={cap_label}"
                                     ),
                                     asset=asset,
                                     live_prices=live_prices,

--- a/forven/strategies/backtest.py
+++ b/forven/strategies/backtest.py
@@ -6007,7 +6007,7 @@ def _build_regime_gate_masks(
     )
 
 
-    if not compatible_regimes and adx_cap is None:
+    if not compatible_regimes and adx_cap is None and adx_min is None:
 
 
         return (
@@ -6055,7 +6055,7 @@ def _build_regime_gate_masks(
 
 
 
-    if adx_cap is not None:
+    if adx_cap is not None or adx_min is not None:
 
 
         adx_period = int(runtime_params.get("adx_period", 14))
@@ -6064,9 +6064,14 @@ def _build_regime_gate_masks(
         adx_source = df["adx_val"] if "adx_val" in df.columns else compute_adx(df, adx_period)
 
 
-        # T01099 FIX: Apply BOTH adx_min AND adx_max bounds
-        adx_min_val = float(runtime_params.get("adx_min", 0))
-        allowed_by_adx = (adx_source >= adx_min_val) & (adx_source <= float(adx_cap))
+        # T01099 FIX: Apply BOTH adx_min AND adx_max bounds. adx_min must gate even
+        # WITHOUT a cap — trend strategies set adx_min alone, and nesting it under
+        # the cap branch silently dropped it (user report 2026-07-08: three Donchian
+        # variants with/without adx_min:25 produced bit-identical backtests).
+        adx_min_val = float(adx_min) if adx_min is not None else 0.0
+        allowed_by_adx = adx_source >= adx_min_val
+        if adx_cap is not None:
+            allowed_by_adx &= adx_source <= float(adx_cap)
         allowed_by_adx = allowed_by_adx.fillna(False)
         entry_allowed &= allowed_by_adx
 

--- a/forven/strategies/params.py
+++ b/forven/strategies/params.py
@@ -367,6 +367,11 @@ _PARAM_ALIASES = {
 
         "entry_period": "donchian_period",
 
+        # "channel period" is the textbook name for the Donchian lookback; users
+        # setting it got a silent no-op (2026-07-08 report: channel_period:40
+        # produced a backtest identical to the 20-period default).
+        "channel_period": "donchian_period",
+
         "donchian_exit_period": "exit_period",
 
         "ema_regime": "ema_period",

--- a/tests/test_param_canonicalization.py
+++ b/tests/test_param_canonicalization.py
@@ -165,6 +165,15 @@ def test_resolve_strategy_family_handles_versioned_runtime_types():
     assert resolve_strategy_family("macd") == "macd"
 
 
+def test_donchian_channel_period_alias_maps_to_donchian_period():
+    # "channel period" is the textbook Donchian lookback name; it used to be a
+    # silent no-op (2026-07-08 report: channel_period:40 backtested identical
+    # to the 20-period default).
+    canonical = canonicalize_params("donchian", {"channel_period": 40})
+
+    assert canonical.params["donchian_period"] == 40
+
+
 def test_donchian_runtime_type_canonicalizes_regime_breakout_aliases():
     canonical, meta = canonicalize_params_with_metadata(
         "donchian_regime",

--- a/tests/test_regime_gate.py
+++ b/tests/test_regime_gate.py
@@ -1,12 +1,73 @@
 from __future__ import annotations
 
+import numpy as np
+import pandas as pd
+
 from forven.regime import RANGE_BOUND, resolve_regime_gate
+
+
+def _adx_frame(adx_values: list[float]) -> tuple[pd.DataFrame, pd.Series]:
+    """OHLCV frame with a precomputed adx_val column + a constant regime series."""
+    n = len(adx_values)
+    index = pd.date_range("2025-01-01", periods=n, freq="h", tz="UTC")
+    close = np.linspace(100.0, 110.0, num=n)
+    df = pd.DataFrame(
+        {
+            "open": close,
+            "high": close + 0.5,
+            "low": close - 0.5,
+            "close": close,
+            "volume": np.full(n, 1000.0),
+            "adx_val": np.asarray(adx_values, dtype=float),
+        },
+        index=index,
+    )
+    return df, pd.Series("TREND_UP", index=index)
 
 
 def test_backtest_module_imports_with_regime_gate_available():
     import forven.strategies.backtest as backtest_mod
 
     assert callable(backtest_mod.resolve_regime_gate)
+
+
+def test_adx_min_gates_without_a_cap():
+    # Regression (user report 2026-07-08): adx_min was only enforced when an
+    # adx_cap was also resolved, so a trend strategy setting adx_min alone ran
+    # unfiltered — Donchian +adx_min:25 backtested bit-identical to no filter.
+    from forven.strategies.backtest import _build_regime_gate_masks
+
+    df, regimes = _adx_frame([10.0, 20.0, 30.0, 40.0])
+    entry_allowed, forced_exit, _ = _build_regime_gate_masks(
+        df, "donchian", {"adx_min": 25}, regimes=regimes,
+    )
+
+    assert list(entry_allowed) == [False, False, True, True]
+    assert list(forced_exit) == [True, True, False, False]
+
+
+def test_adx_min_and_cap_bound_both_sides():
+    from forven.strategies.backtest import _build_regime_gate_masks
+
+    df, regimes = _adx_frame([10.0, 20.0, 30.0, 40.0])
+    entry_allowed, forced_exit, _ = _build_regime_gate_masks(
+        df, "donchian", {"adx_min": 15, "adx_max": 35}, regimes=regimes,
+    )
+
+    assert list(entry_allowed) == [False, True, True, False]
+    assert list(forced_exit) == [True, False, False, True]
+
+
+def test_no_adx_params_still_passes_all_bars():
+    from forven.strategies.backtest import _build_regime_gate_masks
+
+    df, regimes = _adx_frame([10.0, 20.0, 30.0, 40.0])
+    entry_allowed, forced_exit, _ = _build_regime_gate_masks(
+        df, "donchian", {}, regimes=regimes,
+    )
+
+    assert entry_allowed.all()
+    assert not forced_exit.any()
 
 
 def test_resolve_regime_gate_defaults_williams_r_to_range_bound_cap():


### PR DESCRIPTION
## Problem (user report, 2026-07-08)
Three Donchian variants — control (`donchian_period:20`), `+channel_period:40`, `+adx_min:25` — backtested **bit-identical** (same trades/Sharpe/PF). Both of the user''s suspicions verified true:

1. **`channel_period` existed nowhere** — not read by the strategy, not in the donchian alias map. Silently swallowed.
2. **`adx_min` was only enforced when an `adx_cap` was also resolved** — the application was nested inside `if adx_cap is not None:` in the backtest regime gate (`backtest.py`) AND the live scanner (`scanner.py`, same bug shape). Donchian is a trend family (no mean-reversion auto-cap), so `adx_min` alone was silently dropped on every path.

## Fix
- **`strategies/backtest.py`** — `_build_regime_gate_masks` applies `adx_min` on its own: gates entries and forces exits when ADX < min; a cap still bounds the top when present. Covers all three engine paths (kernel, vectorized, slow).
- **`scanner.py`** — live/paper twin fixed identically (parity preserved); skip-log handles a cap-less bound.
- **`strategies/params.py`** — `channel_period` → `donchian_period` alias (textbook name for the Donchian lookback).
- **`engine_provenance.py`** — `BACKTEST_ENGINE_VERSION` 2→3 + changelog entry (stats-affecting: strategies stamping `adx_min` without `adx_max` score differently). Measured sweep impact: 4 active workflow resets + 31 archived failed_gate revivals (5/tick drip); paper/live untouched; unstamped history grandfathered.

## Verification
- **Differential replay** through `backtest_strategy` on real BTC 1h lake data: pre-fix all four configs bit-identical (43 trades / −4.973 / 0.382) — user symptom reproduced exactly; post-fix `channel_period:40` → 30 trades / −6.316 and `adx_min:25` → 40 trades / −4.195.
- **Recreated the user''s three strategies via the Forven MCP** (S06413/S06414/S06415, hypothesis H01712, session ADZ-0071) — ADX divergence and alias divergence confirmed through the real API+worker surface.
- Known limitation (intentional): supplying BOTH `channel_period` and an explicit `donchian_period` resolves last-key-wins by dict order — the user-exact config still matches control; use one key.
- New tests: 3 mask-level ADX gate tests + 1 alias test; 68 passed across touched suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)