### PR TITLE
feat(assistant): soft-land the chat tool-round limit + make it tunable (CHAT-ROUNDS-1)

### DIFF
--- a/forven/api_core.py
+++ b/forven/api_core.py
@@ -1838,6 +1838,12 @@ _DEFAULT_SETTINGS_PAYLOAD = {
     # non-critical findings (high/medium/low) fail closed instead of warn-allow.
     # Backend-only — there is no UI control for this.
     "sandbox_shell_guard_strict": False,
+    # Per-turn tool-round cap for the in-app assistant chat AND deepdive
+    # sessions (each round = one full model call whose input grows with every
+    # prior round, and with actions enabled each round can create real pipeline
+    # objects). On hitting the cap the turn now lands softly (forced no-tools
+    # final answer) instead of erroring. Bounded 2-40 at read time.
+    "assistant_max_tool_rounds": 12,
     "updated_at": _now(),
 }
 
@@ -2824,6 +2830,13 @@ def _apply_settings_section(section: str, payload: dict) -> dict:
         # A disabled backup carries no model.
         if updates.get("backup_ai_provider") == "none":
             updates["backup_ai_model"] = ""
+        if "assistant_max_tool_rounds" in payload:
+            updates["assistant_max_tool_rounds"] = _coerce_bounded_int(
+                payload.get("assistant_max_tool_rounds"),
+                updates.get("assistant_max_tool_rounds", 12),
+                2,
+                40,
+            )
 
     elif section == "notifications":
         if "discord_bot_token" in payload:

--- a/forven/assistant_session.py
+++ b/forven/assistant_session.py
@@ -33,17 +33,25 @@ from forven.assistant_db import (
     list_messages,
     thread_cost_total,
 )
-# Reuse the provider-format converters (pure functions) from the deepdive engine.
+# Reuse the provider-format converters (pure functions) and the shared
+# tool-round policy (operator-tunable cap + wrap-up/forced-final texts) from
+# the deepdive engine.
 from forven.deepdive_session import (
     _ANTHROPIC_FORMAT_PROVIDERS,
     _to_anthropic_messages,
     _to_openai_messages,
+    FORCED_FINAL_INSTRUCTION,
+    WRAP_UP_NUDGE,
+    WRAP_UP_ROUNDS_LEFT,
+    max_tool_rounds,
 )
 from forven.db import kv_get
 
 log = logging.getLogger("forven.assistant")
 
-MAX_TOOL_ROUNDS = 8
+# Fallback only — the live cap is max_tool_rounds() (Settings > System >
+# Assistant > "Chat tool rounds").
+MAX_TOOL_ROUNDS = 12
 # Cap how much history we replay to the model per turn (bounds cost on a
 # long-lived global thread). The converters tolerate a tool row that lands at
 # the cut boundary without a preceding assistant.
@@ -294,7 +302,14 @@ async def run_turn(
         llm_messages: list[dict] = [{"role": "system", "content": system}]
         llm_messages.extend(_history_to_llm_messages(history))
 
-        for _round in range(MAX_TOOL_ROUNDS):
+        rounds_cap = max_tool_rounds()
+        for _round in range(rounds_cap):
+            if _round == rounds_cap - WRAP_UP_ROUNDS_LEFT and rounds_cap > WRAP_UP_ROUNDS_LEFT:
+                # In-flight steering only — not persisted to the thread.
+                llm_messages.append({
+                    "role": "user",
+                    "content": WRAP_UP_NUDGE.format(rounds_left=WRAP_UP_ROUNDS_LEFT),
+                })
             # Stream this round's tokens to the client as they arrive.
             content_parts: list[str] = []
             result: dict | None = None
@@ -394,7 +409,35 @@ async def run_turn(
                     if route:
                         yield {"type": "navigate", "route": route}
 
-        yield {"type": "error", "code": "max_rounds", "message": f"hit {MAX_TOOL_ROUNDS} round limit"}
+        # Out of tool rounds — land softly: force one final answer so the user
+        # gets a summary + "continue?" instead of a dead turn. The tool list is
+        # unchanged (providers cache it per loop, and some reject an empty
+        # array); termination is guaranteed by IGNORING any tool calls below.
+        log.warning("Assistant thread %s hit %d tool rounds; forcing final answer", thread_id, rounds_cap)
+        llm_messages.append({"role": "user", "content": FORCED_FINAL_INSTRUCTION})
+        final_parts: list[str] = []
+        final_result: dict | None = None
+        async for kind, payload in _invoke_llm_stream(llm_messages, system, tools):
+            if kind == "text":
+                if payload:
+                    final_parts.append(payload)
+                    yield {"type": "assistant_token", "content": payload}
+            elif kind == "final":
+                final_result = payload
+        final_text = ""
+        if final_result is not None and not final_result.get("error"):
+            final_text = (final_result.get("content") or "".join(final_parts)).strip()
+        if final_text:
+            # Any tool calls in the forced final are deliberately ignored.
+            final_msg = append_message(
+                thread_id, role="assistant", content=final_text,
+                cost_usd=(final_result or {}).get("cost_usd"),
+                model=(final_result or {}).get("model"),
+            )
+            yield {"type": "done", "message_id": final_msg["id"]}
+            return
+
+        yield {"type": "error", "code": "max_rounds", "message": f"hit {rounds_cap} round limit"}
     except Exception as exc:
         log.exception("assistant turn failed")
         yield {"type": "error", "code": "internal", "message": str(exc)}

--- a/forven/deepdive_session.py
+++ b/forven/deepdive_session.py
@@ -14,7 +14,35 @@ from forven.deepdive_db import (
 
 log = logging.getLogger("forven.deepdive")
 
-MAX_TOOL_ROUNDS = 8
+# Fallback when the setting is unreadable; the live value is
+# Settings > System > Assistant > "Chat tool rounds" (assistant_max_tool_rounds),
+# shared by the in-app assistant and deepdive sessions.
+MAX_TOOL_ROUNDS = 12
+_TOOL_ROUNDS_MIN, _TOOL_ROUNDS_MAX = 2, 40
+# How many rounds before the cap the model is told to start wrapping up.
+WRAP_UP_ROUNDS_LEFT = 2
+
+WRAP_UP_NUDGE = (
+    "Note: only {rounds_left} tool rounds remain in this turn. Start wrapping up: "
+    "finish the most important remaining work and prepare your final answer."
+)
+FORCED_FINAL_INSTRUCTION = (
+    "Tool-round limit reached for this turn — do not call any more tools. "
+    "Summarize what you accomplished, list anything left unfinished, and ask "
+    "the operator whether to continue in a follow-up message."
+)
+
+
+def max_tool_rounds() -> int:
+    """Operator-tunable per-turn tool-round cap (bounded so a typo can't
+    unleash an unbounded loop or strangle the chat to nothing)."""
+    try:
+        from forven.api_core import get_settings
+
+        raw = int(get_settings().get("assistant_max_tool_rounds") or MAX_TOOL_ROUNDS)
+    except Exception:
+        return MAX_TOOL_ROUNDS
+    return max(_TOOL_ROUNDS_MIN, min(raw, _TOOL_ROUNDS_MAX))
 
 # Providers that accept Anthropic Messages format (tool_use / tool_result blocks).
 _ANTHROPIC_FORMAT_PROVIDERS = {"anthropic", "minimax"}
@@ -329,7 +357,14 @@ async def run_turn(thread_id: str, *, user_text: str) -> AsyncIterator[dict]:
         ]
         llm_messages.extend(_history_to_llm_messages(history))
 
-        for _round in range(MAX_TOOL_ROUNDS):
+        rounds_cap = max_tool_rounds()
+        for _round in range(rounds_cap):
+            if _round == rounds_cap - WRAP_UP_ROUNDS_LEFT and rounds_cap > WRAP_UP_ROUNDS_LEFT:
+                # In-flight steering only — not persisted to the thread.
+                llm_messages.append({
+                    "role": "user",
+                    "content": WRAP_UP_NUDGE.format(rounds_left=WRAP_UP_ROUNDS_LEFT),
+                })
             result = await _invoke_llm(llm_messages, thread["strategy_id"])
             content = result.get("content", "") or ""
             tool_calls = result.get("tool_calls") or []
@@ -384,10 +419,32 @@ async def run_turn(thread_id: str, *, user_text: str) -> AsyncIterator[dict]:
                 })
                 yield {"type": "tool_result", "name": tc_name, "output": str(output)[:500]}
 
+        # Out of tool rounds — land softly: force one final no-tools answer so
+        # the user gets a summary + "continue?" instead of a dead turn.
+        log.warning("Deepdive thread %s hit %d tool rounds; forcing final answer", thread_id, rounds_cap)
+        llm_messages.append({"role": "user", "content": FORCED_FINAL_INSTRUCTION})
+        try:
+            final = await _invoke_llm(llm_messages, thread["strategy_id"])
+        except Exception as exc:  # pragma: no cover - defensive
+            final = {"content": "", "error": str(exc)}
+        final_text = (final.get("content") or "").strip()
+        if final_text and not final.get("error"):
+            # Any tool calls in the forced final are deliberately ignored.
+            final_msg = append_message(
+                thread_id,
+                role="assistant",
+                content=final_text,
+                cost_usd=final.get("cost_usd"),
+                model=final.get("model"),
+            )
+            yield {"type": "assistant_token", "content": final_text}
+            yield {"type": "done", "message_id": final_msg["id"]}
+            return
+
         yield {
             "type": "error",
             "code": "max_rounds",
-            "message": f"hit {MAX_TOOL_ROUNDS} round limit",
+            "message": f"hit {rounds_cap} round limit",
         }
     except Exception as exc:
         log.exception("deepdive turn failed")

--- a/frontend/src/lib/settings/manifest.ts
+++ b/frontend/src/lib/settings/manifest.ts
@@ -117,6 +117,7 @@ export const SETTINGS_SUBSECTIONS: SettingsSubsection[] = [
   { id: 'system-remote-engine', area: 'system', label: 'Remote engine', description: 'Offload backtests to a remote engine process.' },
   { id: 'system-throughput', area: 'system', label: 'Throughput', description: 'One preset dial (Trickle / Conserve / Balanced / Max) over agent cadences and the daily develop budget — turn it down to cut AI call volume on rate-limited providers.', advanced: true },
   { id: 'system-resource-tuning', area: 'system', label: 'Resource tuning', description: 'Worker counts, claim limits, drain mode, and other backpressure knobs.', advanced: true },
+  { id: 'system-assistant', area: 'system', label: 'Assistant', description: 'In-app chat assistant limits.' },
   { id: 'system-telemetry', area: 'system', label: 'Health & telemetry', description: 'Health checks, alert thresholds, and regime detection flags.' },
   { id: 'system-db-maintenance', area: 'system', label: 'Database maintenance', description: 'Retention windows for log/result tables and the optional daily VACUUM job.' },
 
@@ -2575,6 +2576,22 @@ export const SETTINGS_MANIFEST: SettingsEntry[] = [
     usedBy: ['forven.gauntlet.engine', 'forven.scheduler'],
     advanced: true,
   },
+  // Assistant
+  {
+    id: 'agents.assistant_max_tool_rounds',
+    label: 'Chat tool rounds',
+    unit: 'rounds',
+    default: 12,
+    type: 'number',
+    area: 'system',
+    subsection: 'system-assistant',
+    backendSection: 'agents',
+    backendPath: 'assistant_max_tool_rounds',
+    description:
+      'Max tool-call rounds per chat turn for the in-app assistant and strategy deep-dives (2-40). Each round is a full model call whose cost grows with the turn, so this is the runaway brake; on hitting it the assistant now wraps up with a summary instead of erroring.',
+    usedBy: ['forven.assistant_session', 'forven.deepdive_session'],
+  },
+
   {
     id: 'bot-operations.pipeline_saturation_threshold',
     label: 'Pipeline saturation threshold',

--- a/tests/test_assistant_session.py
+++ b/tests/test_assistant_session.py
@@ -215,6 +215,79 @@ def test_cost_cap_blocks_turn(forven_db, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Round limit: wrap-up nudge, then a forced no-tools final answer (soft
+# landing) instead of the old dead-turn max_rounds error
+# ---------------------------------------------------------------------------
+
+def test_round_limit_soft_landing(forven_db, monkeypatch):
+    thread = adb.create_or_get_active_thread("global", None)
+    seen = {"nudged": False, "forced_final": False}
+
+    async def fake_stream(llm_messages, system, tools):
+        forced = any(
+            "do not call any more tools" in str(m.get("content", "")).lower()
+            for m in llm_messages
+            if m.get("role") == "user"
+        )
+        if forced:
+            seen["forced_final"] = True
+            yield ("text", "Out of rounds — created S00042 so far. Continue?")
+            yield ("final", {
+                "content": "Out of rounds — created S00042 so far. Continue?",
+                # A stubborn model that STILL tries to call a tool — the soft
+                # landing must ignore it and end the turn.
+                "tool_calls": [{"id": "tx", "name": "assistant_run_backtest", "input": {}}],
+                "cost_usd": 0.0, "model": "test/model",
+            })
+            return
+        if any(
+            "start wrapping up" in str(m.get("content", "")).lower()
+            for m in llm_messages
+            if m.get("role") == "user"
+        ):
+            seen["nudged"] = True
+        # Never stops calling tools on its own — only the cap ends the turn.
+        yield ("final", {
+            "content": "working...",
+            "tool_calls": [{"id": "t1", "name": "assistant_run_backtest", "input": {"strategy_id": "S00042"}}],
+            "cost_usd": 0.0, "model": "test/model",
+        })
+
+    async def fake_execute(name, tool_input):
+        return '{"ok": true}'
+
+    monkeypatch.setattr(asess, "_invoke_llm_stream", fake_stream)
+    monkeypatch.setattr(asess, "execute_tool", fake_execute)
+    monkeypatch.setattr(asess, "max_tool_rounds", lambda: 3)
+
+    events = _collect(thread["id"], user_text="do a big multi-step job")
+    types = [e["type"] for e in events]
+
+    assert "error" not in types, f"soft landing must not error: {events[-1]}"
+    assert types[-1] == "done"
+    assert seen["nudged"], "wrap-up nudge should fire before the last round"
+    assert seen["forced_final"], "final answer must be forced after the cap"
+    msgs = adb.list_messages(thread["id"])
+    assert msgs[-1]["role"] == "assistant"
+    assert "Continue?" in msgs[-1]["content"]
+
+
+def test_max_tool_rounds_setting_bounds(forven_db, monkeypatch):
+    from forven.deepdive_session import max_tool_rounds
+
+    import forven.api_core as core
+
+    monkeypatch.setattr(core, "get_settings", lambda: {"assistant_max_tool_rounds": 999})
+    assert max_tool_rounds() == 40  # upper bound
+    monkeypatch.setattr(core, "get_settings", lambda: {"assistant_max_tool_rounds": 0})
+    assert max_tool_rounds() == 12  # falsy -> default
+    monkeypatch.setattr(core, "get_settings", lambda: {"assistant_max_tool_rounds": 1})
+    assert max_tool_rounds() == 2  # lower bound
+    monkeypatch.setattr(core, "get_settings", lambda: {"assistant_max_tool_rounds": 18})
+    assert max_tool_rounds() == 18
+
+
+# ---------------------------------------------------------------------------
 # Page-awareness: the structured page context lands in the system prompt
 # ---------------------------------------------------------------------------
 

--- a/tests/test_deepdive_session.py
+++ b/tests/test_deepdive_session.py
@@ -50,6 +50,56 @@ def test_run_turn_persists_user_and_assistant(thread, monkeypatch):
     assert any(e["type"] == "assistant_token" for e in events)
 
 
+def test_round_limit_soft_landing(thread, monkeypatch):
+    from forven import deepdive_session
+
+    seen = {"forced": False}
+
+    async def fake_invoke(messages, strategy_id):
+        wrap_requested = any(
+            "do not call any more tools" in str(m.get("content", "")).lower()
+            for m in messages
+            if m.get("role") == "user"
+        )
+        if wrap_requested:
+            seen["forced"] = True
+            return {
+                "content": "Out of rounds — summary here. Continue?",
+                # A stubborn tool call in the forced final must be ignored.
+                "tool_calls": [{"id": "tx", "name": "deepdive_read_code", "input": {}}],
+                "cost_usd": 0.0,
+                "model": "stub",
+            }
+        # Never stops calling tools on its own — only the cap ends the turn.
+        return {
+            "content": "working...",
+            "tool_calls": [{"id": "t1", "name": "deepdive_read_code", "input": {}}],
+            "cost_usd": 0.0,
+            "model": "stub",
+        }
+
+    async def fake_dispatch(name, tool_input):
+        return "ok"
+
+    monkeypatch.setattr(deepdive_session, "_invoke_llm", fake_invoke)
+    monkeypatch.setattr(deepdive_session, "_dispatch_tool", fake_dispatch)
+    monkeypatch.setattr(deepdive_session, "max_tool_rounds", lambda: 3)
+
+    events = []
+    async def collect():
+        async for ev in deepdive_session.run_turn(thread["id"], user_text="big job"):
+            events.append(ev)
+    asyncio.run(collect())
+
+    types = [e["type"] for e in events]
+    assert "error" not in types, f"soft landing must not error: {events[-1]}"
+    assert types[-1] == "done"
+    assert seen["forced"]
+    msgs = list_messages(thread["id"])
+    assert msgs[-1]["role"] == "assistant"
+    assert "Continue?" in msgs[-1]["content"]
+
+
 def test_unknown_thread_emits_error(forven_db, monkeypatch):
     from forven import deepdive_session
     events = []


### PR DESCRIPTION
## Problem
The in-app assistant (and strategy deepdive) chat dies with `hit 8 round limit` mid-task — the turn's work is orphaned and the user gets a dead error bubble (user report, 2026-07-08).

## Changes
- **Tunable cap**: new Settings > System > **Assistant** > "Chat tool rounds" (`assistant_max_tool_rounds`, default **12**, clamped 2–40 at write *and* read). One knob shared by the assistant chat and deepdive sessions.
- **Soft landing** (pattern ported from `agents/runner.py`):
  - wrap-up nudge injected 2 rounds before the cap ("start wrapping up");
  - on hitting the cap, one forced final answer — summary of what got done + ask-to-continue — persisted as a normal assistant message and streamed to the client;
  - tool calls in the forced final are **ignored** (guaranteed termination; the tool list stays in the request because providers cache it per loop and some reject an empty array);
  - the `max_rounds` error remains only as fallback if the forced final itself fails.

## Why the cap stays modest
Each round re-sends the entire turn (cost grows ~quadratically), and with actions enabled each round can mint real pipeline objects (strategies → gauntlet compute). The thread cost cap only counts chat dollars, so rounds are the only bound on downstream fan-out.

## Tests
- `test_round_limit_soft_landing` (assistant + deepdive): model never stops calling tools on its own, turn still ends in `done` with a persisted summary; stubborn tool call in the forced final is ignored; wrap-up nudge observed.
- `test_max_tool_rounds_setting_bounds`: clamping (999→40, 1→2, 0→default 12, 18→18).
- Full `test_assistant_session.py` + `test_deepdive_session.py`: 17 passed. `npm run check`: 0 errors. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CBHuQy6taZsvWNwsKig2N