### PR TITLE
fix(risk): decouple paper trading from real-capital halts (PAPER-HALT-1)

### DIFF
--- a/forven/exchange/risk.py
+++ b/forven/exchange/risk.py
@@ -1290,6 +1290,8 @@ def can_open(
     position authoritatively (mirroring the backtest's execution profile) and
     want the safety GATES (kill-switch, daily-loss, margin, one-per-asset,
     cooldown) without a size cap. Defaults True to preserve all legacy behavior.
+    (Note: the kill-switch / daily-loss / recovery halts apply to LIVE scope
+    only — paper scope is fully decoupled from them, see Rule 0 / PAPER-HALT-1.)
 
     execution_type selects the scope for the concurrency / one-per-asset /
     portfolio-budget checks:
@@ -1317,10 +1319,21 @@ def can_open(
         if risk_pct is None:
             risk_pct = per_strategy_max
 
-        # Rule 0: Kill-switch and daily loss gate
-        allowed, reason = is_trading_allowed()
-        if not allowed:
-            return False, 0.0, reason
+        # Rule 0: Kill-switch and daily loss gate.
+        # PAPER-HALT-1: paper is a simulation sandbox with no real capital at
+        # stake. Every halt gated by is_trading_allowed() (operator system
+        # pause, startup exchange recovery, drawdown kill-switch, daily-loss
+        # halt) exists to protect REAL capital, so NONE of them may block a
+        # paper open. Halting paper only punches gaps into the very track record
+        # the promotion gates later read, and a FALSE kill-switch trip on a
+        # glitched real-wallet read (see the 2026-06-29 incident) would silently
+        # freeze all paper research. Paper is fully decoupled and runs
+        # regardless; only a dedicated paper-specific pause should ever stop it.
+        _halt_scope = str(execution_type or "").strip().lower()
+        if _halt_scope not in _PAPER_EXECUTION_TYPES:
+            allowed, reason = is_trading_allowed()
+            if not allowed:
+                return False, 0.0, reason
 
         # Rule 0b: Per-trade risk cap (skipped when the caller sizes
         # authoritatively, e.g. mirroring the backtest — enforce_risk_caps=False).

--- a/forven/scanner.py
+++ b/forven/scanner.py
@@ -7021,11 +7021,17 @@ def manage_positions_via_kernel(strat_id: str, strat: dict, *, account_equity=No
                     out.append(f"BLOCKED {asset} {label} open — stale candle data (feed may be down)")
                     continue
                 if not is_live:
-                    # RISK-1: honor operator STOP / kill-switch / daily-loss-halt /
-                    # cooldown on the now-default kernel paper open path (the legacy
-                    # paper path gates via can_open; this one did not). Backfill opens
-                    # (historical completed trades) go straight to the applier, NOT
-                    # through this branch, so the recorded paper history stays faithful.
+                    # RISK-1: honor the paper-scope safety gates (per-strategy
+                    # concurrency, one-per-asset, cooldown) on the now-default
+                    # kernel paper open path (the legacy paper path gates via
+                    # can_open; this one did not). Backfill opens (historical
+                    # completed trades) go straight to the applier, NOT through
+                    # this branch, so the recorded paper history stays faithful.
+                    # NOTE (PAPER-HALT-1): can_open deliberately does NOT apply
+                    # the real-capital halts (kill-switch / daily-loss / recovery
+                    # / operator pause) to paper scope — paper is fully decoupled
+                    # and keeps trading through a halt so its track record has no
+                    # drawdown-induced gaps.
                     try:
                         from forven.exchange.risk import can_open as _can_open_gate
                         _g_ok, _g_alloc, _g_why = _can_open_gate(

--- a/tests/test_risk_module.py
+++ b/tests/test_risk_module.py
@@ -185,6 +185,26 @@ class TestKillSwitch:
         assert allowed is False
         assert "Kill-switch" in reason
 
+    def test_kill_switch_does_not_block_paper_opens(self, forven_db):
+        # PAPER-HALT-1: the real-capital kill-switch must NOT gate paper opens.
+        # Paper is a simulation sandbox — halting it only punches gaps into the
+        # track record the promotion gates read, and a FALSE trip on a glitched
+        # real-wallet read would freeze all paper research. Live is still blocked.
+        update_equity(10000.0)
+        update_equity(8900.0)  # trips the kill-switch
+        assert is_trading_allowed()[0] is False  # gate is genuinely active
+
+        live_ok, _, live_why = can_open(
+            "BTC", "long", "S-LIVE", execution_type="live", enforce_risk_caps=False,
+        )
+        assert live_ok is False and "Kill-switch" in live_why
+
+        for scope in ("paper", "paper_challenger", "simulation"):
+            paper_ok, _, paper_why = can_open(
+                "BTC", "long", "S-PAPER", execution_type=scope, enforce_risk_caps=False,
+            )
+            assert paper_ok is True, f"{scope} was wrongly blocked: {paper_why}"
+
     def test_kill_switch_reset(self, forven_db):
         update_equity(10000.0)
         update_equity(8900.0)  # triggers kill switch (11% drawdown)


### PR DESCRIPTION
## Problem
Paper opens funnel through `can_open(execution_type="paper")`, whose **Rule 0** called `is_trading_allowed()` unconditionally — so a tripped drawdown kill-switch (including **false glitch-trips**, cf. the 2026-06-29 incident) blocked **new paper opens** with *"Kill-switch active — all trading halted."* That punches gaps into the paper track record exactly during drawdowns, biasing the very evidence the promotion gates read.

## Fix
`can_open` Rule 0 now **skips the halt gate entirely for paper scope** (`paper` / `paper_challenger` / `simulation`). Paper is a simulation sandbox with no real capital to protect, so **no halt — automated (kill-switch / daily-loss / startup recovery) or manual operator STOP — blocks a paper open**. Live scope still blocks on all halts.

Already-correct behavior confirmed (paper can't *cause* or be flattened by a halt):
- Paper P&L never feeds the kill-switch — equity reads real wallet balances only.
- `close_all_positions` is `execution_type='live'`-only, so a halt can't close paper positions.

Also corrects the now-stale RISK-1 comment in the kernel paper open path.

## Test
`test_risk_module.py::test_kill_switch_does_not_block_paper_opens` — live blocked, all 3 paper scopes allowed. Related suites green (risk module, kill-switch integrity, direction-books, retry-brake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CBHuQy6taZsvWNwsKig2N