### PR TITLE
fix(strategies): stop archiving long-only strategies over trade_mode='both' (TRADE-MODE-3/4)

### DIFF
--- a/forven/db.py
+++ b/forven/db.py
@@ -4876,6 +4876,50 @@ def create_strategy_container(
                 params["trade_mode"] = "both" if "both" in modes else sorted(modes)[0]
         except Exception:
             pass
+    elif str(params.get("trade_mode") or "").strip().lower() == "both":
+        # TRADE-MODE-4 (2026-07-08): the inverse of TRADE-MODE-1. When params
+        # carry trade_mode='both' that the archetype CANNOT run — a long-only
+        # built-in (macd, williams_r, ...) stamped with 'both' by a CRUX-1
+        # short/both authoring directive it can't honor — clamp to the runnable
+        # long side at MINT. Left as-is, the deterministic crucible/validation
+        # backtest hard-fails "does not support trade_mode='both'", which the
+        # pipeline classifies terminal (_DETERMINISTIC_ERROR_TOKENS) and ARCHIVES
+        # the whole strategy over a config technicality (the 2026-07-08 alert
+        # wave). Clamping here makes the stored config internally consistent and
+        # mirrors the backtest-time clamp (resolve_backtest_trade_mode
+        # TRADE-MODE-3) at the source. A dual-side class that genuinely declares
+        # 'both' supports it and is untouched; short_only is left as-is (a
+        # long-only archetype has no faithful short interpretation — a clean
+        # failure beats a silent long-for-short swap). Best-effort and only for
+        # archetypes we can POSITIVELY introspect (registry hit + probe); any
+        # introspection failure leaves params for the backtest-time clamp.
+        try:
+            from forven.strategies.registry import _TYPE_MAP, discover
+
+            discover()
+            cls = _TYPE_MAP.get(str(type_ or "").strip())
+            if cls is not None:
+                from forven.strategies.backtest import (
+                    get_strategy_supported_trade_modes,
+                )
+
+                try:
+                    probe = cls("__trade_mode_probe__", dict(params))
+                except Exception:
+                    probe = None
+                supported = get_strategy_supported_trade_modes(
+                    strategy_type=type_, params=params, strategy_obj=probe,
+                )
+                if "both" not in supported:
+                    params["trade_mode"] = "long_only"
+                    log.warning(
+                        "create_strategy_container: archetype %r does not support "
+                        "trade_mode='both' — clamped to long_only at mint "
+                        "(TRADE-MODE-4)",
+                        type_,
+                    )
+        except Exception:
+            pass
     # RISK-PARITY-1: lift unit-unambiguous top-level risk params (time_stop_bars)
     # into the honored execution_profile channel at mint, so the engine actually
     # enforces them in backtest/paper/live instead of leaving them silently inert

--- a/forven/strategies/backtest.py
+++ b/forven/strategies/backtest.py
@@ -1002,6 +1002,22 @@ def resolve_backtest_trade_mode(
     if resolved == "both" and "both" not in supported:
         if explicit_mode is None and allow_shorting and "short_only" in supported:
             resolved = "short_only"
+        elif explicit_mode is None:
+            # TRADE-MODE-3: the 'both' was NOT an explicit caller override — it
+            # came from the strategy's OWN params/default on a class that can't
+            # run both. The real case: a long-only built-in archetype (macd,
+            # williams_r, ...) that had trade_mode='both' stamped into its params
+            # by a CRUX-1 short/both authoring directive it couldn't actually
+            # honor. That is an internally-inconsistent config, not a deliberate
+            # request. Hard-failing it makes the deterministic crucible /
+            # validation backtest error, which the pipeline classifies terminal
+            # (_DETERMINISTIC_ERROR_TOKENS) and ARCHIVES the strategy over a
+            # config technicality (the 2026-07-08 alert wave). 'both' subsumes
+            # the long side, so clamp to a runnable side and evaluate the
+            # strategy ON MERIT instead. long_only is always supported; a
+            # short-capable-only class falls back to short_only. The strict guard
+            # is UNCHANGED for an explicit override (explicit_mode is not None).
+            resolved = "long_only" if "long_only" in supported else "short_only"
         else:
             return resolved, (
                 f"Strategy '{strategy_type or getattr(strategy_obj, 'strategy_type', '<unknown>')}' "

--- a/tests/test_backtest_trade_modes.py
+++ b/tests/test_backtest_trade_modes.py
@@ -370,3 +370,19 @@ def test_request_override_on_undeclared_class_still_rejected():
     )
     assert err is not None
     assert "does not support trade_mode='both'" in err
+
+
+def test_param_derived_both_on_long_only_clamps_instead_of_erroring():
+    # TRADE-MODE-3: when 'both' is NOT an explicit override but comes from the
+    # strategy's own params (requested_trade_mode=None) on a long-only archetype
+    # that can't run it — the crucible/validation path for a macd/williams_r with
+    # trade_mode='both' stamped in — clamp to the runnable long side and evaluate
+    # on merit, rather than erroring (which archived the strategy). Contrast with
+    # test_request_override_on_undeclared_class_still_rejected: an EXPLICIT 'both'
+    # override on the same class still errors.
+    obj = _UndeclaredLongOnlyStrategy("s-undeclared", {})
+    mode, err = backtest_mod.resolve_backtest_trade_mode(
+        None, strategy_type="undeclared_long_only_dummy", params={"trade_mode": "both"}, strategy_obj=obj,
+    )
+    assert err is None, err
+    assert mode == "long_only"

--- a/tests/test_crucible_allocator.py
+++ b/tests/test_crucible_allocator.py
@@ -275,3 +275,57 @@ def test_trade_mode_injected_for_short_only_class(monkeypatch):
     params = _json.loads(row["params"])
     assert params["trade_mode"] == "both"
     assert params["lookback"] == 20
+
+
+def test_trade_mode_both_clamped_for_long_only_class(monkeypatch):
+    """TRADE-MODE-4: minting a long-only archetype with trade_mode='both'
+    stamped into params (a misapplied CRUX-1 short/both directive) clamps it to
+    long_only at mint, instead of persisting an un-runnable config the crucible
+    backtest hard-fails and then archives."""
+    import forven.strategies.registry as registry
+    from forven.db import create_strategy_container
+
+    class FakeLong:  # no supported_trade_modes override -> long_only only
+        def __init__(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(registry, "discover", lambda: None)
+    monkeypatch.setattr(registry, "_TYPE_MAP", {"fake_long": FakeLong})
+
+    with get_db() as conn:
+        sid, _, _ = create_strategy_container(
+            conn=conn, name="t", type_="fake_long", symbol="BTC",
+            timeframe="1h", params={"trade_mode": "both", "lookback": 20},
+        )
+        row = conn.execute("SELECT params FROM strategies WHERE id=?", (sid,)).fetchone()
+    import json as _json
+
+    params = _json.loads(row["params"])
+    assert params["trade_mode"] == "long_only"
+    assert params["lookback"] == 20
+
+
+def test_trade_mode_both_preserved_for_dual_side_class(monkeypatch):
+    """TRADE-MODE-4 must NOT clamp a class that genuinely declares 'both'."""
+    import forven.strategies.registry as registry
+    from forven.db import create_strategy_container
+
+    class FakeBoth:
+        supported_trade_modes = {"long_only", "both"}
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(registry, "discover", lambda: None)
+    monkeypatch.setattr(registry, "_TYPE_MAP", {"fake_both": FakeBoth})
+
+    with get_db() as conn:
+        sid, _, _ = create_strategy_container(
+            conn=conn, name="t", type_="fake_both", symbol="BTC",
+            timeframe="1h", params={"trade_mode": "both", "lookback": 20},
+        )
+        row = conn.execute("SELECT params FROM strategies WHERE id=?", (sid,)).fetchone()
+    import json as _json
+
+    params = _json.loads(row["params"])
+    assert params["trade_mode"] == "both"


### PR DESCRIPTION
## Problem
A CRUX-1 short/both authoring directive got misapplied to **long-only built-in archetypes**: strategies of type `macd` / `williams_r` had `trade_mode='both'` baked into their stored params, but those archetypes only implement long logic (`supported_trade_modes` defaults to `{long_only}`). The deterministic crucible/validation backtest hard-failed *"does not support trade_mode='both'"*, which the pipeline classifies terminal (`_DETERMINISTIC_ERROR_TOKENS`) and **archives the whole strategy** over a config technicality (the 2026-07-08 alert wave).

## Fix — defense-in-depth, two layers
- **TRADE-MODE-3** (`backtest.py` `resolve_backtest_trade_mode`): when `both` is unsupported **and** it came from the strategy's own params (not an explicit caller override), clamp to the runnable long side and evaluate **on merit** instead of erroring. The strict guard is **unchanged** for an explicit override request.
- **TRADE-MODE-4** (`db.py` `create_strategy_container`, the single mint chokepoint and home to TRADE-MODE-1's inverse): clamp `trade_mode='both'` → `long_only` **at mint** when the archetype can't run both, so new strategies store a consistent config and never reach the failure. Introspects via probe + `get_strategy_supported_trade_modes` (parity with the resolver); only acts on registry-hit archetypes, so custom/dual-side classes that genuinely declare `both` are untouched.

`short_only`-on-long-only is left strict at both layers (no faithful clamp — running longs would contradict short intent).

## Tests
- `test_backtest_trade_modes.py::test_param_derived_both_on_long_only_clamps_instead_of_erroring`
- `test_crucible_allocator.py::{test_trade_mode_both_clamped_for_long_only_class, test_trade_mode_both_preserved_for_dual_side_class}`

Verified live: `macd`/`williams_r` param-`both` → `long_only`/no-error; `macd` explicit `both` → still errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CBHuQy6taZsvWNwsKig2N