### PR TITLE
External-review triage: mode split-brain, TYPE_NAME validation, honest e2e, alert drawer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,8 +158,24 @@ jobs:
       - name: Run Svelte checks
         run: npm run check
 
+      # The e2e smoke suite boots the REAL backend (python -m forven.api,
+      # isolated FORVEN_HOME, control-plane only) behind the vite dev proxy —
+      # see frontend/playwright.config.ts — so this job needs Python too.
+      - name: Set up Python for e2e backend
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: requirements-ci.txt
+
+      - name: Install backend dependencies for e2e
+        working-directory: .
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-ci.txt
+
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium
 
-      - name: Run frontend smoke test
+      - name: Run e2e smoke tests
         run: npm run test:e2e

--- a/forven/api.py
+++ b/forven/api.py
@@ -421,8 +421,18 @@ async def lifespan(_app: FastAPI):
     # Run critical background loops from the API process as a fallback when the
     # Discord bot runtime is unavailable. A file lock ensures only one API
     # process owns these loops.
+    # FORVEN_API_CONTROL_PLANE_ONLY=1 skips ALL in-process runtime workers
+    # (scheduler, agent/brain loops, data/risk daemon) so the API boots as a
+    # pure control plane — used by the Playwright e2e harness to get a
+    # deterministic, network-quiet backend. Never set this on a real install:
+    # without a separate `forven daemon start` nothing trades or ticks.
     try:
-        if acquire_runtime_worker_lock():
+        if _env_bool("FORVEN_API_CONTROL_PLANE_ONLY", False):
+            log.info(
+                "FORVEN_API_CONTROL_PLANE_ONLY=1: skipping in-process runtime "
+                "workers (scheduler/agent/brain/daemon loops)"
+            )
+        elif acquire_runtime_worker_lock():
             _api_runtime_lock_held = True
             from forven.scheduler import reset_scheduler_job_locks, run_scheduler_loop
 

--- a/forven/api_core.py
+++ b/forven/api_core.py
@@ -2528,17 +2528,25 @@ def _apply_settings_section(section: str, payload: dict) -> dict:
             if requested == "live" and is_beta_build():
                 log.warning("refusing trading_mode=live in beta build; coercing to paper")
                 requested = "paper"
-            updates["trading_mode"] = requested
             # CFG-1: the visible 'Trading mode' select must actually arm/disarm the
             # engine. The execution path reads config.get_execution_mode()
             # (config.json execution_mode), NOT this KV key, so without this the
             # control was a no-op and the dashboard could misreport live vs paper.
-            # Keep them in sync; wrapped so a beta-build refusal can't 500 the save.
+            # MODE-SPLIT-1: enforcement is the gatekeeper — persist this KV
+            # mirror only AFTER set_execution_mode accepts. Previously a
+            # refused 'live' was stored anyway, so Settings displayed live
+            # while the runtime stayed paper. A refusal is a loud 400 the
+            # save bar surfaces, never a silently-divergent stored value.
             try:
                 from forven.config import set_execution_mode
                 set_execution_mode(requested)
             except Exception as exc:
-                log.warning("could not sync execution_mode to trading_mode=%s: %s", requested, exc)
+                log.warning("refusing to persist trading_mode=%s: %s", requested, exc)
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"trading_mode '{requested}' was not applied: {exc}",
+                ) from exc
+            updates["trading_mode"] = requested
 
     elif section == "initial-capital":
         if "initial_capital" in payload:

--- a/forven/strategies/registry.py
+++ b/forven/strategies/registry.py
@@ -5,6 +5,7 @@ import inspect
 import json
 import logging
 import pkgutil
+import re
 import threading
 import time
 from collections.abc import Mapping
@@ -88,6 +89,32 @@ class RegistryTypeError(Exception):
     """
 
 
+# Every registered runtime type must be identifier-shaped. All 76 builtin
+# TYPE_NAMEs are lowercase snake_case and imported modules register as
+# ``imported__<module>``, so this rejects only genuine garbage — the observed
+# failure was a codegen'd TYPE_NAME declared as a @property, whose class-level
+# getattr yields the property OBJECT and str() turns it into
+# "<property object at 0x...>", which then rendered verbatim in the Strategy
+# Creator catalog.
+_TYPE_NAME_PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,63}")
+
+
+def _type_name_validation_error(strategy_type: object) -> str | None:
+    """One-line diagnostic if the type name is unusable, else None."""
+    if not isinstance(strategy_type, str):
+        return (
+            f"TYPE_NAME must be a plain string, got {type(strategy_type).__name__} "
+            f"{strategy_type!r} (a TYPE_NAME declared as a @property resolves to the "
+            "property object itself — declare it as a class attribute string)"
+        )
+    if not _TYPE_NAME_PATTERN.fullmatch(strategy_type):
+        return (
+            f"TYPE_NAME {strategy_type!r} is not a valid identifier "
+            "(letters, digits and underscores only, max 64 chars)"
+        )
+    return None
+
+
 def register_type(strategy_type: str, cls: type[BaseStrategy], *, raise_on_skip: bool = False):
     """Register a strategy class for a given type string.
 
@@ -97,6 +124,9 @@ def register_type(strategy_type: str, cls: type[BaseStrategy], *, raise_on_skip:
     rather than re-warned on every discover.
     """
     errors = _registry_type_validation_errors(cls)
+    name_error = _type_name_validation_error(strategy_type)
+    if name_error:
+        errors = [name_error, *errors]
     if errors:
         if raise_on_skip:
             raise RegistryTypeError(
@@ -536,8 +566,10 @@ def _register_module_type_tolerant(module, *, raise_on_skip: bool = False) -> No
     type_name = getattr(module, "TYPE_NAME", None)
 
     # Explicit, well-formed declaration → preserve existing behavior exactly.
+    # Passed raw (no str() coercion) so a non-string TYPE_NAME gets the precise
+    # register_type diagnostic instead of being smuggled in as its repr.
     if isinstance(cls, type) and type_name:
-        register_type(str(type_name), cls, raise_on_skip=raise_on_skip)
+        register_type(type_name, cls, raise_on_skip=raise_on_skip)
         return
 
     # Tolerant fallback (gap-fill only). Resolve the class first.
@@ -557,9 +589,10 @@ def _register_module_type_tolerant(module, *, raise_on_skip: bool = False) -> No
         type_name = getattr(cls, "TYPE_NAME", None)
     if not type_name:
         return
-    type_name = str(type_name)
-    if type_name in _TYPE_MAP:
+    if isinstance(type_name, str) and type_name in _TYPE_MAP:
         # Never override an already-registered type from the tolerant path.
+        # (Non-strings can never be registered, so they skip straight to the
+        # register_type name validation for a precise diagnostic.)
         return
     register_type(type_name, cls, raise_on_skip=raise_on_skip)
 

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from 'playwright/test';
+
+// These run against a REAL `forven.api` boot (isolated FORVEN_HOME temp dir,
+// control-plane only) plus the real SvelteKit frontend — see playwright.config.ts.
+// They are the release smoke: app boots, the canonical execution status is
+// paper, and a live-mode request fails closed end to end.
+
+const api = 'http://127.0.0.1:8017';
+
+test.describe('startup and canonical execution status', () => {
+	test('backend health endpoint responds', async ({ request }) => {
+		const res = await request.get(`${api}/health`);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+		// Control-plane-only boots report "degraded" (no scheduler heartbeat by
+		// design); anything else present here means the process didn't come up.
+		expect(['ok', 'healthy', 'degraded']).toContain(String(body.status));
+	});
+
+	test('a fresh install starts in paper mode', async ({ request }) => {
+		const res = await request.get(`${api}/api/settings`);
+		expect(res.ok()).toBeTruthy();
+		const settings = await res.json();
+		expect(settings.trading_mode).toBe('paper');
+	});
+
+	test('the app shell renders with the risk disclaimer', async ({ page }) => {
+		await page.goto('/');
+		// A fresh browser context has never acknowledged the disclaimer, so the
+		// banner must be visible — its absence on first load means either the
+		// shell failed to render or the paper-only disclaimer regressed.
+		await expect(page.getByText('Paper + testnet only.')).toBeVisible({ timeout: 15_000 });
+	});
+});
+
+test.describe('mode mismatch fails closed', () => {
+	test('a live-mode request is rejected and never persisted (MODE-SPLIT-1)', async ({ request }) => {
+		const put = await request.put(`${api}/api/settings/trading-mode`, {
+			data: { trading_mode: 'live' },
+		});
+		expect(put.status()).toBe(400);
+		const body = await put.json();
+		expect(String(body.detail)).toContain("'live'");
+
+		// The rejected mode must not leak into the stored settings — this is the
+		// split-brain regression (Settings said live while the runtime was paper).
+		const settings = await (await request.get(`${api}/api/settings`)).json();
+		expect(settings.trading_mode).toBe('paper');
+	});
+
+	test('a paper-mode request round-trips', async ({ request }) => {
+		const put = await request.put(`${api}/api/settings/trading-mode`, {
+			data: { trading_mode: 'paper' },
+		});
+		expect(put.ok()).toBeTruthy();
+		const settings = await (await request.get(`${api}/api/settings`)).json();
+		expect(settings.trading_mode).toBe('paper');
+	});
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"test": "vitest run",
 		"test:watch": "vitest",
-		"test:e2e": "playwright test --pass-with-no-tests"
+		"test:e2e": "playwright test"
 	},
 	"dependencies": {
 		"dompurify": "^3.4.9",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,6 +1,19 @@
 import { defineConfig } from 'playwright/test';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 const baseURL = 'http://127.0.0.1:4173';
+
+// The e2e backend is a REAL `forven.api` boot — same process CI ships — but:
+// - on its own port so it never collides with a dev instance on 8003,
+// - with FORVEN_HOME pointed at a throwaway temp dir so it can never read or
+//   write a real install's DB/config,
+// - control-plane only (no scheduler/agent/brain/daemon loops) so runs are
+//   deterministic and network-quiet.
+const backendPort = 8017;
+const backendOrigin = `http://127.0.0.1:${backendPort}`;
+const e2eHome = mkdtempSync(join(tmpdir(), 'forven-e2e-home-'));
 
 export default defineConfig({
 	testDir: './e2e',
@@ -19,10 +32,27 @@ export default defineConfig({
 			},
 		},
 	],
-	webServer: {
-		command: 'npm run dev -- --host 127.0.0.1 --port 4173',
-		url: `${baseURL}/`,
-		reuseExistingServer: !process.env.CI,
-		timeout: 120_000,
-	},
+	webServer: [
+		{
+			command: 'python -m forven.api',
+			cwd: '..',
+			url: `${backendOrigin}/health`,
+			reuseExistingServer: false,
+			timeout: 180_000,
+			env: {
+				FORVEN_PORT: String(backendPort),
+				FORVEN_HOME: e2eHome,
+				FORVEN_API_CONTROL_PLANE_ONLY: '1',
+			},
+		},
+		{
+			command: 'npm run dev -- --host 127.0.0.1 --port 4173',
+			url: `${baseURL}/`,
+			reuseExistingServer: !process.env.CI,
+			timeout: 120_000,
+			env: {
+				FORVEN_API_ORIGIN: backendOrigin,
+			},
+		},
+	],
 });

--- a/frontend/src/lib/components/PositionAlertWidget.svelte
+++ b/frontend/src/lib/components/PositionAlertWidget.svelte
@@ -19,6 +19,14 @@
 
 	let positionAlerts: PositionAlert[] = [];
 
+	// With many open positions the per-position cards stacked indefinitely and
+	// buried the Risk/Data panels under alerts. Show ONE card; the rest
+	// collapse behind an "N more positions open" bar until expanded.
+	let stackExpanded = false;
+	$: visibleAlerts = stackExpanded ? positionAlerts : positionAlerts.slice(0, 1);
+	$: hiddenCount = positionAlerts.length - visibleAlerts.length;
+	$: if (positionAlerts.length <= 1) stackExpanded = false;
+
 	let dismissedPositionTokens = new Set<string>();
 	let positionAlertPoller: RealtimeRefreshController | null = null;
 	let positionAlertInFlight = false;
@@ -185,7 +193,7 @@
 </script>
 
 {#if $snoozeUntil <= Date.now()}
-	{#each positionAlerts as alert (alert.token)}
+	{#each visibleAlerts as alert (alert.token)}
 		<div
 			class="pointer-events-auto bg-[#050505] border border-emerald-900 px-4 py-3 min-w-[280px] max-w-sm"
 			transition:fly={{ x: 300, duration: 250 }}
@@ -258,4 +266,30 @@
 			</a>
 		</div>
 	{/each}
+	{#if hiddenCount > 0 || stackExpanded}
+		<button
+			class="pointer-events-auto bg-[#050505] border border-emerald-900 px-4 py-2 min-w-[280px] max-w-sm text-[10px] uppercase tracking-wider text-emerald-400 font-bold text-left hover:bg-[#111] transition-colors flex items-center justify-between gap-2"
+			transition:fly={{ x: 300, duration: 250 }}
+			on:click={() => (stackExpanded = !stackExpanded)}
+		>
+			<span>
+				{#if stackExpanded}
+					Collapse — {positionAlerts.length} positions open
+				{:else}
+					{hiddenCount} more {hiddenCount === 1 ? 'position' : 'positions'} open
+				{/if}
+			</span>
+			<svg
+				class="w-3 h-3 shrink-0 transition-transform {stackExpanded ? '' : 'rotate-180'}"
+				viewBox="0 0 20 20"
+				fill="currentColor"
+			>
+				<path
+					fill-rule="evenodd"
+					d="M5.23 12.21a.75.75 0 001.06.02L10 8.832l3.71 3.398a.75.75 0 101.02-1.1l-4.22-3.865a.75.75 0 00-1.02 0L5.25 11.13a.75.75 0 00-.02 1.08z"
+					clip-rule="evenodd"
+				/>
+			</svg>
+		</button>
+	{/if}
 {/if}

--- a/tests/test_agent_backtesting_tools.py
+++ b/tests/test_agent_backtesting_tools.py
@@ -84,14 +84,21 @@ def test_agent_run_backtest_persists_result_and_syncs_strategy(forven_db, monkey
         return {
             "start_date": "2025-01-01T00:00:00+00:00",
             "end_date": "2026-01-01T00:00:00+00:00",
-                "metrics": {
-                    "total_trades": 120,
-                    "win_rate": 0.57,
-                    "sharpe": 1.8,
-                    "profit_factor": 1.9,
-                    "max_drawdown_pct": 0.08,
-                    "total_return_pct": 14.0,
+            "metrics": {
+                "total_trades": 120,
+                "win_rate": 0.57,
+                "sharpe": 1.8,
+                "profit_factor": 1.9,
+                "max_drawdown_pct": 0.08,
+                "total_return_pct": 14.0,
                 "robustness_score": 82,
+                # Real backtest_strategy output ALWAYS carries IS/OOS blocks;
+                # the degeneracy-aware best-of rule in
+                # _sync_strategy_metrics_and_promote_if_eligible reads
+                # in_sample.total_trades and treats a missing block as a
+                # zero-IS-trades degenerate slice (which never promotes).
+                "in_sample": {"total_trades": 80, "sharpe": 1.6, "profit_factor": 1.8, "win_rate": 0.56},
+                "out_of_sample": {"total_trades": 40, "sharpe": 1.8, "profit_factor": 1.9, "win_rate": 0.57},
             },
             "trades": [],
         }

--- a/tests/test_registry_type_name_validation.py
+++ b/tests/test_registry_type_name_validation.py
@@ -1,0 +1,103 @@
+"""2026-07-10 — registered runtime type names must be identifier-shaped strings.
+
+Observed failure: a codegen'd strategy declared TYPE_NAME as a @property, so the
+class-level getattr in the tolerant registration path yielded the property OBJECT
+and str() smuggled it into the catalog as "<property object at 0x...>", which the
+Strategy Creator then rendered verbatim. register_type now validates the name and
+quarantines the module with a precise diagnostic instead.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from forven.strategies import base as base_mod
+from forven.strategies import custom as custom_pkg
+from forven.strategies import registry
+
+
+def _point_custom_dir(monkeypatch, tmp_path):
+    d = tmp_path / "custom"
+    d.mkdir()
+    monkeypatch.setattr(custom_pkg, "__path__", [str(d)])
+    monkeypatch.setattr(custom_pkg, "__file__", str(d / "__init__.py"))
+    return d
+
+
+# Complete contract, but TYPE_NAME declared as a @property — the exact codegen
+# slip that produced "<property object at ...>" catalog entries.
+_PROPERTY_TYPE_NAME = (
+    "from forven.strategies.base import BaseStrategy, Signal\n"
+    "import pandas as pd\n"
+    "class PropStrat(BaseStrategy):\n"
+    "    @property\n"
+    "    def TYPE_NAME(self): return 'prop_type_name'\n"
+    "    def name(self): return 'prop'\n"
+    "    def asset(self): return 'BTC/USDT'\n"
+    "    def strategy_type(self): return 'prop_type_name'\n"
+    "    def default_params(self): return {}\n"
+    "    def generate_signal(self, df):\n"
+    "        return Signal(direction='none', entry_signal=False, exit_signal=False)\n"
+    "STRATEGY_CLASS = PropStrat\n"
+)
+
+
+class _GoodCls(base_mod.BaseStrategy):
+    TYPE_NAME = "unit_name_ok"
+
+    def name(self):
+        return "ok"
+
+    def asset(self):
+        return "BTC/USDT"
+
+    def strategy_type(self):
+        return "unit_name_ok"
+
+    def default_params(self):
+        return {}
+
+    def generate_signal(self, df):
+        return base_mod.Signal(direction="none", entry_signal=False, exit_signal=False)
+
+
+def test_property_object_name_is_rejected_with_property_diagnostic():
+    prop = property(lambda self: "x")
+    with pytest.raises(registry.RegistryTypeError) as exc_info:
+        registry.register_type(prop, _GoodCls, raise_on_skip=True)
+    assert "@property" in str(exc_info.value)
+    assert not any(not isinstance(k, str) for k in registry._TYPE_MAP)
+
+
+def test_repr_garbage_string_name_is_rejected(monkeypatch, caplog):
+    monkeypatch.setattr(registry, "_TYPE_MAP", {})
+    with caplog.at_level(logging.WARNING, logger="forven.strategies.registry"):
+        registry.register_type("<property object at 0x1f2e3d4c>", _GoodCls)
+    assert registry._TYPE_MAP == {}
+    assert any("not a valid identifier" in r.message for r in caplog.records)
+
+
+def test_identifier_names_still_register(monkeypatch):
+    monkeypatch.setattr(registry, "_TYPE_MAP", {})
+    registry.register_type("unit_name_ok", _GoodCls)
+    registry.register_type("imported__some_module", _GoodCls)
+    assert "unit_name_ok" in registry._TYPE_MAP
+    assert "imported__some_module" in registry._TYPE_MAP
+
+
+def test_overlong_name_is_rejected(monkeypatch):
+    monkeypatch.setattr(registry, "_TYPE_MAP", {})
+    registry.register_type("a" * 65, _GoodCls)
+    assert registry._TYPE_MAP == {}
+
+
+def test_property_type_name_module_is_quarantined_not_cataloged(monkeypatch, tmp_path, caplog):
+    d = _point_custom_dir(monkeypatch, tmp_path)
+    (d / "prop_tn.py").write_text(_PROPERTY_TYPE_NAME, encoding="utf-8")
+    registry.reset()
+    with caplog.at_level(logging.WARNING, logger="forven.strategies.registry"):
+        registry.discover()
+    # No repr-shaped garbage may reach the catalog the Strategy Creator renders.
+    assert not any(str(k).startswith("<property object") for k in registry._TYPE_MAP)
+    assert "prop_tn" in registry._FAILED_CUSTOM_MODULES

--- a/tests/test_settings_correctness_fixes.py
+++ b/tests/test_settings_correctness_fixes.py
@@ -244,3 +244,36 @@ class TestDataEngineNestedPartialSave:
         # Nested defaults still filled for genuinely-missing keys (source
         # reconciliation now defaults ON — the Binance↔HL divergence safety net).
         assert des["source_reconciliation"]["enabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# MODE-SPLIT-1: a requested trading_mode is persisted only after enforcement
+# (config.set_execution_mode) accepts it. Previously a refused 'live' was
+# stored in the settings blob anyway, so Settings displayed "live" while the
+# runtime stayed paper.
+# ---------------------------------------------------------------------------
+
+
+class TestTradingModePersistAfterAccept:
+    def test_rejected_live_is_a_400_and_never_persisted(self, forven_db):
+        from forven.config import get_execution_mode
+
+        with pytest.raises(HTTPException) as exc_info:
+            put_settings_section("trading-mode", {"trading_mode": "live"})
+        assert exc_info.value.status_code == 400
+        assert "live" in str(exc_info.value.detail)
+        # The stored mirror and the enforced mode both still say paper.
+        assert _load_settings_payload()["trading_mode"] == "paper"
+        assert get_execution_mode() == "paper"
+        assert get_settings()["trading_mode"] == "paper"
+
+    def test_paper_save_round_trips(self, forven_db):
+        result = put_settings_section("trading-mode", {"trading_mode": "paper"})
+        assert result["trading_mode"] == "paper"
+        assert _load_settings_payload()["trading_mode"] == "paper"
+
+    def test_beta_build_coerces_live_to_paper_without_erroring(self, forven_db, monkeypatch):
+        monkeypatch.setenv("FORVEN_ENV", "beta")
+        result = put_settings_section("trading-mode", {"trading_mode": "live"})
+        assert result["trading_mode"] == "paper"
+        assert _load_settings_payload()["trading_mode"] == "paper"


### PR DESCRIPTION
## Summary

Fixes the four actionable findings from the 2026-07-10 external application review.

### MODE-SPLIT-1 — execution-mode "split brain" (`forven/api_core.py`)
The trading-mode settings handler persisted a requested `trading_mode='live'` to the KV blob **before** calling `config.set_execution_mode`, which unconditionally refuses live — and the refusal was swallowed into a warning. Result: Settings displayed **live** while the runtime stayed **paper**. The runtime itself was never at risk (the read path is fail-closed); the display lied.

Now the KV mirror is written only **after** enforcement accepts, and a refusal is a loud 400 that the settings save bar surfaces as an error toast. Beta-build silent coercion to paper is unchanged. Regression tests added.

### TYPE-NAME-1 — garbage strategy type names (`forven/strategies/registry.py`)
A codegen'd strategy declaring `TYPE_NAME` as a `@property` resolved (via class-level `getattr`) to the property **object**, and `str()` smuggled `"<property object at 0x...>"` into the catalog the Strategy Creator renders. `register_type` now validates that the name is an identifier-shaped string (`[A-Za-z_][A-Za-z0-9_]{0,63}`), routed through the existing skip/quarantine flow with a precise diagnostic ("declare it as a class attribute string"). All 76 builtin TYPE_NAMEs and the `imported__<module>` convention pass unchanged. New test file covers the property-object repro end to end through `discover()`.

### E2E-1 — honest e2e suite (`frontend/`, `.github/workflows/ci.yml`)
`test:e2e` ran Playwright with `--pass-with-no-tests` over an **empty** e2e directory — pure theater in CI. Now:
- flag removed; a real smoke suite exists (`frontend/e2e/smoke.spec.ts`)
- the suite boots the **real** backend (`python -m forven.api`) with an isolated throwaway `FORVEN_HOME` and the new `FORVEN_API_CONTROL_PLANE_ONLY=1` switch (skips scheduler/agent/brain/daemon loops for deterministic, network-quiet runs) behind the vite dev proxy on a non-default port (8017) so it can never touch a real install or collide with a dev instance
- scenarios: backend health, fresh-install canonical mode = paper, app shell renders with the risk disclaimer, live-mode request rejected AND never persisted (exercises MODE-SPLIT-1 over real HTTP), paper round-trip
- CI frontend job gains a Python setup step for the e2e backend

Follow-ups (not in this PR): strategy create→backtest→gate, emergency-halt, and restart/recovery e2e scenarios.

### Drifted backend test (`tests/test_agent_backtesting_tools.py`)
`test_agent_run_backtest_persists_result_and_syncs_strategy` failed because its fake backtest result predates the degeneracy-aware best-of rule: real `backtest_strategy` output always carries `in_sample`/`out_of_sample` blocks, and a missing `in_sample` block reads as a zero-IS-trades degenerate slice that never promotes. The fake now mirrors the real contract (with a comment explaining why).

### ALERT-STACK-1 — position-alert pile-up (`PositionAlertWidget.svelte`)
Open-position alerts rendered one card per position with no cap, burying the Risk/Data panels under 8+ cards. Now one card shows and the rest collapse behind an "N more positions open" expand/collapse bar.

## Testing
- Backend: 76 tests across the 8 affected/adjacent files pass (incl. 3 new MODE-SPLIT-1 regressions + 5 new TYPE_NAME tests); ruff clean
- Frontend: 409 unit tests pass; svelte-check 0 errors (2 pre-existing warnings)
- E2E: all 5 smoke tests pass locally against the real backend + real frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CBHuQy6taZsvWNwsKig2N