### PR TITLE
PAPER-HALT-2: halts arm on real-capital equity only — paper strategies can never halt the system

### DIFF
--- a/forven/exchange/risk.py
+++ b/forven/exchange/risk.py
@@ -3566,6 +3566,19 @@ def _get_risk_state() -> dict:
 # be silently dropped.
 _RISK_WRITE_TIMEOUT_SECONDS = 2.0
 
+# PAPER-HALT-2: the kill-switch and daily-loss halt are REAL-CAPITAL protections.
+# Only equity samples read from a real exchange basis may arm them. Paper/sim
+# bases (the credential-less paper fallback, the simulation harness's mock
+# exchange) track drawdown metrics for display but NEVER halt the system —
+# paper strategies run in isolated $10k containers precisely so they can fail,
+# and an aggregate paper drawdown says nothing about real capital at risk.
+# (PAPER-HALT-1 decoupled the other direction: halts don't block paper opens.)
+_REAL_CAPITAL_EQUITY_SOURCES = {"exchange", "books_aggregate", "books_only"}
+
+
+def _is_real_capital_equity_source(source: str | None) -> bool:
+    return str(source or "").strip().lower() in _REAL_CAPITAL_EQUITY_SOURCES
+
 
 def _save_risk_state(state: dict, *, best_effort: bool = False):
     with _RISK_STATE_LOCK:
@@ -3833,7 +3846,11 @@ def _update_equity_locked(account_equity: float, source: str) -> dict:
         _exec_mode = str(_get_execution_mode() or "paper").strip().lower()
     except Exception:
         _exec_mode = "paper"
-    if source == "paper" and prev_source != "paper" and _exec_mode != "paper":
+    if (
+        not _is_real_capital_equity_source(source)
+        and _is_real_capital_equity_source(prev_source)
+        and _exec_mode != "paper"
+    ):
         log.warning(
             "Ignoring transient paper-source equity sample during a live session "
             "(would flap the source basis and re-baseline/clear the kill-switch); risk state unchanged."
@@ -3860,8 +3877,15 @@ def _update_equity_locked(account_equity: float, source: str) -> dict:
     #     live positions. Re-baseline the denominator.
     # The daily-loss HALT is cleared ONLY on the initial paper->live connect; a
     # live<->live basis flip must NOT lift an already-fired halt (RISK-STATE-1).
-    _initial_live_connect = (prev_source == "paper" and source != "paper")
-    _live_basis_changed = (source != prev_source and source != "paper" and prev_source != "paper")
+    _initial_live_connect = (
+        not _is_real_capital_equity_source(prev_source)
+        and _is_real_capital_equity_source(source)
+    )
+    _live_basis_changed = (
+        source != prev_source
+        and _is_real_capital_equity_source(source)
+        and _is_real_capital_equity_source(prev_source)
+    )
     if (_initial_live_connect or _live_basis_changed) and hwm > 0:
         log.info(
             "Equity source basis changed: %s -> %s. Re-baselining HWM ($%.2f -> $%.2f) and daily tracking%s.",
@@ -3960,6 +3984,34 @@ def _update_equity_locked(account_equity: float, source: str) -> dict:
         result["kill_switch"] = True
         # Already-active kill-switch was persisted when it first fired; this is a
         # routine re-save of unchanged state, so best-effort is safe.
+        _save_risk_state(state, best_effort=True)
+        return result
+
+    # PAPER-HALT-2: a non-real-capital basis (paper fallback, sim harness) never
+    # arms the kill-switch or daily-loss halt — those are real-capital
+    # protections, and a paper container failing is the experiment working. Log
+    # the would-have-fired transition once so the operator can still see it.
+    real_capital_basis = _is_real_capital_equity_source(source)
+    if not real_capital_basis:
+        breach = (
+            (drawdown_pct >= max_drawdown)
+            or (daily_pnl_pct <= -daily_loss_limit)
+        )
+        if breach and not state.get("paper_basis_breach_logged"):
+            state["paper_basis_breach_logged"] = True
+            log.info(
+                "paper-basis equity breached a halt threshold (drawdown %.1f%%, "
+                "daily %.1f%%, source=%s) — halts NOT armed (real-capital only)",
+                drawdown_pct * 100, daily_pnl_pct * 100, source,
+            )
+            log_activity("info", "risk", (
+                f"Paper-basis equity crossed a halt threshold (drawdown "
+                f"{drawdown_pct:.1%}, daily {daily_pnl_pct:.1%}, source={source}). "
+                "Kill-switch and daily-loss halts arm on real-capital equity only; "
+                "paper strategies fail in their own containers."
+            ))
+        elif not breach and state.get("paper_basis_breach_logged"):
+            state["paper_basis_breach_logged"] = False
         _save_risk_state(state, best_effort=True)
         return result
 

--- a/forven/sim/mock_exchange.py
+++ b/forven/sim/mock_exchange.py
@@ -140,6 +140,10 @@ def sim_get_account_value() -> dict:
         "totalMarginUsed": 0,
         "totalNtlPos": 0,
         "totalRawUsd": equity,
+        # PAPER-HALT-2: without a label the daemon defaulted this to "exchange",
+        # so SIMULATED losses read as a real-capital basis and could arm the
+        # real kill-switch. "sim" is a non-real basis: metrics only, no halts.
+        "source": "sim",
     }
 
 def sim_get_all_mids() -> dict[str, float]:

--- a/tests/test_paper_no_global_halts.py
+++ b/tests/test_paper_no_global_halts.py
@@ -1,0 +1,109 @@
+"""PAPER-HALT-2: the kill-switch and daily-loss halt are REAL-CAPITAL protections.
+
+Paper strategies each run in an isolated $10k container — failing is the point
+of running them. A non-real equity basis (the credential-less paper fallback,
+the sim harness's mock exchange) must therefore NEVER arm the global halts,
+no matter how deep its drawdown. Real-capital bases (exchange, books_aggregate,
+books_only) keep arming exactly as before.
+
+PAPER-HALT-1 decoupled the other direction (halts don't block paper opens);
+this closes the loop (paper can't trigger halts).
+"""
+
+from __future__ import annotations
+
+from forven.db import kv_get
+from forven.exchange.risk import (
+    _is_real_capital_equity_source,
+    update_equity,
+)
+
+
+def _risk_state() -> dict:
+    from forven.sim.clock import sim_kv_key
+
+    return kv_get(sim_kv_key("risk_state"), {}) or {}
+
+
+def test_source_classification():
+    for real in ("exchange", "books_aggregate", "books_only", "EXCHANGE "):
+        assert _is_real_capital_equity_source(real), real
+    for fake in ("paper", "sim", "", None, "unknown_basis"):
+        assert not _is_real_capital_equity_source(fake), fake
+
+
+def test_paper_basis_drawdown_never_arms_kill_switch(forven_db):
+    update_equity(10_000.0, source="paper")
+    # 50% drawdown — far past any max_drawdown limit.
+    result = update_equity(5_000.0, source="paper")
+    assert result["kill_switch"] is False
+    assert result["action"] is None
+    state = _risk_state()
+    assert not state.get("kill_switch_active")
+    # Metrics still tracked for display.
+    assert state.get("drawdown_pct") > 0.4
+
+
+def test_paper_basis_daily_loss_never_arms_halt(forven_db):
+    update_equity(10_000.0, source="paper")
+    result = update_equity(9_000.0, source="paper")  # -10% day
+    assert result["daily_halt"] is False
+    assert result["action"] is None
+    assert not _risk_state().get("daily_loss_halt")
+
+
+def test_sim_basis_never_arms_kill_switch(forven_db):
+    update_equity(10_000.0, source="sim")
+    result = update_equity(4_000.0, source="sim")
+    assert result["kill_switch"] is False
+    assert not _risk_state().get("kill_switch_active")
+
+
+def test_real_capital_basis_still_arms_kill_switch(forven_db):
+    """The protection must remain fully intact for real capital."""
+    update_equity(10_000.0, source="books_aggregate")
+    result = update_equity(5_000.0, source="books_aggregate")
+    assert result["kill_switch"] is True
+    assert _risk_state().get("kill_switch_active")
+
+
+def test_real_capital_basis_still_arms_daily_halt(forven_db):
+    update_equity(10_000.0, source="exchange")
+    result = update_equity(9_400.0, source="exchange")  # -6% <= default -5% limit
+    assert result["daily_halt"] is True
+    assert _risk_state().get("daily_loss_halt")
+
+
+def test_paper_breach_is_logged_once_not_spammed(forven_db):
+    """The would-have-fired transition surfaces once in the activity feed, then
+    stays quiet while the breach persists (the daemon ticks every ~30s)."""
+    from forven.db import get_db
+
+    update_equity(10_000.0, source="paper")
+    for _ in range(4):
+        update_equity(5_000.0, source="paper")
+    with get_db() as conn:
+        rows = conn.execute(
+            "SELECT COUNT(*) FROM activity_log WHERE message LIKE '%halt threshold%'"
+        ).fetchone()
+    assert rows[0] == 1
+
+
+def test_real_halt_survives_subsequent_paper_samples(forven_db):
+    """An armed real-capital kill-switch is not cleared or re-armed by paper
+    samples arriving afterwards (paper-mode session continuing)."""
+    update_equity(10_000.0, source="books_aggregate")
+    update_equity(5_000.0, source="books_aggregate")
+    assert _risk_state().get("kill_switch_active")
+    result = update_equity(10_000.0, source="paper")
+    # Sample is ignored/state preserved: the real halt stands until manual reset.
+    assert _risk_state().get("kill_switch_active")
+    assert result["kill_switch"] is True
+
+
+def test_sim_mock_exchange_labels_its_source(forven_db):
+    from forven.sim.mock_exchange import sim_get_account_value
+
+    payload = sim_get_account_value()
+    assert payload["source"] == "sim"
+    assert not _is_real_capital_equity_source(payload["source"])


### PR DESCRIPTION
## Summary

Operator request: paper strategies each run in their own \$10k container — failing is *why* we run them — yet paper activity could arm the system-wide kill-switch and daily-loss halt.

Two confirmed paths:
1. **Paper-mode sessions**: `_update_equity_locked` armed `kill_switch_active` / `daily_loss_halt` from `"paper"`-source equity samples (the credential-less fallback basis).
2. **Sim harness**: `sim_get_account_value()` returned no `source` field, the daemon defaulted it to `"exchange"`, and simulated losses read as a **real-capital basis** — arming the real kill-switch and its close-all sweep.

## Change

- Halts are now explicitly real-capital protections: only `exchange` / `books_aggregate` / `books_only` equity bases can arm the kill-switch or daily-loss halt (`_REAL_CAPITAL_EQUITY_SOURCES` + `_is_real_capital_equity_source`).
- Non-real bases (paper, sim) keep updating drawdown/daily metrics for display; a would-have-fired breach logs **once** to the activity feed ("halts arm on real-capital equity only") instead of halting, and the log re-arms when the breach clears.
- The mock exchange labels its equity `source: "sim"`.
- Basis-transition rules (initial live-connect re-baseline + halt clear, live↔live re-anchor, transient-paper-sample-in-live-session reject) generalize from the hardcoded `"paper"` string to the real/non-real classification.
- An armed real-capital halt **survives** subsequent paper samples until manual reset (regression-locked).

Complements PAPER-HALT-1 (halts don't block paper opens — PR #57); this closes the reverse direction. Per-container paper controls (one-position-per-asset, per-session concurrency, kernel sizing parity) are untouched — a blown \$10k container just marks that strategy failed.

## Testing

- New `tests/test_paper_no_global_halts.py` (9 tests): paper/sim drawdown + daily-loss never arm; real-capital bases still arm both; armed halt survives paper samples; breach logged exactly once; sim source labeled.
- Full risk/halt suites pass: `test_risk_drawdown_math`, `test_risk_module`, `test_equity_anchors`, `test_equity_sanity_guard`, `test_book_equity_robust`, `test_kill_switch_close_integrity`, `test_overnight_halt_resilience`, `test_decay_kill_switch_notifications`, `test_risk_reconciliation` (131 tests).
- Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CBHuQy6taZsvWNwsKig2N