### PR TITLE
fix(gates): fire dead win-rate guards (unit mismatch) + re-probe lookahead on lifecycle re-entry

### DIFF
--- a/forven/brain.py
+++ b/forven/brain.py
@@ -203,6 +203,13 @@ def _gauntlet_entry_guardrails(strategy_id: str, metrics: dict) -> tuple[bool, s
         robustness = robustness * 100.0
     if max_drawdown is not None and abs(max_drawdown) <= 1.0:
         max_drawdown = max_drawdown * 100.0
+    # WIN-RATE-UNIT-1: compute_metrics emits win_rate as a 0-1 RATIO, but legacy
+    # blobs may carry it as percent points (79.0). Normalize to percent points so
+    # Guard 6's "> 70%" tail-risk comparison fires for EITHER stored unit; the
+    # ratio form (0.79) would otherwise never exceed 70 and silently pass a
+    # curve-fitted high-win-rate strategy into the gauntlet.
+    if win_rate is not None and abs(win_rate) <= 1.0:
+        win_rate = win_rate * 100.0
 
     # Guard 1: Hard Sanity Check on IS Sharpe. Was a hardcoded 0.3 auto-reject that
     # no Settings knob could relax; now wired to gauntlet.hard_min_is_sharpe
@@ -4048,6 +4055,38 @@ def run_gauntlet_backtest_migration():
     kv_set(flag_key, True)
 
 
+def _reentry_lookahead_reason(strategy_id: str, strategy_type: str, params: dict) -> str | None:
+    """Return a rejection reason if the strategy reads future bars, else None.
+
+    Lifecycle re-entry (research recovery) safety net: the lookahead / data-leak
+    probe runs at registration intake but not on re-entry, so a recovered
+    strategy would otherwise skip the causality check every fresh strategy passes.
+
+    Preserves the PR#60 rejection/inconclusive split established in
+    ``detect_lookahead``: a leak (or a strategy-authoring fault raised inside the
+    strategy's own module) returns a reason string (REJECTION); a probe
+    INFRASTRUCTURE fault returns None (INCONCLUSIVE), so an environmental crash
+    never converts a recoverable strategy into a rejection.
+
+    Fail-OPEN on resolution/instantiation faults: if the class can't be resolved
+    or built here (a probe-side fault, not a strategy fault), return None so
+    recovery is never blocked on this net's own bug — mirrors
+    ``gauntlet.engine._strategy_reproducibly_crashes``.
+    """
+    try:
+        from forven.strategies.backtest import _resolve_strategy_class
+        from forven.strategies.lookahead_probe import detect_lookahead
+
+        cls = _resolve_strategy_class(strategy_type)
+        if cls is None:
+            return None
+        probe = cls(strategy_id, params if isinstance(params, dict) else {})
+        return detect_lookahead(probe)
+    except Exception:  # never block a recovery on a probe-infrastructure fault
+        log.debug("Research recovery lookahead re-probe inconclusive for %s", strategy_id, exc_info=True)
+        return None
+
+
 def try_research_recovery(strategy_id: str) -> dict:
     """Re-certify a research_only strategy and promote to quick_screen if it passes.
 
@@ -4118,7 +4157,36 @@ def try_research_recovery(strategy_id: str) -> dict:
             )
         return {"promoted": False, "reason": block_reason}
 
-    # Certification + data availability passed — promote via transition_stage
+    # LOOKAHEAD-REENTRY-1: the lookahead / data-leak probe runs at registration
+    # intake but NOT on lifecycle re-entry — so a strategy parked to research_only
+    # and later recovered would re-enter quick_screen WITHOUT the causality check
+    # that gates first-time entry. A future-bar leak (e.g. .shift(-1)) makes both
+    # IS and OOS slices amazing, defeating the overfit/win-rate-trap detectors, so
+    # the probe is the primary catch. Re-probe here, at the same choke point that
+    # already re-runs certification + data availability, so recovery cannot smuggle
+    # a leaking strategy past a check every fresh strategy must pass.
+    lookahead_reason = _reentry_lookahead_reason(strategy_id, strategy_type, params)
+    if lookahead_reason:
+        # A leak / strategy-authoring fault is a QUARANTINE reason, not a
+        # repeated-failure archive count — park with a tier-classified reason,
+        # mirroring the certification-failure branch above. Probe INFRASTRUCTURE
+        # faults never reach here: detect_lookahead returns None for them, so an
+        # environmental probe crash stays inconclusive/retryable (recovery is
+        # re-attempted on the next sweep) rather than becoming a rejection.
+        from forven.strategies.certification import classify_failure_tier
+        tier, canonical = classify_failure_tier(lookahead_reason)
+        with get_db() as conn:
+            conn.execute(
+                "UPDATE strategies SET status_reason = ? WHERE id = ?",
+                (f"lookahead_blocked:tier{tier}:{canonical}", strategy_id),
+            )
+        log.warning(
+            "Research recovery: NOT reviving %s — lookahead re-probe rejected: %s",
+            strategy_id, lookahead_reason,
+        )
+        return {"promoted": False, "reason": lookahead_reason}
+
+    # Certification + data availability + causality passed — promote via transition_stage
     result = transition_stage(
         strategy_id=strategy_id,
         target_stage="quick_screen",

--- a/forven/policy.py
+++ b/forven/policy.py
@@ -3522,7 +3522,12 @@ def _evaluate_quick_screen_gate(strategy_id: str, config: dict) -> tuple[bool, s
         return False, reason
 
     # === S00552 GUARDRAIL 4: Win Rate Trap Detection (WR > 60% but PF < 1.0) ===
-    win_rate = float(out_of_sample.get("win_rate", out_of_sample.get("winRate", 0.0)) or 0.0)
+    # WIN-RATE-UNIT-1: compute_metrics emits win_rate as a 0-1 RATIO, but legacy
+    # blobs may carry it as percent points (57.0). Normalize to percent points so
+    # the > 60% comparisons below fire for EITHER stored unit (values <= 1.0 are
+    # scaled x100 as ratios; > 1.0 are already percent). Without this the ratio
+    # form (0.79) never trips the > 60.0 guards — a silent lookahead escape hatch.
+    win_rate = _to_percent_points(out_of_sample.get("win_rate", out_of_sample.get("winRate", 0.0)))
     min_pf = min(is_pf, oos_pf) if has_distinct_oos else is_pf
     if has_distinct_oos and win_rate > 60.0 and min_pf < 1.0:
         return False, f"S00552 REJECT: Win rate trap detected - WR {win_rate:.1f}% but PF {min_pf:.2f} < 1.0 (likely curve-fitted)"

--- a/forven/strategies/certification.py
+++ b/forven/strategies/certification.py
@@ -140,6 +140,11 @@ FAILURE_TIERS: dict[str, int] = {
     # Tier 2 — structural issues, lower recovery priority
     "code_error": 2,
     "pattern_invalid": 2,
+    # A future-bar leak is a structural quarantine, not a param-tweak fix; give it
+    # a stable canonical key so a lookahead rejection classifies deterministically
+    # (the raw probe reason otherwise defaults to tier 2 with the whole message as
+    # the canonical, producing an unbounded status_reason).
+    "lookahead": 2,
 }
 
 

--- a/tests/test_lookahead_leak_gates.py
+++ b/tests/test_lookahead_leak_gates.py
@@ -136,6 +136,104 @@ def test_quick_screen_passes_sane_strategy(forven_db):
     assert "implausible" not in reason.lower()
 
 
+# ============ WIN-RATE-UNIT-1: win-rate guards fire in EITHER unit ============
+# compute_metrics emits win_rate as a 0-1 RATIO, but the S00552 guards compared
+# against percent values (> 60), so the ratio form (0.79) could never trip them —
+# a silent lookahead escape hatch. The guards now normalize to percent points, so
+# they fire whether win_rate is stored as a ratio (0.80) or percent (80.0).
+
+
+def _config_with_low_pf_floor():
+    # Drop the PF floor below 1.0 so the win-rate-TRAP guard (which needs
+    # min PF < 1.0) is reachable — otherwise GUARDRAIL 3 (PF floor, default 1.0)
+    # rejects first and the win-rate guard is never exercised.
+    config = load_pipeline_config()
+    config = dict(config)
+    qs = dict(config.get("quick_screen", {}))
+    qs["min_profit_factor"] = 0.5
+    config["quick_screen"] = qs
+    return config
+
+
+def test_quick_screen_win_rate_trap_fires_ratio_form(forven_db):
+    # OOS win_rate 0.80 (RATIO) + min PF 0.9 (< 1.0): the win-rate-trap must fire.
+    # Pre-fix this passed because 0.80 is not > 60.0.
+    metrics = _sane_metrics(
+        in_sample={
+            "sharpe": 1.2, "profit_factor": 0.95, "total_trades": 45,
+            "total_return_pct": 4.0, "max_drawdown_pct": 0.12, "win_rate": 0.80,
+        },
+        out_of_sample={
+            "sharpe": 0.9, "profit_factor": 0.9, "total_trades": 40,
+            "total_return_pct": 3.0, "max_drawdown_pct": 0.12, "win_rate": 0.80,
+        },
+    )
+    _insert_strategy("qs-wrtrap-ratio", metrics=metrics)
+    passed, reason = _evaluate_quick_screen_gate("qs-wrtrap-ratio", _config_with_low_pf_floor())
+    assert passed is False, reason
+    assert "win rate trap" in reason.lower(), reason
+    # Log message prints sensible percent, not the raw 0.80 ratio.
+    assert "80.0%" in reason, reason
+
+
+def test_quick_screen_win_rate_trap_fires_percent_form(forven_db):
+    # win_rate 80.0 (PERCENT) + PF 0.9: unit-agnostic — still fires.
+    metrics = _sane_metrics(
+        in_sample={
+            "sharpe": 1.2, "profit_factor": 0.95, "total_trades": 45,
+            "total_return_pct": 4.0, "max_drawdown_pct": 0.12, "win_rate": 80.0,
+        },
+        out_of_sample={
+            "sharpe": 0.9, "profit_factor": 0.9, "total_trades": 40,
+            "total_return_pct": 3.0, "max_drawdown_pct": 0.12, "win_rate": 80.0,
+        },
+    )
+    _insert_strategy("qs-wrtrap-pct", metrics=metrics)
+    passed, reason = _evaluate_quick_screen_gate("qs-wrtrap-pct", _config_with_low_pf_floor())
+    assert passed is False, reason
+    assert "win rate trap" in reason.lower(), reason
+    assert "80.0%" in reason, reason
+
+
+def test_quick_screen_legacy_high_wr_requires_pf_ratio_form(forven_db):
+    # OOS win_rate 0.75 (RATIO) + OOS PF 1.1 (<= 1.2): the legacy high-WR standard
+    # must fire (requires OOS PF > 1.2). Both PFs stay >= the 1.0 floor so the
+    # win-rate-TRAP branch does not swallow this — only the legacy branch bites.
+    metrics = _sane_metrics(
+        in_sample={
+            "sharpe": 1.2, "profit_factor": 1.15, "total_trades": 45,
+            "total_return_pct": 6.0, "max_drawdown_pct": 0.12, "win_rate": 0.75,
+        },
+        out_of_sample={
+            "sharpe": 0.9, "profit_factor": 1.1, "total_trades": 40,
+            "total_return_pct": 4.0, "max_drawdown_pct": 0.12, "win_rate": 0.75,
+        },
+    )
+    _insert_strategy("qs-legacy-wr", metrics=metrics)
+    passed, reason = _evaluate_quick_screen_gate("qs-legacy-wr", load_pipeline_config())
+    assert passed is False, reason
+    assert "overfit reject" in reason.lower() and "high win rate" in reason.lower(), reason
+    assert "75.0%" in reason, reason
+
+
+def test_quick_screen_healthy_win_rate_ratio_does_not_fire(forven_db):
+    # win_rate 0.55 (RATIO, = 55%): below the 60% trigger — guards must not fire.
+    metrics = _sane_metrics(
+        in_sample={
+            "sharpe": 1.4, "profit_factor": 1.5, "total_trades": 45,
+            "total_return_pct": 18.0, "max_drawdown_pct": 0.12, "win_rate": 0.55,
+        },
+        out_of_sample={
+            "sharpe": 1.0, "profit_factor": 1.3, "total_trades": 40,
+            "total_return_pct": 8.0, "max_drawdown_pct": 0.12, "win_rate": 0.55,
+        },
+    )
+    _insert_strategy("qs-healthy-wr", metrics=metrics)
+    passed, reason = _evaluate_quick_screen_gate("qs-healthy-wr", load_pipeline_config())
+    assert passed is True, reason
+    assert "win rate" not in reason.lower(), reason
+
+
 # ============================ GATE B: probe ================================
 
 class _LeakStrategy:

--- a/tests/test_metrics_integrity.py
+++ b/tests/test_metrics_integrity.py
@@ -90,6 +90,63 @@ class TestGuardrailQuarantine:
         assert "(reject)" not in reason
 
 
+class TestGauntletEntryWinRateUnit:
+    """WIN-RATE-UNIT-1: Guard 6 tail-risk detection (win_rate > 70% + PF < 1.5)
+    must fire whether win_rate is stored as a 0-1 RATIO or as percent points.
+
+    compute_metrics emits win_rate as a ratio; the guard compared against 70, so
+    the ratio form (0.75) could never trip it — a curve-fitted high-win-rate
+    strategy sailed into the gauntlet. The guard now normalizes to percent points.
+    """
+
+    @staticmethod
+    def _metrics_passing_up_to_guard6(win_rate, profit_factor):
+        # Clears Guards 1-5 and 7 so only Guard 6 (tail-risk) can bite:
+        # IS Sharpe 1.2 (> 0.5), OOS 1.0 (<= 2x IS, no divergence), 120 trades
+        # (>= 100), robustness 0.70 -> 70 (>= 60), max_dd 0.10 -> 10% (<= 25%).
+        return {
+            "in_sample": {"sharpe": 1.2, "total_trades": 120},
+            "out_of_sample": {"sharpe": 1.0, "total_trades": 40},
+            "total_trades": 120,
+            "sharpe": 1.2,
+            "win_rate": win_rate,
+            "profit_factor": profit_factor,
+            "robustness_score": 0.70,
+            "max_drawdown_pct": 0.10,
+        }
+
+    def test_tail_risk_fires_ratio_form(self):
+        from forven.brain import _gauntlet_entry_guardrails
+
+        can_proceed, reason = _gauntlet_entry_guardrails(
+            "S-wr-ratio", self._metrics_passing_up_to_guard6(0.75, 1.3)
+        )
+        assert can_proceed is False, reason
+        assert "tail risk" in reason.lower(), reason
+        assert "75.0%" in reason, reason  # printed as percent, not raw 0.75
+
+    def test_tail_risk_fires_percent_form(self):
+        from forven.brain import _gauntlet_entry_guardrails
+
+        can_proceed, reason = _gauntlet_entry_guardrails(
+            "S-wr-pct", self._metrics_passing_up_to_guard6(75.0, 1.3)
+        )
+        assert can_proceed is False, reason
+        assert "tail risk" in reason.lower(), reason
+        assert "75.0%" in reason, reason
+
+    def test_healthy_win_rate_ratio_passes(self):
+        from forven.brain import _gauntlet_entry_guardrails
+
+        # win_rate 0.55 (= 55%) + PF 1.3: below the 70% trigger — Guard 6 must not
+        # fire, and with all other guards cleared the strategy proceeds.
+        can_proceed, reason = _gauntlet_entry_guardrails(
+            "S-wr-healthy", self._metrics_passing_up_to_guard6(0.55, 1.3)
+        )
+        assert can_proceed is True, reason
+        assert "tail risk" not in reason.lower(), reason
+
+
 class TestSweepTreatsHoldAsNonTerminal:
     def test_data_quality_hold_is_not_terminal(self):
         from forven.evolution import _is_terminal_quick_screen_gate_failure

--- a/tests/test_pipeline_hardening.py
+++ b/tests/test_pipeline_hardening.py
@@ -2625,6 +2625,62 @@ def test_research_recovery_on_edit_promotes_if_certified(forven_db):
     assert row["stage"] == "quick_screen"
 
 
+def test_research_recovery_reprobes_lookahead_and_parks_on_leak(forven_db, monkeypatch):
+    # LOOKAHEAD-REENTRY-1: recovery must re-run the causality probe every fresh
+    # strategy passes at intake. Certification + data-availability pass (valid
+    # rsi_momentum), but the lookahead re-probe reports a leak → recovery must
+    # NOT promote; the strategy stays research_only with a lookahead status_reason,
+    # classified as a quarantine (not a repeated-failure archive count).
+    from forven.brain import try_research_recovery
+    import forven.strategies.lookahead_probe as lookahead_probe
+
+    _insert_strategy("s-recov-leak", stage="research_only")
+    with get_db() as conn:
+        conn.execute(
+            "UPDATE strategies SET type = 'rsi_momentum', params = ? WHERE id = 's-recov-leak'",
+            (json.dumps({"rsi_threshold": 30, "lookback_period": 14}),),
+        )
+
+    leak_reason = (
+        "Lookahead detected: vectorized signal at bar t=-20 changes when future "
+        "bars are withheld (long_entries) -- strategy reads future data; rejected"
+    )
+    monkeypatch.setattr(lookahead_probe, "detect_lookahead", lambda _obj: leak_reason)
+
+    result = try_research_recovery("s-recov-leak")
+    assert result.get("promoted") is False
+    assert "lookahead" in (result.get("reason") or "").lower()
+    with get_db() as conn:
+        row = conn.execute(
+            "SELECT stage, status_reason FROM strategies WHERE id = 's-recov-leak'"
+        ).fetchone()
+    assert row["stage"] == "research_only"
+    assert (row["status_reason"] or "").startswith("lookahead_blocked:")
+    # Quarantine classification: a leak is a structural (tier2) quarantine.
+    assert "tier2:lookahead" in row["status_reason"]
+
+
+def test_research_recovery_promotes_when_lookahead_probe_passes(forven_db, monkeypatch):
+    # Same setup, but the re-probe reports no leak → recovery proceeds as before.
+    from forven.brain import try_research_recovery
+    import forven.strategies.lookahead_probe as lookahead_probe
+
+    _insert_strategy("s-recov-clean", stage="research_only")
+    with get_db() as conn:
+        conn.execute(
+            "UPDATE strategies SET type = 'rsi_momentum', params = ? WHERE id = 's-recov-clean'",
+            (json.dumps({"rsi_threshold": 30, "lookback_period": 14}),),
+        )
+
+    monkeypatch.setattr(lookahead_probe, "detect_lookahead", lambda _obj: None)
+
+    result = try_research_recovery("s-recov-clean")
+    assert result.get("promoted") is True
+    with get_db() as conn:
+        row = conn.execute("SELECT stage FROM strategies WHERE id = 's-recov-clean'").fetchone()
+    assert row["stage"] == "quick_screen"
+
+
 def test_research_recovery_on_edit_debounce_5min(forven_db):
     from forven.api_core import _try_research_recovery_on_edit
     _insert_strategy("s-debounce", stage="research_only")


### PR DESCRIPTION
Two verified P0 fixes: guards that could never fire because of a win-rate unit mismatch, and a lookahead probe that never re-ran when a strategy re-entered the lifecycle.

## FIX 1 — Dead win-rate guards (unit mismatch)

`compute_metrics` emits `win_rate` as a **0–1 ratio** (`backtest.py`: `len(wins)/len(pnls)`), but three guard sites compared it against **percent** values, so for any modern (ratio-form) metrics blob they could never fire — a silent escape hatch for curve-fitted / lookahead-leaking high-win-rate strategies:

- `policy._evaluate_quick_screen_gate` — S00552 GUARDRAIL 4 win-rate-trap (`win_rate > 60.0 and min_pf < 1.0`) and the legacy high-WR standard (`win_rate > 60.0` → requires OOS PF > 1.2).
- `brain._gauntlet_entry_guardrails` — Guard 6 tail-risk detection (`win_rate > 70 and profit_factor < 1.5`).

**Fix:** normalize `win_rate` to percent points at all three sites using the existing `_to_percent_points` idiom / the same inline `abs(x) <= 1.0` scaling already used for robustness & max_drawdown right beside Guard 6. The convention is **unit-agnostic**: values `<= 1.0` are treated as ratios (×100), values `> 1.0` are already percent points and pass through unchanged. Legacy blobs that stored `57.0`/`80.0` still work; modern `0.57`/`0.80` blobs now trip the guards. Log messages print sensible percents (e.g. `80.0%`, not `0.80%`).

## FIX 2 — Lookahead probe never re-runs on lifecycle re-entry

`detect_lookahead` runs only at registration/intake (api_core, intake, sandbox worker). `brain.try_research_recovery` re-certifies + re-checks data availability on re-entry but **skipped the causality probe**, so a strategy parked to `research_only` and later recovered could re-enter `quick_screen` without a check every fresh strategy passes. A future-bar leak makes *both* the IS and OOS slices amazing, defeating the overfit / win-rate-trap detectors — so the probe is the primary catch, and re-entry was a blind spot.

**Design choice for the choke point.** I evaluated putting the probe inside `certify_execution_strategy` (so every caller gets it for free) and rejected it: certification is a **pure, fast, hot-loop** function (param canonicalization + registry lookup, no DB, no strategy instantiation) called all over intake/inference. Building a strategy instance and running a synthetic-frame probe there would change its cost profile and risk surface for every caller. Instead I added the re-probe **only at the re-entry choke point** (`try_research_recovery`), right after the certification and data-availability gates it already runs — the minimal-risk, minimal-blast-radius placement. A small `_reentry_lookahead_reason` helper resolves the class via the same `_resolve_strategy_class` the gauntlet revival probe uses, instantiates, and calls the existing in-process `detect_lookahead` (no new probe machinery, no subprocess added; `lookahead_probe.py` untouched).

**Behavior on failure.** A leak (or a strategy-authoring fault raised inside the strategy's own module) parks the strategy — it does **not** proceed into `quick_screen` — with a tier-classified `lookahead_blocked:tier2:lookahead` `status_reason`, mirroring the existing certification-failure branch. A lookahead rejection is a **quarantine**, not a repeated-failure archive count. Probe **infrastructure** faults stay **inconclusive/retryable**: `detect_lookahead` already returns `None` for engine/probe-side faults (PR#60's strategy-exception=rejection vs infra-fault=inconclusive split), and the helper additionally fails **open** on class-resolution/instantiation faults, so an environmental crash never converts a recoverable strategy into a rejection. Added a stable `"lookahead"` key to `FAILURE_TIERS` so the reason classifies deterministically instead of dumping the whole probe message as an unbounded canonical.

### Deviation from spec (in scope)
The spec also names engine-version-staleness and graveyard revivals as re-entry paths. Those live in `forven/gauntlet/engine.py` (`_strategy_reproducibly_crashes` / `requeue_stale_engine_artifacts`), which the HARD RULES forbid editing (out of the allowed file set). That path **already gates revival on a `detect_execution_crash` probe but not `detect_lookahead`** — the same blind spot, one file over. The brain/policy references to revival are only reason-code plumbing, not choke points. **Follow-up:** extend `engine._strategy_reproducibly_crashes` to also run `detect_lookahead` (a 2-line change, same rejection/inconclusive contract) in a PR that owns `engine.py`.

## Test evidence

All new tests **fail before, pass after** (verified by stashing the source fixes and re-running — the 4 representative new tests failed on clean base, e.g. the recovery-leak test promoted to quick_screen without the probe).

- `tests/test_lookahead_leak_gates.py` — win-rate-trap fires in ratio (0.80) and percent (80.0) form; legacy high-WR fires in ratio form (0.75 + OOS PF 1.1); healthy 0.55 does not fire.
- `tests/test_metrics_integrity.py::TestGauntletEntryWinRateUnit` — Guard 6 tail-risk fires in ratio (0.75 + PF 1.3) and percent (75.0) form; healthy 0.55 passes.
- `tests/test_pipeline_hardening.py` — recovery re-probe: mocked leak → stays `research_only` with `lookahead_blocked:tier2:lookahead`; mocked pass → promotes to `quick_screen`. Probe function is mocked (no real sandbox subprocess).

```
tests/test_lookahead_leak_gates.py + tests/test_metrics_integrity.py: 36 passed
tests/test_pipeline_hardening.py -k research_recovery: 7 passed
```

`ruff check forven tests` — clean.

**Pre-existing failures (NOT introduced here, confirmed on clean base 6ebb8a68):** `test_pipeline_hardening.py::{test_transition_stage_keeps_paper_when_live_graduation_gate_fails, test_brain_promote_strategy_returns_false_when_live_gate_blocks, test_gate_rejection_does_not_fetch_market_data}` — live-graduation gate message drift, plus the known `test_source_reconciliation_gate.py` reconcile failures noted in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CBHuQy6taZsvWNwsKig2N
