### PR TITLE
fix(risk): close two P0 live-capital reconcile-integrity gaps

### DIFF
--- a/forven/exchange/risk.py
+++ b/forven/exchange/risk.py
@@ -3428,6 +3428,91 @@ def reconcile_all_books(
         exchange_open += int(p.get("exchange_open") or 0)
         synced = synced and bool(p.get("synced"))
 
+    # UNRESOLVABLE-ROUTE-1: an OPEN book-stamped trade whose route resolves to
+    # _UNRESOLVABLE_ROUTE (a locked/unreadable settings read in _trade_routed_address)
+    # is EXCLUDED from every pass above — its own book's and master's — by the scope
+    # filter. That is correct (mis-scoping into master would ghost-close a real
+    # sub-account position), but silent: if that account's position is liquidated or
+    # closed while settings reads fail, the DB trade stays OPEN indefinitely and
+    # nobody knows. Fail LOUD, not silent — re-check the OPEN book-stamped trades now
+    # and surface any that are still unroutable, then try ONE fresh re-resolution +
+    # catch-up pass in case the settings read has recovered.
+    unresolved_ids: list[str] = []
+    reresolved_addresses: set[str | None] = set()
+    try:
+        with get_db() as conn:
+            open_booked = conn.execute(
+                "SELECT * FROM trades WHERE status = 'OPEN' AND book IS NOT NULL AND book != ''"
+            ).fetchall()
+        for _row in open_booked:
+            _trade = dict(_row)
+            if _trade_routed_address(_trade) == _UNRESOLVABLE_ROUTE:
+                _tid = str(_trade.get("id") or "").strip()
+                if _tid:
+                    unresolved_ids.append(_tid)
+    except Exception:
+        log.debug("Unresolvable-route re-check failed", exc_info=True)
+
+    if unresolved_ids:
+        log.error(
+            "Reconcile: %d OPEN book-stamped trade(s) have an UNRESOLVABLE route "
+            "(settings read failure) and were skipped by every pass — %s. A close/"
+            "liquidation on those accounts would go unreconciled until the settings "
+            "read recovers.",
+            len(unresolved_ids), ", ".join(unresolved_ids),
+        )
+        log_activity(
+            "error",
+            "risk",
+            (
+                f"Reconcile could not route {len(unresolved_ids)} open trade(s) "
+                f"({', '.join(unresolved_ids)}) — settings read failure left them "
+                f"OUT of every reconcile pass. A close/liquidation on those accounts "
+                f"is currently invisible; will retry route resolution."
+            ),
+            {"unresolvable_route_trade_ids": unresolved_ids},
+        )
+
+        # ONE fresh re-resolution: the settings read may have recovered since the
+        # per-book passes ran. Collect the accounts these trades now route to and run
+        # a scoped catch-up pass for each; a trade that resolves cleanly this time is
+        # reconciled normally. A trade still unroutable stays flagged (surfaced above).
+        try:
+            with get_db() as conn:
+                catchup_rows = conn.execute(
+                    f"SELECT * FROM trades WHERE id IN ({','.join('?' for _ in unresolved_ids)})",
+                    tuple(unresolved_ids),
+                ).fetchall()
+            for _row in catchup_rows:
+                _addr = _trade_routed_address(dict(_row))
+                if _addr != _UNRESOLVABLE_ROUTE:
+                    reresolved_addresses.add(_addr)
+        except Exception:
+            log.debug("Unresolvable-route re-resolution failed", exc_info=True)
+
+        catchup_passes: list[dict] = []
+        for _addr in reresolved_addresses:
+            _label = address_labels.get(_addr)
+            catchup_passes.append(
+                reconcile_exchange_positions(
+                    testnet,
+                    adopt_missing_in_sqlite=False,
+                    recovery_batch_id=recovery_batch_id,
+                    account_address=_addr,
+                    book_label=_label,
+                    open_orders=None,
+                )
+            )
+        for _p in catchup_passes:
+            if not isinstance(_p, dict) or _p.get("error"):
+                synced = False
+                continue
+            merged_discrepancies.extend(_p.get("discrepancies") or [])
+            merged_informational.extend(_p.get("informational") or [])
+            merged_adopted.extend(_p.get("adopted_positions") or [])
+            merged_actions.extend(_p.get("resolved_actions") or [])
+            synced = synced and bool(_p.get("synced"))
+
     merged = {
         "sqlite_open": sqlite_open,
         "exchange_open": exchange_open,
@@ -3438,8 +3523,11 @@ def reconcile_all_books(
         "resolved_actions": merged_actions,
         "synced": synced,
         "testnet": bool(testnet),
-        "per_book_passes": len(passes),
+        "per_book_passes": len(passes) + len(reresolved_addresses),
     }
+    if unresolved_ids:
+        merged["unresolvable_route_trade_ids"] = unresolved_ids
+        merged["unresolvable_route_reresolved_count"] = len(reresolved_addresses)
     if unreachable_books:
         merged["degraded"] = True
         merged["unreachable_books"] = unreachable_books
@@ -4146,6 +4234,38 @@ def close_all_positions() -> list[dict]:
             strategy_ids = open_strategy_by_asset.get(coin.upper(), [])
             strategy_id = _first_item(strategy_ids) if len(strategy_ids) == 1 else None
             trade_ids = open_trade_ids_by_asset.get(coin.upper(), [])
+
+            # KS-TIMEOUT-1: stamp pending_close_reconcile on this asset's trade rows
+            # BEFORE the exchange close. The daemon wraps this whole call in a hard
+            # timeout (RISK_CLOSE_TIMEOUT_SECONDS): if it fires after the exchange
+            # close SUCCEEDS but before the post-loop close_trade_record runs, the
+            # row would otherwise stay a bare OPEN with no marker — and the
+            # reconciler would ghost-close it at the reconcile-time mid, fabricating
+            # PnL on the emergency path. Marking first means a timeout at ANY point
+            # leaves the trade carrying the marker; the reconciler then re-verifies
+            # against exchange truth (recovers the true exit from the fill ledger,
+            # guarded by the empty-read streak) instead of guessing a mid. A
+            # confirmed close runs close_trade_record below, which SUPERSEDES the
+            # marker (it pops every pending_close_* key). Best-effort: a failed
+            # pre-mark must not abort the flatten — the FAILED-close path re-marks
+            # with the richer error metadata at the fallback below.
+            preclose_marked_at = get_now().isoformat()
+            for trade_id in trade_ids:
+                try:
+                    mark_trade_pending_close_reconcile(
+                        trade_id,
+                        close_reason="kill_switch",
+                        close_price_source="kill_switch_close",
+                        requested_at=preclose_marked_at,
+                        extra_signal_data={
+                            "kill_switch_close_preclose_marked_at": preclose_marked_at,
+                        },
+                    )
+                except Exception as _premark_exc:
+                    log.error(
+                        "Kill-switch could not pre-mark trade %s pending-close for %s: %s",
+                        trade_id, coin, _premark_exc,
+                    )
 
             log.warning("Kill-switch closing: %s %.4f %s", side, size, coin)
             close_response = None

--- a/tests/test_direction_books.py
+++ b/tests/test_direction_books.py
@@ -187,6 +187,92 @@ class TestReconcilerBookSafetyGuard:
         assert dict(row)["status"] != "OPEN"
 
 
+class TestUnresolvableRouteAlerting:
+    """UNRESOLVABLE-ROUTE-1: an OPEN book-stamped trade whose route can't be
+    resolved (a locked/unreadable settings read -> _UNRESOLVABLE_ROUTE) is EXCLUDED
+    from every reconcile pass by the scope guard. That is correct (mis-scoping into
+    master could ghost-close a real sub-account position), but it must NOT be silent:
+    a close/liquidation on that account would otherwise leave the DB trade OPEN
+    forever with nobody alerted."""
+
+    def _empty_snapshot(self, *_args, **_kwargs):
+        return {"raw_positions": [], "positions": [], "open_orders": [], "price_map": {}}
+
+    def test_unresolvable_route_emits_alert_and_flags_trade(self, forven_db, monkeypatch):
+        _books_settings()
+        _seed_open_trade("T-UNRES-1", "BTC", "short", "scalp", "short")
+        monkeypatch.setattr(
+            "forven.exchange.risk._snapshot_exchange_state", self._empty_snapshot
+        )
+        # The settings read fails for the WHOLE cycle -> the trade routes to the
+        # sentinel on every resolution, including the end-of-cycle re-resolution.
+        from forven.exchange import risk as risk_mod
+        monkeypatch.setattr(
+            risk_mod, "_trade_routed_address",
+            lambda trade: risk_mod._UNRESOLVABLE_ROUTE,
+        )
+        alerts: list[tuple] = []
+        monkeypatch.setattr(
+            risk_mod, "log_activity",
+            lambda level, source, message, *a, **k: alerts.append((level, source, message)),
+        )
+
+        result = reconcile_all_books()
+
+        # (a) LOUD, not silent: an error-level risk alert names the trade + cause.
+        assert any(
+            lvl == "error" and src == "risk" and "T-UNRES-1" in msg
+            for (lvl, src, msg) in alerts
+        ), alerts
+        # The trade is flagged in the merged result and stays OPEN (never guessed
+        # into a pass that could have ghost-closed it).
+        assert "T-UNRES-1" in (result.get("unresolvable_route_trade_ids") or [])
+        assert result.get("unresolvable_route_reresolved_count") == 0
+        with get_db() as conn:
+            row = conn.execute("SELECT status FROM trades WHERE id = 'T-UNRES-1'").fetchone()
+        assert dict(row)["status"] == "OPEN"
+
+    def test_recovered_route_reconciles_in_catch_up_pass(self, forven_db, monkeypatch):
+        # confirm_count=1: isolate the routing catch-up from the empty-read streak
+        # guard (RECONCILE-6) so the recovered pass sweeps on its first empty read.
+        _books_settings(reconcile_empty_read_confirm_count=1)
+        _seed_open_trade("T-UNRES-2", "BTC", "short", "scalp", "short")
+        monkeypatch.setattr(
+            "forven.exchange.risk._snapshot_exchange_state", self._empty_snapshot
+        )
+        from forven.exchange import risk as risk_mod
+
+        # Settings read is DOWN during the per-book passes + the re-check (so the
+        # trade is excluded and the alert fires), then RECOVERS for the end-of-cycle
+        # re-resolution — the catch-up pass then reconciles it against exchange truth.
+        # The unresolvable alert fires exactly once, AFTER the re-check loop and
+        # BEFORE the re-resolution; use it to flip the read back up deterministically
+        # (independent of how many book passes ran).
+        real_route = risk_mod._trade_routed_address
+        state = {"down": True}
+
+        def _routed(trade):
+            if state["down"]:
+                return risk_mod._UNRESOLVABLE_ROUTE
+            return real_route(trade)
+
+        def _log_activity(level, source, message, *a, **k):
+            if level == "error" and source == "risk" and "T-UNRES-2" in str(message):
+                state["down"] = False  # settings read recovered
+
+        monkeypatch.setattr(risk_mod, "_trade_routed_address", _routed)
+        monkeypatch.setattr(risk_mod, "log_activity", _log_activity)
+
+        result = reconcile_all_books()
+
+        # The re-resolution recovered the route, so a catch-up pass ran and the
+        # ghost (empty snapshot) was reconciled — the trade is no longer bare OPEN.
+        assert result.get("unresolvable_route_reresolved_count") == 1
+        with get_db() as conn:
+            row = conn.execute("SELECT status FROM trades WHERE id = 'T-UNRES-2'").fetchone()
+        assert dict(row)["status"] != "OPEN"
+
+
 class TestLongOnlyVolumeGateSurfacing:
     def test_status_note_explains_100k_volume_gate(self, forven_db):
         _books_settings(hyperliquid_short_book_address="")

--- a/tests/test_kill_switch_close_integrity.py
+++ b/tests/test_kill_switch_close_integrity.py
@@ -78,3 +78,78 @@ def test_kill_switch_flatten_spares_paper_rows(forven_db, monkeypatch):
     assert float(rows["LIVE-1"]["exit_price"]) == 100.2
     assert rows["PAPER-1"]["status"] == "OPEN"
     assert rows["BOT-1"]["status"] == "OPEN"
+
+
+def test_kill_switch_timeout_window_never_leaves_bare_open(forven_db, monkeypatch):
+    """KS-TIMEOUT-1: the daemon wraps close_all_positions in a hard timeout. The
+    dangerous window is a position whose exchange close ALREADY SUCCEEDED but whose
+    post-loop close_trade_record bookkeeping hasn't run — a timeout landing there
+    would leave a bare OPEN row (no marker) that the reconciler ghost-closes at mid,
+    fabricating PnL. Simulate the timeout landing IN the bookkeeping gap: both
+    exchange closes succeed, but close_trade_record raises for the SECOND asset (as
+    the daemon's thread timeout would). The pre-close pending_close_reconcile marker
+    must keep that row from ever being a bare OPEN lie; the first asset, whose
+    bookkeeping did run, is fully CLOSED with the marker superseded."""
+    from forven.db import get_db
+
+    with get_db() as conn:
+        _insert_open_trade(conn, "LIVE-BTC", "BTC", "live")
+        _insert_open_trade(conn, "LIVE-ETH", "ETH", "live")
+
+    monkeypatch.setattr(
+        "forven.exchange.hyperliquid.get_positions",
+        lambda *a, **k: {
+            "positions": [
+                {"position": {"coin": "BTC", "szi": 1.0}},
+                {"position": {"coin": "ETH", "szi": 1.0}},
+            ],
+            "margin_summary": {},
+        },
+    )
+    # BOTH exchange closes SUCCEED — the exchange truth is "flat" for both assets.
+    monkeypatch.setattr(
+        "forven.exchange.hyperliquid.close_position",
+        lambda coin, *a, **k: {
+            "status": "ok", "mid": 100.0, "close_price": 103.0,
+            "exit_price": (100.2 if str(coin).upper() == "BTC" else 200.4),
+            "requested_size": 1.0, "filled_size": 1.0,
+        },
+    )
+    monkeypatch.setattr(risk, "release", lambda *a, **k: None, raising=False)
+
+    # The timeout lands during the post-loop bookkeeping: BTC's close_trade_record
+    # commits, then ETH's raises (as a thread-timeout interrupt would). The raise
+    # propagates out of close_all_positions exactly as the daemon's timeout wrapper
+    # sees it.
+    real_close_trade_record = risk.close_trade_record
+
+    def _close_trade_record(trade_id, *a, **k):
+        if str(trade_id) == "LIVE-ETH":
+            raise TimeoutError("daemon close timeout landed in bookkeeping gap")
+        return real_close_trade_record(trade_id, *a, **k)
+
+    monkeypatch.setattr(risk, "close_trade_record", _close_trade_record)
+
+    try:
+        risk.close_all_positions()
+    except TimeoutError:
+        pass  # the daemon's _to_thread_with_timeout swallows this
+
+    with get_db() as conn:
+        rows = {r["id"]: dict(r) for r in conn.execute(
+            "SELECT id, status, exit_price, signal_data FROM trades").fetchall()}
+
+    # Position 1: exchange close succeeded AND bookkeeping ran → fully CLOSED at the
+    # real fill, with the pre-close marker superseded by close_trade_record.
+    assert rows["LIVE-BTC"]["status"] == "CLOSED"
+    assert float(rows["LIVE-BTC"]["exit_price"]) == 100.2
+    btc_sig = json.loads(rows["LIVE-BTC"]["signal_data"])
+    assert "pending_close_reconcile" not in btc_sig
+
+    # Position 2: bookkeeping interrupted by the timeout → still OPEN, but carries
+    # the pre-close marker, so the reconciler re-verifies exchange truth (recovers
+    # the true exit from the fill ledger) instead of ghost-closing a bare OPEN.
+    assert rows["LIVE-ETH"]["status"] == "OPEN"
+    eth_sig = json.loads(rows["LIVE-ETH"]["signal_data"])
+    assert eth_sig.get("pending_close_reconcile") is True
+    assert eth_sig.get("pending_close_reason") == "kill_switch"


### PR DESCRIPTION
Two verified P0 live-capital integrity fixes in the reconcile path. Both are confined to `forven/exchange/risk.py` plus regression tests; `daemon.py`, `policy.py`, and `brain.py` are untouched.

## FIX 1 — Kill-switch flatten could strand a position closed-on-exchange but OPEN-in-DB (KS-TIMEOUT-1)

**Bug.** `close_all_positions()` closes exchange positions in one loop and finalizes the SQLite bookkeeping (`close_trade_record`) in a *separate* post-loop. The daemon wraps the whole call in a 20s async timeout (`RISK_CLOSE_TIMEOUT_SECONDS`). If the timeout fired after a position's exchange close **succeeded** but before its `close_trade_record` ran, the trade stayed **bare OPEN in SQLite with no `pending_close_reconcile` marker**. The reconciler then saw an OPEN trade with no matching exchange position, treated it as a ghost, and closed it at the reconcile-time mid — fabricated PnL on the emergency path. (Positions that *exhaust their close retries* were already marked at ~line 4237; the gap was the in-flight/timeout window on a *successful* close whose bookkeeping hadn't run.)

**Fix.** Stamp each position's live trade rows with `pending_close_reconcile` (+ `close_reason="kill_switch"`, `close_price_source="kill_switch_close"`, a timestamp) **before** attempting that position's exchange close, matching the existing marker shape. On a confirmed successful close, the normal post-loop `close_trade_record()` flow runs, which **supersedes** the marker. A timeout at ANY point now leaves the trade either properly closed or carrying the marker — never a bare OPEN lie. The pre-mark is best-effort (a failed pre-mark logs and continues; the FAILED-close path still re-marks with richer error metadata).

**Reconciler-behavior verification (Fix 1 relies on this).**
- `close_trade_record` (forven/trade_state.py ~225–232) **explicitly pops** all five `pending_close_*` keys (`pending_close_reconcile`, `_at`, `_reason`, `_price_source`, `_requested_exit_price`) when it finalizes, so a confirmed close cleanly supersedes the pre-mark. Verified by the test asserting `pending_close_reconcile` is absent on the closed row.
- A marker does **not** blind-close at mid. A trade only becomes a "ghost" when its asset is genuinely absent from the exchange snapshot (risk.py ~2869). A marked ghost is closed with `close_reason="pending_close_reconcile_confirmed"` and its exit is recovered from the **exchange fill ledger** (`_recover_exit_from_fills`) — the reconcile-time mid is only the last-resort fallback when no fill is found. The mass-ghost-close is further guarded by the N-consecutive-empty-read streak (RECONCILE-6). So the marker path re-verifies exchange truth rather than fabricating a mid-price close.

**Regression test** (`tests/test_kill_switch_close_integrity.py::test_kill_switch_timeout_window_never_leaves_bare_open`): both positions' exchange closes succeed, but `close_trade_record` raises for the second asset (the daemon's thread-timeout landing in the bookkeeping gap). Asserts position 1 is fully CLOSED with the marker superseded, and position 2 is still OPEN **carrying `pending_close_reconcile`** — never bare OPEN. Fails before the fix (`{'kernel_managed': True}`, no marker), passes after.

## FIX 2 — Unresolvable-route trades invisible to ALL reconcile passes (UNRESOLVABLE-ROUTE-1)

**Bug.** `_trade_routed_address()` returns the `_UNRESOLVABLE_ROUTE` sentinel when the settings read fails (DB busy/lock). The scope filter in `reconcile_exchange_positions()` (~2858) then excludes that trade from **every** pass — its own book's and master's — correctly refusing to guess-scope (mis-scoping into master could ghost-close a real sub-account position), but **silently**. A close/liquidation on that account while settings reads fail left the DB trade OPEN indefinitely with nobody alerted.

**Fix (both parts shipped).**
- **(a) Fail loud.** After the per-book + master passes, `reconcile_all_books()` re-checks OPEN book-stamped trades; any still resolving to `_UNRESOLVABLE_ROUTE` trigger a `log.error` **and** a `log_activity("error", "risk", ...)` alert naming the trade ids and the settings-read cause, so the operator and health surface see it. The ids are also surfaced in the merged result (`unresolvable_route_trade_ids`).
- **(b) One re-resolution + catch-up.** The settings read may have recovered since the passes ran, so it attempts **one** fresh route re-resolution for the flagged trades and runs a scoped catch-up pass for each that now resolves. Trades still unroutable stay flagged.

The pass architecture is unchanged — the detection is a self-contained end-of-cycle DB re-check, so no `reconcile_exchange_positions` signature or scope-filter changes were needed.

**Regression tests** (`tests/test_direction_books.py::TestUnresolvableRouteAlerting`):
- `test_unresolvable_route_emits_alert_and_flags_trade`: route stays unresolvable for the whole cycle → asserts the `error`/`risk` alert names the trade, the trade is flagged in the result (`unresolvable_route_reresolved_count == 0`), and stays OPEN (never guessed into a ghost-close).
- `test_recovered_route_reconciles_in_catch_up_pass`: read is down during the passes + re-check (alert fires), then recovers for the re-resolution → asserts the catch-up pass ran (`unresolvable_route_reresolved_count == 1`) and the trade reconciled normally.

Both fail before the fix and pass after.

## Test evidence
- `tests/test_kill_switch_close_integrity.py tests/test_risk_module.py tests/test_risk_reconciliation.py tests/test_paper_no_global_halts.py tests/test_direction_books.py` → **118 passed**.
- Broader risk/reconcile sweep (adds `test_overnight_halt_resilience_2026_06_18.py`) → **134 passed**.
- `ruff check forven tests` → **All checks passed** (one pre-existing unrelated noqa warning in `test_assistant_session.py`).
- Each new test verified to FAIL before its fix and PASS after (stash/pop).
- Pre-existing / environmental failures on this machine, unrelated to this change and confirmed identical on baseline main: `test_source_reconciliation_gate.py::test_reconcile_one_*` (the 3 known producer-test failures) and `test_daemon_startup_recovery.py::test_startup_recovery_preflight_blocks_on_reconciliation_issues` (an `exchange_account` snapshot-dict schema drift — extra `books: {}` key — nothing to do with reconcile routing).

## Deviations from spec
None. Fix 1 was implementable entirely within `close_all_positions` (daemon.py untouched). Fix 2 shipped both (a) and (b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CBHuQy6taZsvWNwsKig2N
