### PR TITLE
fix(settings): serialize + atomicize control-plane mutations (P1)

### DIFF
--- a/forven/api_core.py
+++ b/forven/api_core.py
@@ -1,4 +1,5 @@
-﻿import json
+﻿import copy
+import json
 import math
 import os
 import re
@@ -43,6 +44,7 @@ from forven.db import (
     get_db,
     kv_get,
     kv_set,
+    kv_set_many,
     _now,
     log_activity,
     normalize_agent_visibility,
@@ -1660,6 +1662,19 @@ _SETTINGS_SECRET_STORAGE_KEY = "forven:settings:secrets"
 _SETTINGS_API_KEYS_STORAGE_KEY = "forven:settings:api-keys"
 _SETTINGS_PIPELINE_STORAGE_KEY = "forven:pipeline:settings"
 
+# Serializes the FULL read->apply->diff->audit->save sequence of a settings
+# mutation. Settings are the control plane (trading mode, risk caps, gate
+# thresholds); a mutation loads the current blob, mutates it, diffs old-vs-new
+# for the audit log, and writes several KV keys. Two concurrent PUTs without
+# serialization race that read-modify-write: one edit is lost entirely and the
+# audit diff can attribute one request's changes to the other's actor. A
+# process-level lock (single-process app, uvicorn workers=1) makes each mutation
+# atomic against every other mutation so both edits land and each audit entry
+# reflects exactly its own request. Held only around the in-memory
+# apply+diff+persist critical section — post-save side-effect hooks (scheduler
+# overrides, daemon-state cleanup) run outside it.
+_SETTINGS_MUTATION_LOCK = threading.RLock()
+
 # Single source of truth for the default backtest window (calendar days). This ONE
 # setting governs every automatic backtest that doesn't carry an explicit start/end:
 # quick-screen, gauntlet timeframe-sweep/optimization/confirmation, walk-forward,
@@ -2181,20 +2196,24 @@ def resolve_strategy_query_limit(status: str | None, requested_limit: object = N
     return bounded_limit
 
 
-def _sync_pipeline_wip_cap_kv(payload: dict) -> None:
+def _pipeline_wip_cap_kv_items(payload: dict) -> dict:
+    """Compute the ``pipeline:wip_cap:*`` KV entries a payload implies (no write)."""
+    items: dict = {}
     for stage, stage_config in _PIPELINE_STAGE_WIP_CAPS.items():
         mode_key = str(stage_config["mode_key"])
         cap_key = str(stage_config["cap_key"])
         if _normalize_pipeline_wip_cap_mode(payload.get(mode_key)) == "unlimited":
-            kv_set(f"pipeline:wip_cap:{stage}", "unlimited")
+            items[f"pipeline:wip_cap:{stage}"] = "unlimited"
         else:
-            kv_set(
-                f"pipeline:wip_cap:{stage}",
-                _normalize_pipeline_wip_cap_value(
-                    payload.get(cap_key),
-                    int(stage_config["default"]),
-                ),
+            items[f"pipeline:wip_cap:{stage}"] = _normalize_pipeline_wip_cap_value(
+                payload.get(cap_key),
+                int(stage_config["default"]),
             )
+    return items
+
+
+def _sync_pipeline_wip_cap_kv(payload: dict) -> None:
+    kv_set_many(_pipeline_wip_cap_kv_items(payload))
 
 
 def _normalize_agent_model_key(raw: str) -> str | None:
@@ -2317,14 +2336,19 @@ def _load_settings_secrets() -> dict:
     return secrets
 
 
-def _save_settings_secrets(payload: dict) -> None:
+def _encrypt_settings_secrets(payload: dict) -> dict:
+    """Encrypt a plaintext secrets dict into its at-rest KV form (no write)."""
     encrypted: dict = {}
     for key, value in payload.items():
         if isinstance(value, str):
             encrypted[key] = encrypt_secret(value.strip()) if value.strip() else ""
         else:
             encrypted[key] = value
-    kv_set(_SETTINGS_SECRET_STORAGE_KEY, encrypted)
+    return encrypted
+
+
+def _save_settings_secrets(payload: dict) -> None:
+    kv_set(_SETTINGS_SECRET_STORAGE_KEY, _encrypt_settings_secrets(payload))
 
 
 def _load_settings_payload() -> dict:
@@ -2448,12 +2472,27 @@ _NOTIF_TOGGLE_PREF_KEYS: dict[str, tuple[str, ...]] = {
 }
 
 
-def _apply_settings_section(section: str, payload: dict) -> dict:
+def _apply_settings_section(section: str, payload: dict, actor: str = "ui") -> dict:
+    """Apply a settings-section edit and persist it atomically.
+
+    The whole load -> mutate -> diff -> audit -> persist sequence must run
+    under ``_SETTINGS_MUTATION_LOCK`` (the endpoint acquires it). Within one
+    call every touched KV key — the encrypted secrets blob and the main
+    settings blob, audit entry included — is written in a SINGLE transaction
+    via ``kv_set_many`` so a crash can never split them. The audit diff is
+    computed here (against the ``old`` snapshot taken before mutation) and
+    attributed to ``actor``, so with the lock held each entry reflects exactly
+    its own request's changes.
+    """
     if not isinstance(payload, dict):
         raise HTTPException(status_code=400, detail="settings payload must be an object")
 
     updates = _load_settings_payload()
     secrets = _load_settings_secrets()
+    # Snapshot the pre-mutation blob for the audit diff. `updates` is mutated in
+    # place below, so a shallow copy would alias nested dicts and diff to
+    # nothing; deep-copy to capture the true "from" values.
+    old_snapshot = copy.deepcopy(updates)
 
     section = str(section or "").strip().lower()
     if section in {"pipeline", "api-keys", "test-discord", "reset"}:
@@ -3255,11 +3294,27 @@ def _apply_settings_section(section: str, payload: dict) -> dict:
         updates["discord_bot_token_configured"] = False
         updates["discord_bot_token_source"] = "none"
 
-    _save_settings_secrets(secrets)
-
     updates["updated_at"] = _now()
 
-    _save_settings_payload(updates)
+    # Compute the audit diff against the pre-mutation snapshot and fold the
+    # audit_log into the SAME blob we persist. `old_snapshot` carries the prior
+    # audit_log (in _AUDIT_IGNORE_KEYS, so it never self-diffs); append this
+    # request's entries onto it before writing.
+    entries = _diff_settings_section(section, old_snapshot, updates, actor=actor)
+    if entries:
+        updates["audit_log"] = _append_settings_audit(
+            old_snapshot.get("audit_log") or [], entries
+        )
+
+    # Persist the encrypted secrets blob AND the main settings blob (audit
+    # entry included) in ONE transaction: a crash between them can no longer
+    # leave enforcement diverged from display. Replaces the two separate
+    # _save_settings_secrets / _save_settings_payload calls that used to run
+    # here and the third blob save the endpoint did after appending audit.
+    kv_set_many({
+        _SETTINGS_SECRET_STORAGE_KEY: _encrypt_settings_secrets(secrets),
+        _SETTINGS_STORAGE_KEY: updates,
+    })
 
     if section == "bot-operations":
         try:
@@ -6496,7 +6551,6 @@ def _find_null_setting_leaves(value, prefix: str = "") -> list[str]:
 
 
 def put_pipeline_settings(body: PipelineSettingsUpdateBody):
-    payload = _load_pipeline_settings_payload()
     updates = body.updates or {}
     if not isinstance(updates, dict):
         raise HTTPException(status_code=400, detail="updates must be an object")
@@ -6515,25 +6569,40 @@ def put_pipeline_settings(body: PipelineSettingsUpdateBody):
                 + " — enter a value or revert the field before saving"
             ),
         )
-    threshold_updates = {key: value for key, value in updates.items() if key in _PIPELINE_THRESHOLD_SETTING_KEYS}
-    flat_updates = {key: value for key, value in updates.items() if key not in _PIPELINE_THRESHOLD_SETTING_KEYS}
-    if threshold_updates:
-        from forven.policy import load_pipeline_config, save_pipeline_config
+    # Serialize the whole load->merge->save against every other settings
+    # mutation so a concurrent pipeline (or section) save can't race the
+    # read-modify-write and lose an edit.
+    with _SETTINGS_MUTATION_LOCK:
+        payload = _load_pipeline_settings_payload()
+        threshold_updates = {key: value for key, value in updates.items() if key in _PIPELINE_THRESHOLD_SETTING_KEYS}
+        flat_updates = {key: value for key, value in updates.items() if key not in _PIPELINE_THRESHOLD_SETTING_KEYS}
+        if threshold_updates:
+            from forven.policy import load_pipeline_config, save_pipeline_config
 
-        policy_config = load_pipeline_config()
-        for key, value in threshold_updates.items():
-            if isinstance(value, dict) and isinstance(policy_config.get(key), dict):
-                policy_config[key] = {**policy_config[key], **value}
-            else:
-                policy_config[key] = value
-        save_pipeline_config(policy_config)
-    payload.update(flat_updates)
-    _normalize_pipeline_wip_cap_payload(payload)
-    _normalize_graveyard_strategy_limit_payload(payload)
-    payload["created_by"] = str(body.actor or "manual") or "manual"
-    payload["created_at"] = _now()
-    _save_pipeline_settings_payload(payload)
-    _sync_pipeline_wip_cap_kv(payload)
+            policy_config = load_pipeline_config()
+            for key, value in threshold_updates.items():
+                if isinstance(value, dict) and isinstance(policy_config.get(key), dict):
+                    policy_config[key] = {**policy_config[key], **value}
+                else:
+                    policy_config[key] = value
+            # forven:pipeline_thresholds lives in policy.py and opens its own
+            # write; it stays a distinct KV key from the pipeline payload +
+            # WIP-cap mirror. The lock serializes it against the payload write
+            # below; a crash between them leaves the thresholds updated but the
+            # display payload stale (never a torn payload+mirror).
+            save_pipeline_config(policy_config)
+        payload.update(flat_updates)
+        _normalize_pipeline_wip_cap_payload(payload)
+        _normalize_graveyard_strategy_limit_payload(payload)
+        payload["created_by"] = str(body.actor or "manual") or "manual"
+        payload["created_at"] = _now()
+        # Write the pipeline payload AND its WIP-cap KV mirror in ONE
+        # transaction so the display blob and the enforced per-stage caps can
+        # never diverge on a crash between them.
+        kv_set_many({
+            _SETTINGS_PIPELINE_STORAGE_KEY: payload,
+            **_pipeline_wip_cap_kv_items(payload),
+        })
     return payload
 
 
@@ -6714,14 +6783,14 @@ def get_settings_audit_log(limit: int = 5) -> list[dict]:
 
 
 def put_settings_section(section: str, payload: dict):
-    old = _load_settings_payload()
-    result = _apply_settings_section(section, payload)
-    new = _load_settings_payload()
-    entries = _diff_settings_section(section, old, new, actor="ui")
-    if entries:
-        new["audit_log"] = _append_settings_audit(new.get("audit_log") or [], entries)
-        _save_settings_payload(new)
-    return result
+    # Serialize the entire read->apply->diff->audit->save sequence so two
+    # concurrent section saves can't race the read-modify-write (losing one
+    # edit) or cross-attribute the audit diff. _apply_settings_section computes
+    # the audit entries against its own pre-mutation snapshot and persists the
+    # secrets + main blob (audit included) in ONE atomic transaction, so there
+    # is no longer a second re-read/diff/save out here.
+    with _SETTINGS_MUTATION_LOCK:
+        return _apply_settings_section(section, payload, actor="ui")
 
 
 def get_settings_discord_audit(send_probe: bool = False):

--- a/forven/db.py
+++ b/forven/db.py
@@ -3612,6 +3612,31 @@ def kv_set(key: str, value):
         )
 
 
+def kv_set_many(items: dict) -> None:
+    """Write several KV keys inside ONE transaction (all-or-nothing).
+
+    A settings mutation touches multiple KV keys (the main settings blob plus
+    the encrypted-secrets blob, or the pipeline payload plus its WIP-cap
+    mirrors). Persisting them via separate ``kv_set`` calls leaves a window
+    where a crash or lock failure between writes diverges enforcement from
+    display. Committing every touched key on a single connection closes that
+    window: either the whole logical mutation lands or none of it does.
+
+    Values are already-final Python objects (JSON-serializable). Callers that
+    encrypt secrets must pass the ENCRYPTED value here — this helper does not
+    transform values, it only serializes and writes them atomically.
+    """
+    if not items:
+        return
+    now = _now()
+    with get_db() as conn:
+        for key, value in items.items():
+            conn.execute(
+                "INSERT OR REPLACE INTO kv (key, value, updated_at) VALUES (?, ?, ?)",
+                (str(key), json.dumps(value), now),
+            )
+
+
 def live_equity_baseline_kv_key(strategy_id: str) -> str:
     """KV key holding a live strategy's go-live account equity baseline.
 

--- a/tests/test_settings_atomic_mutations.py
+++ b/tests/test_settings_atomic_mutations.py
@@ -1,0 +1,248 @@
+"""P1 control-plane integrity: settings mutations must be atomic and serialized.
+
+Two confirmed integrity problems these tests lock down:
+
+1. Read-modify-write race — ``put_settings_section`` used to load settings,
+   apply (which itself loaded+mutated+saved), reload, diff old-vs-new for the
+   audit log, then save AGAIN. Two concurrent section saves could lose one edit
+   entirely and mis-attribute the audit diff to the wrong request's actor.
+   Every mutation now runs under ``_SETTINGS_MUTATION_LOCK`` so both edits land
+   and each audit entry reflects exactly its own request's changes.
+
+2. Non-atomic multi-key persistence — one logical mutation wrote the main
+   settings blob and the encrypted-secrets blob (and, for pipeline, the payload
+   plus its WIP-cap mirror) as SEPARATE ``kv_set`` calls. A crash between them
+   left enforcement diverged from display. Every touched key is now written in a
+   single ``kv_set_many`` transaction: the whole mutation lands or none of it.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+import forven.api_core as core
+from forven.api_core import (
+    PipelineSettingsUpdateBody,
+    _load_settings_payload,
+    get_pipeline_settings,
+    put_pipeline_settings,
+    put_settings_section,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Concurrency: two threads mutate different sections at once
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_section_saves_both_land_with_correct_audit(forven_db):
+    """Two threads PUT different sections simultaneously, N times over.
+
+    Both edited values must always land, and the audit log must contain BOTH
+    entries with per-entry field attribution intact (no lost update, no
+    cross-attributed diff). Without the mutation lock the read-modify-write
+    race drops one edit and/or the losing writer's blob overwrites the other's
+    audit entry.
+    """
+    core._save_settings_payload(core._default_settings_payload())
+
+    iterations = 25
+    for n in range(iterations):
+        drawdown_value = 10 + n
+        capital_value = 1000 + n
+
+        barrier = threading.Barrier(2)
+        errors: list[BaseException] = []
+
+        def put_risk() -> None:
+            try:
+                barrier.wait(timeout=5)
+                put_settings_section("risk", {"max_drawdown_pct": drawdown_value})
+            except BaseException as exc:  # pragma: no cover - surfaced via assert
+                errors.append(exc)
+
+        def put_capital() -> None:
+            try:
+                barrier.wait(timeout=5)
+                put_settings_section("initial-capital", {"initial_capital": capital_value})
+            except BaseException as exc:  # pragma: no cover - surfaced via assert
+                errors.append(exc)
+
+        workers = [threading.Thread(target=put_risk), threading.Thread(target=put_capital)]
+        for worker in workers:
+            worker.start()
+        for worker in workers:
+            worker.join(timeout=10)
+
+        assert errors == [], f"worker error on iteration {n}: {errors}"
+
+        # Both edits landed — neither writer clobbered the other's field.
+        blob = _load_settings_payload()
+        assert blob["max_drawdown_pct"] == drawdown_value, f"lost risk edit on iteration {n}"
+        assert blob["initial_capital"] == capital_value, f"lost capital edit on iteration {n}"
+
+        # Both audit entries are present for this iteration, each attributed to
+        # its own field (the diff is not cross-contaminated between requests).
+        audit = blob.get("audit_log") or []
+        drawdown_entries = [
+            e for e in audit
+            if e["id"] == "risk.max_drawdown_pct" and e["to"] == drawdown_value
+        ]
+        capital_entries = [
+            e for e in audit
+            if e["id"] == "initial-capital.initial_capital" and e["to"] == capital_value
+        ]
+        assert drawdown_entries, f"missing risk audit entry on iteration {n}"
+        assert capital_entries, f"missing capital audit entry on iteration {n}"
+        # Each entry changed exactly ONE leaf — its own — so a risk entry never
+        # carries the capital field and vice versa.
+        assert drawdown_entries[-1]["id"] != capital_entries[-1]["id"]
+
+
+def test_concurrent_pipeline_and_section_saves_serialize(forven_db):
+    """A pipeline save and a section save racing must both land."""
+    core._save_settings_payload(core._default_settings_payload())
+
+    for n in range(15):
+        capital_value = 5000 + n
+        wip_value = 3 + (n % 5)
+
+        barrier = threading.Barrier(2)
+        errors: list[BaseException] = []
+
+        def put_section() -> None:
+            try:
+                barrier.wait(timeout=5)
+                put_settings_section("initial-capital", {"initial_capital": capital_value})
+            except BaseException as exc:  # pragma: no cover
+                errors.append(exc)
+
+        def put_pipeline() -> None:
+            try:
+                barrier.wait(timeout=5)
+                put_pipeline_settings(
+                    PipelineSettingsUpdateBody(updates={"paper_wip_cap": wip_value})
+                )
+            except BaseException as exc:  # pragma: no cover
+                errors.append(exc)
+
+        workers = [threading.Thread(target=put_section), threading.Thread(target=put_pipeline)]
+        for worker in workers:
+            worker.start()
+        for worker in workers:
+            worker.join(timeout=10)
+
+        assert errors == [], f"worker error on iteration {n}: {errors}"
+        assert _load_settings_payload()["initial_capital"] == capital_value
+        assert get_pipeline_settings()["paper_wip_cap"] == wip_value
+
+
+# ---------------------------------------------------------------------------
+# 2. Atomicity: a mid-mutation persistence failure leaves NO partial state
+# ---------------------------------------------------------------------------
+
+
+def test_section_save_persistence_failure_is_all_or_nothing(forven_db, monkeypatch):
+    """If the FINAL atomic write raises, neither the main blob nor the secrets
+    blob is left half-updated: the mutation lands whole or not at all.
+    """
+    core._save_settings_payload(core._default_settings_payload())
+    # Establish a known-good baseline for both the main blob and secrets.
+    put_settings_section("risk", {"max_drawdown_pct": 20})
+    baseline_blob = _load_settings_payload()
+    baseline_drawdown = baseline_blob["max_drawdown_pct"]
+    assert baseline_drawdown == 20
+
+    from forven.db import kv_get
+
+    baseline_secrets_raw = kv_get(core._SETTINGS_SECRET_STORAGE_KEY, {})
+
+    # Make the single atomic persist raise, simulating a crash/lock failure
+    # mid-write. Because kv_set_many commits every key on ONE connection, a
+    # failure rolls back the whole transaction — nothing is written.
+    def boom(_items):
+        raise RuntimeError("simulated kv failure mid-mutation")
+
+    monkeypatch.setattr(core, "kv_set_many", boom)
+
+    with pytest.raises(RuntimeError, match="simulated kv failure"):
+        put_settings_section(
+            "hyperliquid",
+            {"actual_wallet_address": "0xdeadbeef", "api_secret_key": "0x" + "a" * 64},
+        )
+
+    monkeypatch.undo()
+
+    # No partial state: the main blob still holds the baseline (the failed
+    # mutation's wallet/drawdown never landed) and the secrets blob is unchanged
+    # (the private key from the failed request was NOT persisted).
+    after_blob = _load_settings_payload()
+    assert after_blob["max_drawdown_pct"] == baseline_drawdown
+    assert after_blob.get("hyperliquid_wallet", "") != "0xdeadbeef"
+    assert after_blob.get("hyperliquid_has_key") is False
+
+    after_secrets_raw = kv_get(core._SETTINGS_SECRET_STORAGE_KEY, {})
+    assert after_secrets_raw == baseline_secrets_raw
+
+
+def test_pipeline_save_persistence_failure_is_all_or_nothing(forven_db, monkeypatch):
+    """A mid-write failure on the pipeline path leaves the payload + WIP-cap
+    mirror untouched (no torn payload-vs-cap state).
+    """
+    baseline_cap = get_pipeline_settings()["paper_wip_cap"]
+
+    from forven.db import kv_get
+
+    baseline_wip_kv = kv_get("pipeline:wip_cap:paper")
+
+    def boom(_items):
+        raise RuntimeError("simulated pipeline kv failure")
+
+    monkeypatch.setattr(core, "kv_set_many", boom)
+
+    with pytest.raises(RuntimeError, match="simulated pipeline kv failure"):
+        put_pipeline_settings(
+            PipelineSettingsUpdateBody(updates={"paper_wip_cap": baseline_cap + 7})
+        )
+
+    monkeypatch.undo()
+
+    # Neither the display payload nor the enforced WIP-cap mirror moved.
+    assert get_pipeline_settings()["paper_wip_cap"] == baseline_cap
+    assert kv_get("pipeline:wip_cap:paper") == baseline_wip_kv
+
+
+# ---------------------------------------------------------------------------
+# 3. The single atomic write really touches BOTH keys together
+# ---------------------------------------------------------------------------
+
+
+def test_section_mutation_writes_secrets_and_blob_in_one_transaction(forven_db, monkeypatch):
+    """A section save that touches a secret persists the secrets blob and the
+    main blob via a SINGLE kv_set_many call (one transaction), not two writes.
+    """
+    core._save_settings_payload(core._default_settings_payload())
+
+    calls: list[dict] = []
+    real_kv_set_many = core.kv_set_many
+
+    def spy(items):
+        calls.append(dict(items))
+        return real_kv_set_many(items)
+
+    monkeypatch.setattr(core, "kv_set_many", spy)
+
+    put_settings_section(
+        "hyperliquid",
+        {"actual_wallet_address": "0xabc", "api_secret_key": "0x" + "b" * 64},
+    )
+
+    # Exactly one atomic persist for the mutation, carrying BOTH keys.
+    persist_calls = [
+        c for c in calls
+        if core._SETTINGS_STORAGE_KEY in c and core._SETTINGS_SECRET_STORAGE_KEY in c
+    ]
+    assert len(persist_calls) == 1
+    assert _load_settings_payload().get("hyperliquid_has_key") is True


### PR DESCRIPTION
## Problem

Settings are the control plane — trading mode, risk caps, gate thresholds — stored across several SQLite KV keys (`forven:settings`, `forven:settings:secrets`, and for pipeline the `save_pipeline_config` key + `forven:pipeline:settings` payload + `pipeline:wip_cap:*` mirrors). Two confirmed integrity problems lived in `forven/api_core.py`:

1. **Read-modify-write race.** `put_settings_section` loaded settings, called `_apply_settings_section` (which itself loaded, mutated, and **saved** internally), reloaded, diffed old-vs-new for the audit log, then **saved again**. Two concurrent section saves could lose one edit entirely, and the audit diff could attribute the other request's changes to the wrong actor. The same read-modify-write shape existed in `put_pipeline_settings`.
2. **Non-atomic multi-key persistence.** One logical mutation wrote the main settings blob and the encrypted-secrets blob (and, for pipeline, the payload plus its WIP-cap mirror) as **separate** `kv_set` calls. A crash or lock failure between writes left enforcement diverged from display.

## Serialization mechanism — and why

**A process-level `threading.RLock` (`_SETTINGS_MUTATION_LOCK`), not a `BEGIN IMMEDIATE` DB transaction, wraps the whole mutation.** The task offered both; I chose the lock deliberately:

- The app is single-process (uvicorn `workers=1`, per the codebase's own operating assumptions), so a process lock genuinely serializes every settings PUT.
- A settings mutation reaches **across modules** whose helpers each open their own `get_db()` connection — `set_execution_mode` / `load_config` / `save_config` (config.json), `update_notification_preferences`, and the encrypted-secrets + main-blob writes. A single `BEGIN IMMEDIATE` transaction can only make writes atomic if **every** write rides the same connection; it cannot enclose those cross-module side effects. The `get_db_immediate` idiom from PR#60 (`brain.transition_stage`) fits a self-contained single-table state transition — not this multi-store fan-out.
- The lock gives the required property directly: two concurrent PUTs serialize, both edits land, and each audit entry (computed against a pre-mutation snapshot taken *inside* the lock) reflects exactly its own request's changes. `RLock` (not `Lock`) so the endpoint can hold it while `_apply_settings_section` runs without any self-deadlock risk from nested calls.

This is surgical — a module-level lock plus a small `kv_set_many` helper — not the "settings service" module extraction, which remains a later project.

## Atomicity guarantee

Added `db.kv_set_many(items)` — writes several KV keys on **one** `get_db()` connection, so the whole set commits or rolls back together.

- **Section saves:** `_apply_settings_section` now computes the audit diff against a deep-copied pre-mutation snapshot and folds `audit_log` into the blob, then persists the **encrypted secrets blob + main blob (audit included) in a single `kv_set_many`**. This replaces the two internal `kv_set` saves *and* the endpoint's third re-read/diff/save. One atomic write per request; a crash can no longer split secrets from the main blob or drop the audit entry.
- **Pipeline saves:** `put_pipeline_settings` writes the pipeline payload + its WIP-cap KV mirror in one `kv_set_many` under the lock, so display and enforced per-stage caps can't tear apart. The `policy.save_pipeline_config` write to `forven:pipeline_thresholds` stays a **distinct** key owned by `forven/policy.py` (out of this change's touch scope) — it is serialized by the lock so no read-modify-write race remains, and it is ordered before the payload write.

## Preserved behavior

Response payloads, HTTPException semantics (**trading-mode 400 / MODE-SPLIT-1** and the null-leaf 400 both intact), beta-build coercion, section validation, and the post-save hooks (scheduler runtime overrides, hyperliquid daemon-recovery cleanup) — those hooks are side effects and stay **outside** the transaction.

## Test evidence

New `tests/test_settings_atomic_mutations.py`:
- **Concurrency:** two threads PUT `risk.max_drawdown_pct` and `initial-capital` simultaneously, x25 iterations behind a `Barrier` → both values always land and the audit log carries both entries with correct per-entry field attribution. **Verified it FAILS** ("lost risk edit on iteration 0") when the lock is neutralized to `nullcontext()`, proving it catches the real race. A second test races a pipeline save against a section save.
- **Atomicity:** monkeypatch the final `kv_set_many` to raise mid-mutation → assert no partial state (secrets blob and main blob both unchanged) for both the section path and the pipeline path.
- **Single-transaction:** a section save touching a secret goes through exactly one `kv_set_many` carrying both keys.

Existing suites stay green **unmodified**: `test_settings_correctness_fixes.py` (incl. MODE-SPLIT-1), `test_settings_audit_log.py`, `test_hyperliquid_settings_fields.py`, `test_throughput_presets.py`, `test_research_settings.py`, plus `test_settings_route_sync.py` and `test_forge_lifecycle_hardening.py` (db.py touched). `ruff check forven tests` clean on the changed files.

## Scope

Touched only `forven/api_core.py`, `forven/db.py` (added `kv_set_many`), and the new test file. No changes to `policy.py`, `brain.py`, `exchange/risk.py`, `daemon.py`, `source_reconciliation.py`, `agents/*`, or `gauntlet/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CBHuQy6taZsvWNwsKig2N
