### PR TITLE
fix(pipeline): reconciliation coverage gaps, brain-callback drops, revival lookahead (P1)

### DIFF
--- a/forven/agents/runner.py
+++ b/forven/agents/runner.py
@@ -620,6 +620,14 @@ async def _call_with_tools_single(
 
 _AGENT_TASK_TIMEOUT_SECONDS = DEFAULT_AGENT_TASK_TIMEOUT_SECONDS  # 15-minute hard wall-clock limit per task
 _BRAIN_CALLBACK_MAX_PENDING = 10  # Don't queue brain callbacks if queue is already this deep
+# A saturated brain queue drops MANY callbacks in quick succession (every agent
+# that completes while the backlog persists), so alert on the coverage problem at
+# most once per window rather than once per drop. Module-level timestamp — reset
+# on process restart, which is the right scope (a fresh backlog deserves a fresh
+# alert). Not persisted to KV: the log_activity/emit_notification records are the
+# durable trail; this only debounces the emit.
+_BRAIN_CALLBACK_DROP_ALERT_COOLDOWN_MINUTES = 30
+_last_brain_callback_drop_alert_ts = 0.0
 
 
 def _walk_exception_chain(error: Exception):
@@ -779,16 +787,56 @@ def _resolve_task_timeout_seconds(task_type: str) -> int:
     return resolve_agent_task_timeout_seconds(task_type, settings=settings)
 
 
+def _emit_brain_callback_drop_alert(agent_id: str, task_title: str, backlog: int) -> None:
+    """Raise a throttled, visible alert that a completion callback was dropped.
+
+    A dropped callback means an agent's finished work is never reviewed by the
+    brain — silent work loss the operator can't see unless it's surfaced. But a
+    saturated queue drops MANY callbacks back-to-back, so debounce on a
+    module-level timestamp: emit at most one alert per cooldown window naming the
+    latest dropped task + the backlog depth (the coverage problem), rather than
+    flooding the alerts panel with one per drop.
+    """
+    global _last_brain_callback_drop_alert_ts
+    now = datetime.now(timezone.utc).timestamp()
+    if now - _last_brain_callback_drop_alert_ts < _BRAIN_CALLBACK_DROP_ALERT_COOLDOWN_MINUTES * 60:
+        return
+    _last_brain_callback_drop_alert_ts = now
+    detail = (
+        f"Brain review queue saturated ({backlog} pending) — completed agent work "
+        f"is not being reviewed. Most recent dropped callback: agent {agent_id} "
+        f"task '{task_title}'. Drain the brain queue or raise the backlog cap."
+    )
+    log_activity("warning", f"agent:{agent_id}", detail)
+    try:
+        from forven.notifications import emit_notification
+
+        emit_notification(
+            "agent_alert",
+            severity="warning",
+            source="agents",
+            title="Brain review queue saturated — agent work unreviewed",
+            summary=f"{backlog} pending; latest drop: {task_title}",
+            body=detail,
+            dedupe_key="brain_callback_backlog",
+        )
+    except Exception:  # a notification-store fault must never break task completion
+        log.debug("Brain callback drop notification failed", exc_info=True)
+
+
 def _maybe_queue_brain_callback(conn, agent_id: str, task: dict, target_channel) -> bool:
     """Queue a brain callback only if the brain queue isn't already overloaded."""
     pending_count = conn.execute(
         "SELECT COUNT(*) as c FROM tasks WHERE type='brain_invoke' AND status='pending'"
     ).fetchone()["c"]
     if pending_count >= _BRAIN_CALLBACK_MAX_PENDING:
-        log.info(
-            "Skipping brain callback for agent %s task '%s' — brain queue full (%d pending)",
-            agent_id, task.get("title", ""), pending_count,
+        task_title = str(task.get("title", "") or "Untitled")
+        log.warning(
+            "Skipping brain callback for agent %s task '%s' — brain queue full (%d pending); "
+            "completed work will not be reviewed until the queue drains",
+            agent_id, task_title, pending_count,
         )
+        _emit_brain_callback_drop_alert(agent_id, task_title, int(pending_count))
         return False
     create_pending_task(
         conn,

--- a/forven/gauntlet/engine.py
+++ b/forven/gauntlet/engine.py
@@ -1291,6 +1291,63 @@ def requeue_stale_engine_artifacts(*, limit: int = 20, revive_limit: int = _ENGI
                     kv_set(marker_key, {"at": now, "action": "skipped_execution_crash", "reason": crash_reason})
                     continue
 
+                # LOOKAHEAD-REENTRY-2: the crash-probe above only catches strategies
+                # that raise on execution — it does NOT catch a future-bar data leak
+                # (e.g. .shift(-1)), which runs cleanly but makes both IS and OOS
+                # slices impossibly good, defeating the overfit/win-rate-trap gates.
+                # The lookahead probe runs at registration intake but not on this
+                # re-entry, so a stale-engine revival would smuggle a leaking
+                # strategy back into quick_screen WITHOUT the causality check every
+                # fresh strategy passes. PR#63 added the same re-probe to the brain's
+                # research-recovery re-entry; mirror it here at the sibling choke
+                # point. Import brain.py's helper lazily (this loop already does that
+                # for transition_stage just below) to avoid the gauntlet<->brain
+                # import cycle. A leak returns a reason string (park archived); an
+                # infra fault returns None (helper fails OPEN — never blocks a
+                # legitimate revival on the probe's own bug).
+                #
+                # The helper needs the strategy's type + params; the candidate row
+                # only carries id + stage, so load them here (the helper itself is
+                # fail-open on an unresolvable class, so a missing row degrades to a
+                # None reason = revive, matching the crash-probe's fail-open stance).
+                lk_stype, lk_params = "", {}
+                try:
+                    with get_db() as conn:
+                        srow = conn.execute(
+                            "SELECT type, params FROM strategies WHERE id = ?", (strategy_id,)
+                        ).fetchone()
+                    if srow is not None:
+                        lk_stype = str(srow["type"] or "").strip()
+                        raw_params = srow["params"]
+                        if isinstance(raw_params, (str, bytes, bytearray)):
+                            import json as _json
+
+                            try:
+                                raw_params = _json.loads(raw_params)
+                            except Exception:
+                                raw_params = {}
+                        lk_params = raw_params if isinstance(raw_params, dict) else {}
+                except Exception:
+                    # A load fault is not evidence of a leak — fall through with the
+                    # empty defaults; the helper fails open on an unresolvable class.
+                    lk_stype, lk_params = "", {}
+
+                from forven.brain import _reentry_lookahead_reason
+
+                lookahead_reason = _reentry_lookahead_reason(strategy_id, lk_stype, lk_params)
+                if lookahead_reason:
+                    log.warning(
+                        "Engine re-baseline: NOT reviving %s — lookahead re-probe rejected: %s",
+                        strategy_id, lookahead_reason,
+                    )
+                    with get_db() as conn:
+                        conn.execute(
+                            "UPDATE strategies SET status_reason = ? WHERE id = ?",
+                            ("lookahead_blocked:tier2:lookahead", strategy_id),
+                        )
+                    kv_set(marker_key, {"at": now, "action": "skipped_lookahead", "reason": lookahead_reason})
+                    continue
+
                 from forven.brain import transition_stage
 
                 # archived -> quick_screen is the standard (ungated) revival

--- a/forven/source_reconciliation.py
+++ b/forven/source_reconciliation.py
@@ -29,16 +29,27 @@ from typing import Any
 import pandas as pd
 
 from forven.data import get_dataset_source, load_parquet, reconcile_close_prices
-from forven.db import get_db, kv_set_best_effort
+from forven.db import get_db, kv_get, kv_set_best_effort
 
 log = logging.getLogger(__name__)
 
 _LIVE_VENUE = "hyperliquid"
 _MIN_OVERLAP_BARS = 20
 _DEFAULT_LOOKBACK_BARS = 500
-# Stages whose strategies bear (or are about to bear) capital — the only ones the
-# divergence gate guards, so the only ones worth reconciling.
+# Stages whose strategies bear (or are about to bear) capital — reconciled FIRST
+# so they always win under the pair cap (a capital-bearing pair must never be
+# starved of a reading by a merely-eligible one).
 _CAPITAL_STAGES = ("gauntlet", "paper", "paper_trading", "live_graduated", "deployed")
+# Pre-capital pipeline stages that WILL hit the gauntlet->paper divergence gate
+# soon and so also need a pre-computed reading — else they reach the gate with no
+# data and get "Source reconciliation pending" indefinitely (the blocker is
+# job-coverage, not real divergence). quick_screen strategies are one promotion
+# from gauntlet; gauntlet is already a capital stage above but listed here too so
+# the coverage-gap accounting (every active-pipeline pair) is exhaustive.
+_PRECAPITAL_STAGES = ("quick_screen",)
+# The full active-pipeline set (quick_screen and up) whose pairs must have a
+# reading for the gate to ever pass — capital stages ordered first for the cap.
+_PIPELINE_STAGES = _CAPITAL_STAGES + _PRECAPITAL_STAGES
 
 
 def divergence_key(symbol: str, timeframe: str) -> str:
@@ -92,23 +103,40 @@ def _ts_close_frame(frame: pd.DataFrame | None) -> pd.DataFrame | None:
 
 
 def _active_symbol_timeframes(limit: int) -> list[tuple[str, str]]:
-    """Distinct ``(symbol, timeframe)`` pairs across capital-bearing strategies.
+    """Distinct ``(symbol, timeframe)`` pairs across the active pipeline.
+
+    Covers not just capital-bearing strategies but the pre-capital stages
+    (``quick_screen``) that will hit the gauntlet->paper divergence gate next — a
+    pair with no stored reading blocks that gate as "pending" forever, so it must
+    be reconciled BEFORE the strategy arrives. Capital-bearing stages are ordered
+    first so that, under the pair ``limit`` cap, a capital pair is never dropped in
+    favour of a merely-eligible one.
 
     Read-only. Timeframe is read per-strategy (not hardcoded) so a 4h strategy is
     reconciled on 4h bars, not 1h.
     """
-    placeholders = ",".join("?" for _ in _CAPITAL_STAGES)
+    placeholders = ",".join("?" for _ in _PIPELINE_STAGES)
+    # ORDER BY: 0 for capital-bearing stages, 1 for the rest — so the LIMIT keeps
+    # capital pairs when the pipeline exceeds the cap. Distinct pairs are collapsed
+    # to their best (lowest) priority so a symbol held BOTH in paper and
+    # quick_screen counts as capital-bearing.
+    capital_placeholders = ",".join("?" for _ in _CAPITAL_STAGES)
     try:
         with get_db() as conn:
             rows = conn.execute(
-                f"""SELECT DISTINCT UPPER(TRIM(symbol)) AS sym,
-                           LOWER(TRIM(COALESCE(NULLIF(timeframe, ''), '1h'))) AS tf
-                    FROM strategies
-                    WHERE symbol IS NOT NULL
-                      AND TRIM(symbol) NOT IN ('', 'GENERIC')
-                      AND stage IN ({placeholders})
+                f"""SELECT sym, tf FROM (
+                        SELECT UPPER(TRIM(symbol)) AS sym,
+                               LOWER(TRIM(COALESCE(NULLIF(timeframe, ''), '1h'))) AS tf,
+                               MIN(CASE WHEN stage IN ({capital_placeholders}) THEN 0 ELSE 1 END) AS prio
+                        FROM strategies
+                        WHERE symbol IS NOT NULL
+                          AND TRIM(symbol) NOT IN ('', 'GENERIC')
+                          AND stage IN ({placeholders})
+                        GROUP BY sym, tf
+                    )
+                    ORDER BY prio, sym, tf
                     LIMIT ?""",
-                (*_CAPITAL_STAGES, int(limit)),
+                (*_CAPITAL_STAGES, *_PIPELINE_STAGES, int(limit)),
             ).fetchall()
     except Exception as exc:
         log.warning("source-reconciliation: could not list active symbols: %s", exc)
@@ -120,6 +148,61 @@ def _active_symbol_timeframes(limit: int) -> list[tuple[str, str]]:
         if sym and sym != "GENERIC":
             pairs.append((sym, tf))
     return pairs
+
+
+def _all_pipeline_pairs() -> list[tuple[str, str]]:
+    """Every distinct active-pipeline ``(symbol, timeframe)`` pair, uncapped.
+
+    Used ONLY for coverage-gap accounting after a sweep — unlike
+    ``_active_symbol_timeframes`` (which is capped at the reconcile ``limit``),
+    this returns the full set so a pair silently dropped under the cap still shows
+    up as an uncovered blocker.
+    """
+    placeholders = ",".join("?" for _ in _PIPELINE_STAGES)
+    try:
+        with get_db() as conn:
+            rows = conn.execute(
+                f"""SELECT DISTINCT UPPER(TRIM(symbol)) AS sym,
+                           LOWER(TRIM(COALESCE(NULLIF(timeframe, ''), '1h'))) AS tf
+                    FROM strategies
+                    WHERE symbol IS NOT NULL
+                      AND TRIM(symbol) NOT IN ('', 'GENERIC')
+                      AND stage IN ({placeholders})""",
+                (*_PIPELINE_STAGES,),
+            ).fetchall()
+    except Exception as exc:
+        log.warning("source-reconciliation: could not list pipeline pairs: %s", exc)
+        return []
+    out: list[tuple[str, str]] = []
+    for row in rows:
+        sym = str(row["sym"] or "").strip().upper()
+        tf = str(row["tf"] or "1h").strip().lower() or "1h"
+        if sym and sym != "GENERIC":
+            out.append((sym, tf))
+    return out
+
+
+def _coverage_gap_pairs() -> list[tuple[str, str]]:
+    """Active-pipeline pairs with NO stored divergence reading at all.
+
+    A gauntlet->paper promotion reads the pre-computed reading cache-only and, when
+    ``block_when_missing`` is set (the capital-path default), blocks as "Source
+    reconciliation pending" until a reading exists. If the JOB never produced one
+    for a pair — because the pair only just entered the pipeline, or was dropped
+    under the reconcile cap — that "pending" is a COVERAGE problem, not real
+    divergence, and nothing otherwise tells the operator which it is. This lists
+    those uncovered pairs so the sweep can name them.
+
+    "No stored reading" = the KV key is absent. A pair the job DID reach (even with
+    an ``insufficient_overlap``/``fetch_error``/``same_venue`` status) is not a
+    coverage gap — the job covered it; any remaining block is a data/gate matter,
+    not a scheduling one.
+    """
+    gaps: list[tuple[str, str]] = []
+    for symbol, timeframe in _all_pipeline_pairs():
+        if not isinstance(kv_get(divergence_key(symbol, timeframe)), dict):
+            gaps.append((symbol, timeframe))
+    return gaps
 
 
 def reconcile_one(
@@ -256,6 +339,43 @@ def run_source_reconciliation_job(
                 f"Source reconciliation: {summary['pairs']} series checked "
                 f"({summary['ok']} ok, {summary['insufficient']} low-overlap, {summary['errors']} errors)",
                 {"action": "source_reconciliation", **summary},
+            )
+        except Exception:
+            pass
+
+    # Coverage-gap surfacing: an active-pipeline pair with NO stored reading will
+    # hit the gauntlet->paper divergence gate and stick on "Source reconciliation
+    # pending" indefinitely — a JOB-COVERAGE blocker, not real divergence. Name the
+    # uncovered pairs so the operator sees which it is (e.g. a pair dropped under
+    # the reconcile cap, which the operator can fix by raising the cap).
+    try:
+        gaps = _coverage_gap_pairs()
+    except Exception as exc:
+        log.debug("source-reconciliation: coverage-gap scan failed: %s", exc)
+        gaps = []
+    summary["coverage_gaps"] = len(gaps)
+    if gaps:
+        preview = ", ".join(f"{sym} {tf}" for sym, tf in gaps[:20])
+        more = "" if len(gaps) <= 20 else f" (+{len(gaps) - 20} more)"
+        log.warning(
+            "source-reconciliation: %d active-pipeline pair(s) have NO divergence reading — "
+            "they will block the gauntlet->paper gate as 'pending' until reconciled: %s%s",
+            len(gaps), preview, more,
+        )
+        try:
+            from forven.db import log_activity
+
+            log_activity(
+                "warning",
+                "data",
+                f"Source reconciliation: {len(gaps)} pipeline pair(s) have no divergence "
+                f"reading — gate will block them as 'pending' (coverage gap, not divergence): "
+                f"{preview}{more}",
+                {
+                    "action": "source_reconciliation_coverage_gap",
+                    "gap_count": len(gaps),
+                    "pairs": [f"{sym}:{tf}" for sym, tf in gaps],
+                },
             )
         except Exception:
             pass

--- a/tests/test_brain_callback_drop_alert.py
+++ b/tests/test_brain_callback_drop_alert.py
@@ -1,0 +1,110 @@
+"""Brain-callback drop visibility (BRAIN-CALLBACK-DROP-1).
+
+When an agent completes work, a ``brain_invoke`` review callback is queued so the
+brain reviews the output and takes next steps. If the brain queue is already deep
+(>= _BRAIN_CALLBACK_MAX_PENDING pending), the callback is SKIPPED — the agent's
+finished work is then never reviewed. This used to be a silent ``log.info`` drop.
+
+It now emits a VISIBLE, throttled alert (log.warning + a log_activity warning + a
+notification) naming the dropped task + backlog size, so the operator can see the
+work-loss. Because a saturated queue drops MANY callbacks back-to-back, the alert
+is debounced on a module-level timestamp: at most one per cooldown window.
+"""
+
+from __future__ import annotations
+
+import forven.agents.runner as runner
+from forven.db import get_db
+
+
+class _FakeCursor:
+    def __init__(self, count):
+        self._count = count
+
+    def fetchone(self):
+        return {"c": self._count}
+
+
+class _FakeConn:
+    """A conn whose COUNT(*) of pending brain callbacks is forced over the cap, so
+    _maybe_queue_brain_callback always takes the drop branch."""
+
+    def __init__(self, pending):
+        self.pending = pending
+        self.created = []
+
+    def execute(self, sql, *args):
+        return _FakeCursor(self.pending)
+
+
+def _reset_throttle(monkeypatch):
+    # Fresh throttle window per test — the module-level timestamp persists across
+    # tests in the same process otherwise.
+    monkeypatch.setattr(runner, "_last_brain_callback_drop_alert_ts", 0.0)
+
+
+def _activity_warnings(agent_id):
+    with get_db() as conn:
+        return conn.execute(
+            "SELECT level, message FROM activity_log WHERE source = ?",
+            (f"agent:{agent_id}",),
+        ).fetchall()
+
+
+def test_backlog_drop_emits_warning_and_alert_once(forven_db, monkeypatch, caplog):
+    _reset_throttle(monkeypatch)
+    from forven.notifications import list_notifications
+
+    conn = _FakeConn(pending=runner._BRAIN_CALLBACK_MAX_PENDING + 5)
+    task = {"id": "7", "title": "Investigate SOL breakout"}
+
+    with caplog.at_level("WARNING", logger="forven.agents.runner"):
+        queued = runner._maybe_queue_brain_callback(conn, "quant-researcher", task, None)
+
+    # Dropped (not queued) ...
+    assert queued is False
+    # ... with a log.warning naming the task + backlog ...
+    assert any("brain queue full" in r.message.lower() or "queue full" in r.message.lower()
+               for r in caplog.records), [r.message for r in caplog.records]
+    # ... a visible activity warning ...
+    rows = _activity_warnings("quant-researcher")
+    assert len(rows) == 1
+    assert rows[0]["level"] == "warning"
+    assert "Investigate SOL breakout" in rows[0]["message"]
+    assert str(runner._BRAIN_CALLBACK_MAX_PENDING + 5) in rows[0]["message"]
+    # ... and a notification.
+    items = list_notifications(limit=20)
+    assert any("brain review queue" in str(n.get("title", "")).lower() for n in items), items
+
+
+def test_second_drop_within_window_does_not_duplicate(forven_db, monkeypatch):
+    _reset_throttle(monkeypatch)
+
+    conn = _FakeConn(pending=runner._BRAIN_CALLBACK_MAX_PENDING + 1)
+    runner._maybe_queue_brain_callback(conn, "quant-researcher", {"id": "1", "title": "First"}, None)
+    # A saturated queue drops many callbacks in a row — the SECOND drop inside the
+    # cooldown window must NOT emit another alert.
+    runner._maybe_queue_brain_callback(conn, "quant-researcher", {"id": "2", "title": "Second"}, None)
+
+    rows = _activity_warnings("quant-researcher")
+    assert len(rows) == 1  # throttled, not one-per-drop
+    assert "First" in rows[0]["message"]  # the first drop's alert, not the second
+
+
+def test_healthy_queue_still_queues_the_callback(forven_db, monkeypatch):
+    _reset_throttle(monkeypatch)
+    created = {}
+
+    def _fake_create_pending_task(conn, task_type, payload, **kw):
+        created["type"] = task_type
+        created["payload"] = payload
+
+    monkeypatch.setattr(runner, "create_pending_task", _fake_create_pending_task)
+
+    conn = _FakeConn(pending=0)  # queue not full
+    queued = runner._maybe_queue_brain_callback(conn, "quant-researcher", {"id": "9", "title": "OK"}, None)
+
+    assert queued is True
+    assert created["type"] == "brain_invoke"
+    # No drop alert when the callback was actually queued.
+    assert _activity_warnings("quant-researcher") == []

--- a/tests/test_lookahead_leak_gates.py
+++ b/tests/test_lookahead_leak_gates.py
@@ -293,3 +293,123 @@ def test_detect_lookahead_blocks_strategy_originated_probe_errors():
     reason = detect_lookahead(_Boom())
     assert reason is not None
     assert "causal execution could not be verified" in reason
+
+
+# ================= GATE B: engine-revival re-entry (LOOKAHEAD-REENTRY-2) =================
+# PR#63 added a lookahead re-probe to the brain's research-recovery re-entry
+# (brain.try_research_recovery via brain._reentry_lookahead_reason). The OTHER
+# re-entry path — the engine-version-staleness revival in
+# gauntlet.engine.requeue_stale_engine_artifacts — gated only on
+# detect_execution_crash (a raise), so a clean-running future-bar leak could be
+# revived back into quick_screen WITHOUT the causality check. It now runs the same
+# re-probe at that choke point. These tests mirror the brain-recovery tests: a leak
+# blocks the revival (archived, status_reason lookahead_blocked:tier2:lookahead); an
+# inconclusive probe (helper returns None) never blocks a legitimate revival.
+
+from forven.db import create_strategy_container, kv_get  # noqa: E402
+from forven.engine_provenance import BACKTEST_ENGINE_VERSION  # noqa: E402
+
+_STALE_VERSION = BACKTEST_ENGINE_VERSION + 1000  # explicitly stamped, never current
+
+
+def _revival_strategy(stage="archived", name="Revival Leak Test"):
+    with get_db() as conn:
+        strategy_id, _display_id, _base_id = create_strategy_container(
+            conn=conn,
+            name=name,
+            type_="rsi_momentum",
+            symbol="ETH/USDT",
+            timeframe="1h",
+            params={"rsi_period": 14},
+            stage="quick_screen",
+        )
+        if stage != "quick_screen":
+            conn.execute(
+                "UPDATE strategies SET stage = ?, stage_changed_at = ? WHERE id = ?",
+                (stage, datetime.now(timezone.utc).isoformat(), strategy_id),
+            )
+    return strategy_id
+
+
+def _insert_stale_verdict(strategy_id, *, result_id, verdict="FAIL"):
+    from forven.api_core import _persist_backtest_result_row
+
+    _persist_backtest_result_row(
+        result_id=result_id,
+        strategy_id=strategy_id,
+        result_type="walk_forward",
+        symbol="ETH/USDT",
+        timeframe="1h",
+        start_date=None,
+        end_date=None,
+        metrics={"status": "succeeded", "verdict": verdict},
+        config={"status": "succeeded", "engine_version": _STALE_VERSION},
+    )
+
+
+def _make_failed_gate_archive(name):
+    """An archived strategy with a failed_gate workflow + a stale-engine verdict —
+    exactly the shape the revival sweep would otherwise un-archive."""
+    from forven.gauntlet.settings import build_settings_snapshot
+    from forven.gauntlet.store import create_or_get_workflow
+
+    strategy_id = _revival_strategy(stage="archived", name=name)
+    workflow = create_or_get_workflow(
+        strategy_id=strategy_id, created_by="pytest", settings_snapshot=build_settings_snapshot()
+    )
+    with get_db() as conn:
+        conn.execute(
+            "UPDATE gauntlet_workflows SET status = 'failed_gate' WHERE id = ?", (workflow["id"],)
+        )
+    _insert_stale_verdict(strategy_id, result_id=f"r-{name}", verdict="FAIL")
+    return strategy_id, workflow["id"]
+
+
+def _stage_of(strategy_id):
+    with get_db() as conn:
+        row = conn.execute("SELECT stage, status_reason FROM strategies WHERE id = ?", (strategy_id,)).fetchone()
+    return row["stage"], row["status_reason"]
+
+
+def test_engine_revival_blocks_lookahead_leak(forven_db, monkeypatch):
+    """A stale-engine revival candidate whose re-probe reports a leak is NOT
+    revived: it stays archived with the lookahead status_reason and a
+    skipped_lookahead marker (mirrors the crash-probe skip)."""
+    import forven.brain as brain
+    from forven.gauntlet.engine import requeue_stale_engine_artifacts
+
+    strategy_id, _wf = _make_failed_gate_archive("leak-revival")
+    # Force the re-probe (imported lazily from brain inside the sweep) to report a
+    # leak — mock the source so the test is deterministic and offline.
+    monkeypatch.setattr(
+        brain, "_reentry_lookahead_reason",
+        lambda sid, stype, params: "Lookahead leak: causal signal flips when future bars withheld",
+    )
+
+    summary = requeue_stale_engine_artifacts(limit=10)
+
+    assert summary["revived"] == 0
+    stage, status_reason = _stage_of(strategy_id)
+    assert stage == "archived"
+    assert status_reason == "lookahead_blocked:tier2:lookahead"
+    marker = kv_get(f"forven:engine_rebaseline:v{BACKTEST_ENGINE_VERSION}:{strategy_id}")
+    assert marker and marker["action"] == "skipped_lookahead"
+
+
+def test_engine_revival_proceeds_when_probe_is_clean(forven_db, monkeypatch):
+    """A clean re-probe (helper returns None — no leak, or an inconclusive infra
+    fault) never blocks a legitimate revival: the strategy is revived normally."""
+    import forven.brain as brain
+    from forven.gauntlet.engine import requeue_stale_engine_artifacts
+
+    strategy_id, _wf = _make_failed_gate_archive("clean-revival")
+    # None = no leak / inconclusive — the sweep must revive as before.
+    monkeypatch.setattr(brain, "_reentry_lookahead_reason", lambda sid, stype, params: None)
+
+    summary = requeue_stale_engine_artifacts(limit=10)
+
+    assert summary["revived"] == 1
+    stage, _status_reason = _stage_of(strategy_id)
+    assert stage == "quick_screen"
+    marker = kv_get(f"forven:engine_rebaseline:v{BACKTEST_ENGINE_VERSION}:{strategy_id}")
+    assert marker and marker["action"] == "revived"

--- a/tests/test_source_reconciliation_gate.py
+++ b/tests/test_source_reconciliation_gate.py
@@ -382,3 +382,83 @@ def test_measured_divergence_rejection_still_counts(forven_db):
     ok, _ = evaluate_promotion("S-DIV", "gauntlet", "paper", record_rejection=True)
     assert ok is False
     assert {r["reason_code"] for r in _rejection_rows("S-DIV")} == {"source_divergence_reject"}
+
+
+# --------------------------- coverage asymmetry (job discovery) ---------------------------
+# The precompute job originally scanned only capital-bearing stages, but the gate
+# fires at gauntlet->paper for pairs that may not be covered yet (a quick_screen
+# strategy one promotion from gauntlet, or a gauntlet pair whose symbol has no
+# prior capital strategy). Those pairs then hit the gate with no reading and stick
+# on "Source reconciliation pending" forever, with nothing telling the operator the
+# blocker is JOB COVERAGE, not divergence. The job now (a) discovers pre-capital
+# pipeline pairs too (capital pairs ordered first under the cap) and (b) names any
+# uncovered active-pipeline pair after each sweep.
+
+
+def _activity_rows(source="data"):
+    with get_db() as conn:
+        return conn.execute(
+            "SELECT level, message, data FROM activity_log WHERE source = ? ORDER BY id",
+            (source,),
+        ).fetchall()
+
+
+def test_quick_screen_pair_enters_the_sweep_plan(forven_db):
+    """A quick_screen strategy's (symbol, timeframe) must be discovered for
+    reconciliation — it is one promotion from the gate that reads the reading."""
+    _seed_strategy(strategy_id="S-QS", symbol="LINK/USDT", timeframe="4h", stage="quick_screen")
+    pairs = sr._active_symbol_timeframes(limit=200)
+    assert ("LINK/USDT", "4h") in pairs
+
+
+def test_capital_pairs_win_under_the_cap(forven_db):
+    """Under a tight pair cap, capital-bearing stages are reconciled FIRST so a
+    quick_screen pair never starves a paper pair of its reading."""
+    _seed_strategy(strategy_id="S-PAPER", symbol="BTC/USDT", timeframe="1h", stage="paper")
+    _seed_strategy(strategy_id="S-QS", symbol="ETH/USDT", timeframe="1h", stage="quick_screen")
+    # limit=1 must keep the capital-bearing (paper) pair, not the quick_screen one.
+    pairs = sr._active_symbol_timeframes(limit=1)
+    assert pairs == [("BTC/USDT", "1h")]
+
+
+def test_symbol_held_in_both_capital_and_precapital_counts_as_capital(forven_db):
+    """A pair present in BOTH a capital stage and quick_screen collapses to its
+    capital priority, so it is never dropped in favour of a pure-precapital pair."""
+    _seed_strategy(strategy_id="S-PAPER", symbol="BTC/USDT", timeframe="1h", stage="paper")
+    _seed_strategy(strategy_id="S-QS-DUP", symbol="BTC/USDT", timeframe="1h", stage="quick_screen")
+    _seed_strategy(strategy_id="S-QS-OTHER", symbol="ETH/USDT", timeframe="1h", stage="quick_screen")
+    pairs = sr._active_symbol_timeframes(limit=1)
+    assert pairs == [("BTC/USDT", "1h")]
+
+
+def test_coverage_gap_warns_on_uncovered_pipeline_pair(forven_db, monkeypatch):
+    """An active-pipeline pair with NO stored reading produces the coverage-gap
+    warning (log.warning + a 'coverage_gap' activity row), so 'pending' blockers
+    read as a coverage problem, not divergence."""
+    _seed_strategy(strategy_id="S-GAP", symbol="DOGE/USDT", timeframe="1h", stage="quick_screen")
+    # Neutralize the actual reconcile so the test is deterministic and offline: the
+    # pair is discovered but no reading is written, leaving a coverage gap.
+    monkeypatch.setattr(
+        sr, "reconcile_one",
+        lambda *a, **k: {"status": "fetch_error", "symbol": a[0], "timeframe": a[1]},
+    )
+    monkeypatch.setattr(sr, "kv_set_best_effort", lambda *a, **k: True)  # persist nothing
+
+    summary = sr.run_source_reconciliation_job()
+
+    assert summary["coverage_gaps"] >= 1
+    gap_rows = [r for r in _activity_rows("data")
+                if "source_reconciliation_coverage_gap" in str(r["data"] or "")]
+    assert len(gap_rows) == 1
+    assert gap_rows[0]["level"] == "warning"
+    assert "DOGE/USDT" in gap_rows[0]["message"]
+
+
+def test_no_coverage_gap_when_reading_exists(forven_db):
+    """A pair WITH a stored reading is not a coverage gap — no gap warning."""
+    _seed_strategy(strategy_id="S-COV", symbol="BTC/USDT", timeframe="1h", stage="gauntlet")
+    _seed_divergence("BTC/USDT", "1h", status="ok", max_pct=0.3)
+
+    gaps = sr._coverage_gap_pairs()
+
+    assert ("BTC/USDT", "1h") not in gaps


### PR DESCRIPTION
Three small P1 fixes in one PR. Touches only `forven/source_reconciliation.py`, `forven/agents/runner.py`, `forven/gauntlet/engine.py`, and test files.

## FIX 1 — Source-reconciliation coverage asymmetry
`forven/source_reconciliation.py`

The precompute job discovered `(symbol, timeframe)` pairs only from **capital-bearing** stages, but the promotion gate (`_evaluate_source_divergence_gate`) fires at **gauntlet→paper** for pairs that may not be covered yet — e.g. a `quick_screen` strategy one promotion from gauntlet, or a gauntlet pair on a symbol with no prior capital strategy. Those hit the gate with **no reading** and stuck on "Source reconciliation pending" indefinitely, with nothing telling the operator the blocker was **job coverage**, not real divergence.

- `_active_symbol_timeframes` now scans the full active pipeline (`quick_screen` + capital stages). Capital-bearing stages are ordered **first** (SQL `ORDER BY prio` where capital=0, else 1; distinct pairs collapse to their best priority) so a capital pair is never dropped under the `limit` cap in favour of a merely-eligible one.
- After each sweep, `_coverage_gap_pairs()` lists active-pipeline pairs (uncapped) with **no stored reading** and, if non-empty, `log.warning` + `log_activity("warning","data",...)` names them under a distinct `source_reconciliation_coverage_gap` action. `summary["coverage_gaps"]` is added.

## FIX 2 — Brain-callback silent drop
`forven/agents/runner.py`

`_maybe_queue_brain_callback` silently `log.info`-skipped the review callback when the brain queue was `>= _BRAIN_CALLBACK_MAX_PENDING` deep — agent work completed but was never reviewed and nobody was told.

- On drop: `log.warning` **and** a visible alert (`log_activity` warning + `emit_notification`) naming the dropped task + backlog size.
- Throttled to **one alert per 30-min window** via a module-level timestamp (`_last_brain_callback_drop_alert_ts`) — a saturated queue drops many callbacks in a row, so it debounces rather than flooding. Notification store faults never break task completion.

## FIX 3 — Engine revival path lookahead blind spot
`forven/gauntlet/engine.py`

PR#63 added a lookahead re-probe to the brain's research-recovery re-entry. The **other** re-entry path — the engine-version-staleness revival in `requeue_stale_engine_artifacts` — still gated only on `detect_execution_crash` (a raise), so a **clean-running future-bar leak** could be revived back into `quick_screen` without the causality check every fresh strategy passes.

- Mirrors PR#63 exactly: re-probe via `brain._reentry_lookahead_reason` (imported **lazily inside the function** — the established cycle-avoidance pattern, same as the existing `from forven.brain import transition_stage` a few lines below).
- A leak → strategy **not** revived, stays archived, `status_reason = lookahead_blocked:tier2:lookahead`, marker `skipped_lookahead`. Infra faults stay inconclusive (helper fails open). `forven/brain.py` is **not edited** — import only.

## Tests
New / extended regression tests:
- `tests/test_source_reconciliation_gate.py`: quick_screen pair enters the sweep plan; capital pairs win under the cap; dual-stage symbol counts as capital; uncovered pair produces the coverage-gap warning; a covered pair does not.
- `tests/test_lookahead_leak_gates.py`: revival blocks a lookahead leak (archived + status_reason + marker); revival proceeds when the probe is clean.
- `tests/test_brain_callback_drop_alert.py` (new): backlog drop emits warning + activity + notification once; second drop within the window does not duplicate; healthy queue still queues the callback.

**Results:** all new tests pass (10/10). Full runs of the touched files + `test_engine_provenance.py` and agent/runner test files pass. `ruff check forven tests` clean. The only failures in `test_source_reconciliation_gate.py` are the 3 pre-existing environmental ones (`test_reconcile_one_ok_low_divergence` / `_high_divergence` / `_fetch_error`) called out as ignore-list in the task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CBHuQy6taZsvWNwsKig2N
