### PR TITLE
fix(risk): P1 operational integrity — drain-aware equity cache + durable failed-open cooldown

### DIFF
--- a/forven/control_plane/ops.py
+++ b/forven/control_plane/ops.py
@@ -996,7 +996,17 @@ def post_equity_rebaseline(body: ConfirmBody) -> dict[str, object]:
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    return {"ok": True, "equity": equity, **result}
+    # DRAIN-1: also purge the daemon's last-known-good book-equity cache. Without
+    # this, a wallet the operator intentionally drained keeps getting its stale
+    # balance substituted from cache on the next tick, re-inflating the aggregate
+    # the operator just re-baselined away — the recovery path wouldn't fully reset.
+    try:
+        from forven.daemon import clear_book_equity_cache
+        cleared = clear_book_equity_cache()
+    except Exception as exc:
+        log.warning("Equity re-baseline: could not clear book-equity cache: %s", exc)
+        cleared = 0
+    return {"ok": True, "equity": equity, "book_equity_cache_cleared": cleared, **result}
 
 
 def post_kill_switch_toggle(body: dict) -> dict[str, object]:

--- a/forven/daemon.py
+++ b/forven/daemon.py
@@ -170,6 +170,35 @@ _BOOK_EQUITY_CACHE: dict[str, float] = {}
 _LAST_BOOKS_ENABLED: bool = False
 _BOOKS_DISABLED_STREAK: int = 0
 _BOOKS_OFF_CONFIRM_TICKS: int = 3
+# DRAIN-1: per-account CLEAN-zero streak. A read that SUCCEEDS (no exception) and
+# reports ~0 equity is TRUTH — an operator draining/defunding a wallet — not a
+# transient glitch. Substituting last-known-good forever keeps the aggregate
+# inflated and the HWM high; when the cache finally clears (restart) the sudden
+# drop computes a phantom drawdown and trips a false kill-switch. So after a few
+# CONSECUTIVE clean-zero reads on an account that previously had funds we ACCEPT
+# the zero, purge its cache entry, and signal the risk engine to re-baseline the
+# step-down (a drain, not a loss). A raised/errored read never counts toward this
+# streak (that stays on the last-known-good path); a positive read resets it.
+# The streak requirement — not the magnitude — is what distinguishes a drain from
+# a trading loss, so a genuine loss still flows through as drawdown.
+_BOOK_CLEAN_ZERO_STREAK: dict[str, int] = {}
+_BOOK_CLEAN_ZERO_CONFIRM_TICKS: int = 3
+
+
+def clear_book_equity_cache() -> int:
+    """DRAIN-1: purge the per-account last-known-good equity cache (and clean-zero
+    streaks). The operator equity re-baseline action calls this so the documented
+    recovery path fully resets the stale substitution state — otherwise a wallet
+    the operator intentionally drained keeps getting its old balance substituted
+    from cache, re-inflating the aggregate the operator just re-baselined away.
+    Returns the number of cached account entries cleared."""
+    n = len(_BOOK_EQUITY_CACHE)
+    _BOOK_EQUITY_CACHE.clear()
+    _BOOK_CLEAN_ZERO_STREAK.clear()
+    if n:
+        log.info("book equity: cleared %d cached last-known-good account entr%s (operator re-baseline)",
+                 n, "y" if n == 1 else "ies")
+    return n
 
 
 def _env_float(name: str, default: float, minimum: float = 0.1) -> float:
@@ -1189,6 +1218,7 @@ def _book_aware_account_value(testnet: bool = True) -> dict | None:
     skips this tick rather than acting on incomplete data.
     """
     global _LAST_BOOKS_ENABLED, _BOOKS_DISABLED_STREAK
+    drain_accepted = False  # DRAIN-1: a clean-zero streak purged an inflated cache this tick
     try:
         from forven.exchange import books
 
@@ -1272,6 +1302,7 @@ def _book_aware_account_value(testnet: bool = True) -> dict | None:
                 err_reason = f"{type(exc).__name__}: {exc}"
             if val > 0:
                 _BOOK_EQUITY_CACHE[key] = val  # last-known-good
+                _BOOK_CLEAN_ZERO_STREAK.pop(key, None)  # DRAIN-1: real funds -> reset streak
                 total_val += val
                 books_equity[label] = round(val, 2)
                 breakdown.append(f"{key}=${val:,.2f}(live)")
@@ -1282,17 +1313,51 @@ def _book_aware_account_value(testnet: bool = True) -> dict | None:
                 if raised:
                     read_failed = True
                 cached = _BOOK_EQUITY_CACHE.get(key)
-                if cached is not None and cached > 0:
-                    # Had funds before, now reads 0/failed => transient glitch.
-                    # Substitute last-known-good so it can't fake a drawdown.
+                # DRAIN-1: a read that SUCCEEDED and reports ~0 is a CLEAN zero
+                # (truth), not a transient glitch. Track a consecutive-clean-zero
+                # streak per account; a raised/errored read is NOT clean and never
+                # advances (or resets) it — that path keeps riding last-known-good.
+                clean_zero = (not raised)
+                if clean_zero:
+                    zstreak = _BOOK_CLEAN_ZERO_STREAK.get(key, 0) + 1
+                    _BOOK_CLEAN_ZERO_STREAK[key] = zstreak
+                else:
+                    zstreak = _BOOK_CLEAN_ZERO_STREAK.get(key, 0)
+                if (
+                    cached is not None and cached > 0
+                    and clean_zero
+                    and zstreak >= _BOOK_CLEAN_ZERO_CONFIRM_TICKS
+                ):
+                    # Confirmed drain: the exchange has reported ~0 for this account
+                    # cleanly N times running. Accept the zero, PURGE the stale
+                    # last-known-good so it stops inflating the aggregate, and flag
+                    # the tick so the risk engine re-baselines the step-down instead
+                    # of counting an operator drain as a drawdown (see update_equity's
+                    # rebaseline hook). A raised read never reaches here.
+                    _BOOK_EQUITY_CACHE.pop(key, None)
+                    _BOOK_CLEAN_ZERO_STREAK.pop(key, None)
+                    drain_accepted = True
+                    books_equity[label] = 0.0
+                    breakdown.append(f"{key}=$0(DRAINED,{zstreak} clean reads)")
+                    log.warning(
+                        "book equity: ACCEPTED clean-zero DRAIN for %s after %d "
+                        "consecutive clean reads — purged cached $%.2f; re-baselining "
+                        "the equity step-down (operator drain, not a drawdown)",
+                        key, zstreak, cached,
+                    )
+                elif cached is not None and cached > 0:
+                    # Had funds before, now reads 0/failed but not yet a confirmed
+                    # drain => transient glitch (or a drain still building its
+                    # streak). Substitute last-known-good so it can't fake a drawdown.
                     total_val += cached
                     books_equity[label] = round(float(cached), 2)
                     substituted = True
-                    breakdown.append(f"{key}=${cached:,.2f}(CACHED)")
+                    _zsuffix = f", clean-zero streak {zstreak}/{_BOOK_CLEAN_ZERO_CONFIRM_TICKS}" if clean_zero else ""
+                    breakdown.append(f"{key}=${cached:,.2f}(CACHED{_zsuffix})")
                     log.warning(
-                        "book equity: SUBSTITUTED cached $%.2f for %s (live read %s) — "
+                        "book equity: SUBSTITUTED cached $%.2f for %s (live read %s%s) — "
                         "stale cache can poison the aggregate",
-                        cached, key, err_reason or "returned 0/non-positive",
+                        cached, key, err_reason or "returned 0/non-positive", _zsuffix,
                     )
                 elif raised:
                     # Read ERRORED with no history => genuinely unknown; skip tick.
@@ -1302,7 +1367,8 @@ def _book_aware_account_value(testnet: bool = True) -> dict | None:
                     # else: read returned 0 with no history => a legitimately EMPTY
                     # account (e.g. master drained, all capital in the sub-accounts).
                     # Count it as $0 — do NOT mark unreliable, or the daemon could
-                    # never compute equity for a valid empty-master config.
+                    # never compute equity for a valid empty-master config. No cache
+                    # to purge, so the clean-zero streak just harmlessly accrues.
                     breakdown.append(f"{key}=$0(empty)")
         if unreliable or total_val <= 0:
             log.warning(
@@ -1322,6 +1388,9 @@ def _book_aware_account_value(testnet: bool = True) -> dict | None:
             "totalRawUsd": total_val,
             "source": source_label,
             "books": books_equity,
+            # DRAIN-1: signals update_equity to re-baseline the (lower) step-down
+            # instead of computing a drawdown against the pre-drain HWM.
+            "drain_accepted": drain_accepted,
         }
     except Exception:
         # Hard failure: skip rather than fall back to a master-only value that
@@ -1461,6 +1530,10 @@ async def _run_risk_cycle() -> dict:
             return snapshot
         snapshot["equity"] = equity
         equity_source = acct.get("source", "exchange")
+        # DRAIN-1: an accepted clean-zero drain is a genuine step-down in at-risk
+        # capital, not a loss — re-baseline the HWM/daily start to it so the drop
+        # can't compute a phantom drawdown and trip the kill-switch.
+        drain_accepted = bool(acct.get("drain_accepted"))
 
         risk_check = await _to_thread_with_timeout(
             "daemon.update_equity",
@@ -1468,6 +1541,7 @@ async def _run_risk_cycle() -> dict:
             update_equity,
             equity,
             equity_source,
+            rebaseline=drain_accepted,
         )
         if not isinstance(risk_check, dict):
             return snapshot

--- a/forven/exchange/risk.py
+++ b/forven/exchange/risk.py
@@ -315,6 +315,87 @@ def _get_failed_open_window_hours(settings: dict) -> float:
     return max(0.0, hours)
 
 
+# RETRY-STORM-2: in-memory fallback for the failed-open cooldown. The DB FAILED
+# mark is what the cooldown query below reads; if that write is dropped (a busy /
+# locked DB while the scanner is hammering it), the trade never shows FAILED, the
+# cooldown never engages, and the scanner re-submits a REAL order every tick — a
+# retry-storm against the exchange with possible duplicate exposure. So the
+# failure-marking path (scanner._fail_unfilled_open_trade) ALSO records the failed
+# open here, keyed by (strategy, asset, direction) -> last-failure timestamp, and
+# this cooldown check consults it alongside the DB. It only holds within this
+# process (a restart both wipes it AND re-reads the DB), which is exactly the
+# window the DB write was meant to cover. Bounded: expired entries are pruned on
+# every read/write so the map can't grow without bound.
+_FAILED_OPEN_INMEM_COOLDOWN: dict[tuple[str, str, str], datetime] = {}
+_FAILED_OPEN_INMEM_LOCK = threading.Lock()
+# Absolute cap so a pathological churn of distinct keys can't grow the map even
+# before any entry expires; oldest entries are evicted first.
+_FAILED_OPEN_INMEM_MAX_ENTRIES = 512
+
+
+def _failed_open_inmem_key(strategy: str, asset: str, direction: str) -> tuple[str, str, str]:
+    return (
+        str(strategy or "").strip(),
+        str(asset or "").strip().upper(),
+        str(direction or "long").strip().lower() or "long",
+    )
+
+
+def _prune_failed_open_inmem(now: datetime, window_seconds: float) -> None:
+    """Drop entries older than the cooldown window (caller holds the lock)."""
+    if window_seconds <= 0:
+        _FAILED_OPEN_INMEM_COOLDOWN.clear()
+        return
+    stale = [
+        key for key, ts in _FAILED_OPEN_INMEM_COOLDOWN.items()
+        if (now - ts).total_seconds() > window_seconds
+    ]
+    for key in stale:
+        _FAILED_OPEN_INMEM_COOLDOWN.pop(key, None)
+    # Hard cap: evict oldest first if the live set is still too large.
+    if len(_FAILED_OPEN_INMEM_COOLDOWN) > _FAILED_OPEN_INMEM_MAX_ENTRIES:
+        for key, _ts in sorted(_FAILED_OPEN_INMEM_COOLDOWN.items(), key=lambda kv: kv[1])[
+            : len(_FAILED_OPEN_INMEM_COOLDOWN) - _FAILED_OPEN_INMEM_MAX_ENTRIES
+        ]:
+            _FAILED_OPEN_INMEM_COOLDOWN.pop(key, None)
+
+
+def register_failed_open_inmem_cooldown(
+    strategy: str, asset: str, direction: str, *, when: datetime | None = None
+) -> None:
+    """RETRY-STORM-2: record a failed live open in the process-local cooldown map.
+
+    Called by the failure-marking path when the durable DB FAILED mark could not be
+    confirmed, so the cooldown still holds within this process. Safe to call even
+    when the DB write DID succeed (belt-and-braces) — the DB and in-memory paths
+    dedupe on the same window. No-op for an empty strategy/asset."""
+    key = _failed_open_inmem_key(strategy, asset, direction)
+    if not key[0] or not key[1]:
+        return
+    ts = when or get_now()
+    with _FAILED_OPEN_INMEM_LOCK:
+        # Prune against a generous window (the longest cooldown/breaker lookback we
+        # might reasonably use) so the map stays bounded regardless of settings.
+        _prune_failed_open_inmem(ts, 24 * 3600.0)
+        _FAILED_OPEN_INMEM_COOLDOWN[key] = ts
+
+
+def _failed_open_inmem_remaining_minutes(
+    strategy: str, asset: str, direction: str, cooldown_minutes: float, now: datetime
+) -> float:
+    """Minutes still to wait per the in-memory cooldown (0 if none / expired)."""
+    if cooldown_minutes <= 0:
+        return 0.0
+    key = _failed_open_inmem_key(strategy, asset, direction)
+    with _FAILED_OPEN_INMEM_LOCK:
+        _prune_failed_open_inmem(now, cooldown_minutes * 60.0)
+        ts = _FAILED_OPEN_INMEM_COOLDOWN.get(key)
+    if ts is None:
+        return 0.0
+    elapsed_minutes = (now - ts).total_seconds() / 60.0
+    return max(cooldown_minutes - elapsed_minutes, 0.0)
+
+
 def _is_strategy_in_failed_open_cooldown(
     strategy: str, asset: str, direction: str, settings: dict
 ) -> tuple[bool, str | None]:
@@ -343,29 +424,36 @@ def _is_strategy_in_failed_open_cooldown(
     if cooldown_minutes <= 0 and (max_attempts <= 0 or window_hours <= 0):
         return False, None
 
-    with get_db() as conn:
-        rows = conn.execute(
-            """
-            SELECT COALESCE(NULLIF(closed_at, ''), created_at) AS failed_at,
-                   failure_reason
-            FROM trades
-            WHERE status = 'FAILED'
-              AND (
-                COALESCE(NULLIF(strategy_id, ''), strategy) = ?
-                OR strategy = ?
-              )
-              AND UPPER(COALESCE(asset, '')) = ?
-              AND LOWER(COALESCE(direction, 'long')) = ?
-              AND COALESCE(execution_type, 'live') NOT IN ('paper', 'paper_challenger', 'simulation')
-            ORDER BY failed_at DESC
-            LIMIT 50
-            """,
-            (normalized_strategy, normalized_strategy, normalized_asset, normalized_direction),
-        ).fetchall()
-    if not rows:
-        return False, None
-
     now = get_now()
+    try:
+        with get_db() as conn:
+            rows = conn.execute(
+                """
+                SELECT COALESCE(NULLIF(closed_at, ''), created_at) AS failed_at,
+                       failure_reason
+                FROM trades
+                WHERE status = 'FAILED'
+                  AND (
+                    COALESCE(NULLIF(strategy_id, ''), strategy) = ?
+                    OR strategy = ?
+                  )
+                  AND UPPER(COALESCE(asset, '')) = ?
+                  AND LOWER(COALESCE(direction, 'long')) = ?
+                  AND COALESCE(execution_type, 'live') NOT IN ('paper', 'paper_challenger', 'simulation')
+                ORDER BY failed_at DESC
+                LIMIT 50
+                """,
+                (normalized_strategy, normalized_strategy, normalized_asset, normalized_direction),
+            ).fetchall()
+    except Exception:
+        # RETRY-STORM-2: if even READING the FAILED rows fails (locked/busy DB), fall
+        # through to the in-memory cooldown rather than treating the strategy as clear.
+        log.warning(
+            "failed-open cooldown: DB read failed for %s %s %s; relying on in-memory cooldown",
+            normalized_strategy, normalized_asset, normalized_direction, exc_info=True,
+        )
+        rows = []
+
     lookback_hours = max(window_hours, cooldown_minutes / 60.0)
     failures: list[datetime] = []
     last_reason: str | None = None
@@ -386,6 +474,18 @@ def _is_strategy_in_failed_open_cooldown(
         if last_reason is None:
             last_reason = str(trade.get("failure_reason") or "").strip() or None
     if not failures:
+        # RETRY-STORM-2: the durable FAILED mark may have been dropped (busy DB).
+        # Consult the process-local fallback so a failed open still cools down.
+        inmem_remaining = _failed_open_inmem_remaining_minutes(
+            normalized_strategy, normalized_asset, normalized_direction, cooldown_minutes, now
+        )
+        if inmem_remaining > 0:
+            return True, (
+                f"Failed-open cooldown for {normalized_strategy}: a recent live open on "
+                f"{normalized_asset} {normalized_direction} FAILED (in-memory fallback — the "
+                f"durable failure mark could not be persisted). Wait {inmem_remaining:.1f}m "
+                "before retrying."
+            )
         return False, None
 
     reason_suffix = f" Last exchange error: {last_reason}" if last_reason else ""
@@ -3687,7 +3787,7 @@ def _get_live_risk_state() -> dict:
         return dict(state) if isinstance(state, dict) else dict(default_state)
 
 
-def update_equity(account_equity: float, source: str = "exchange") -> dict:
+def update_equity(account_equity: float, source: str = "exchange", *, rebaseline: bool = False) -> dict:
     """Update equity tracking. Call this every daemon tick.
 
     Updates the high-water mark, checks drawdown kill-switch,
@@ -3696,6 +3796,15 @@ def update_equity(account_equity: float, source: str = "exchange") -> dict:
     Args:
         account_equity: Current account equity in USD.
         source: "exchange" for real exchange data, "paper" for paper-mode fallback.
+        rebaseline: DRAIN-1. When the caller has already established that this
+            (lower) equity reflects an INTENTIONAL operator drain of at-risk
+            capital — not a trading loss — re-anchor the HWM / daily-start to it
+            (same mechanism as a basis change) so the step-down cannot compute a
+            phantom drawdown and trip the kill-switch. Never lifts an already-fired
+            daily-loss halt. The caller (daemon's book-aware read) only sets this
+            after a confirmed consecutive-clean-zero streak, so a genuine loss —
+            which arrives as a lower-but-nonzero clean read — still flows through
+            as drawdown.
 
     Returns:
         {
@@ -3709,7 +3818,7 @@ def update_equity(account_equity: float, source: str = "exchange") -> dict:
         }
     """
     with _RISK_STATE_LOCK:
-        return _update_equity_locked(account_equity, source)
+        return _update_equity_locked(account_equity, source, rebaseline=rebaseline)
 
 
 def _recompute_daily_halt_from_equity(account_equity: float) -> bool:
@@ -3890,7 +3999,7 @@ def _rejected_equity_result(state: dict, reason: str) -> dict:
     }
 
 
-def _update_equity_locked(account_equity: float, source: str) -> dict:
+def _update_equity_locked(account_equity: float, source: str, *, rebaseline: bool = False) -> dict:
     state = _get_risk_state()
     prev_last_equity = float(state.get("last_equity") or 0.0)  # KS-CACHE-LOG: detect sharp accepted moves
 
@@ -3989,6 +4098,35 @@ def _update_equity_locked(account_equity: float, source: str) -> dict:
         if _initial_live_connect:
             state["daily_loss_halt"] = False
             state["daily_loss_halt_date"] = None
+        kv_set_best_effort(
+            sim_kv_key("daily_risk"),
+            {"date": today, "start_equity": account_equity},
+            timeout_seconds=_RISK_WRITE_TIMEOUT_SECONDS,
+        )
+
+    # DRAIN-1: an INTENTIONAL operator drain/defund of a real-capital wallet is a
+    # step-down in at-risk capital, NOT a trading loss. Without this, the accepted
+    # lower equity computes a large drawdown against the pre-drain HWM and trips a
+    # false kill-switch (either immediately or when the substitution cache clears at
+    # restart). Re-anchor the HWM / daily-start to the drained equity — same as a
+    # basis change — but NEVER lift an already-fired daily-loss halt (RISK-STATE-1).
+    # Only honored for real-capital bases: a paper/sim "drain" has no live meaning.
+    # The caller gates this behind a confirmed consecutive-clean-zero streak, so a
+    # genuine loss (a lower-but-nonzero clean read) never sets rebaseline and still
+    # flows through the drawdown math below.
+    if rebaseline and _is_real_capital_equity_source(source) and hwm > 0 and account_equity < hwm:
+        log.warning(
+            "Equity re-baselined for an ACCEPTED wallet DRAIN (source=%s): HWM $%.2f -> $%.2f, "
+            "daily start reset (operator defund, not a drawdown).",
+            source, hwm, account_equity,
+        )
+        log_activity("warning", "risk", (
+            f"Re-baselined equity for an accepted wallet drain ({source}): "
+            f"HWM ${hwm:,.2f} -> ${account_equity:,.2f}, daily start reset. "
+            "Kill-switch / daily-halt unchanged; a drain is not a drawdown."
+        ))
+        hwm = account_equity
+        state["high_water_mark"] = hwm
         kv_set_best_effort(
             sim_kv_key("daily_risk"),
             {"date": today, "start_equity": account_equity},

--- a/forven/scanner.py
+++ b/forven/scanner.py
@@ -16,6 +16,7 @@ import json
 import logging
 import sqlite3
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 
@@ -3292,45 +3293,93 @@ def _fail_unfilled_open_trade(trade_id: str | None, reason: str | None) -> None:
     tid = str(trade_id or "").strip()
     if not tid:
         return
-    try:
-        with get_db() as conn:
-            row = conn.execute(
-                "SELECT status, fill_entry_price, signal_data FROM trades WHERE id = ?",
-                (tid,),
-            ).fetchone()
-            if not row or str(row["status"] or "").strip().upper() != "OPEN":
-                return  # already resolved — idempotent
-            fill_entry = row["fill_entry_price"]
-            try:
-                if fill_entry is not None and float(fill_entry) > 0:
-                    return  # entry actually filled → real position, do not fail it
-            except (TypeError, ValueError):
-                pass
-            try:
-                signal_data = json.loads(row["signal_data"]) if row["signal_data"] else {}
-            except Exception:
-                signal_data = {}
-            if not isinstance(signal_data, dict):
-                signal_data = {}
-            signal_data.update(
-                {
-                    "open_execution_failed": True,
-                    "open_execution_failure_reason": str(reason or "execution open failed"),
-                    "open_execution_failed_at": get_now().isoformat(),
-                }
-            )
-            conn.execute(
-                "UPDATE trades SET status = 'FAILED', closed_at = ?, failure_reason = ?, signal_data = ? "
-                "WHERE id = ? AND status = 'OPEN'",
-                (
-                    get_now().isoformat(),
-                    str(reason or "execution open failed"),
-                    json.dumps(signal_data),
-                    tid,
-                ),
-            )
-    except Exception:
-        log.warning("Open-failure cleanup: could not mark trade %s FAILED", tid, exc_info=True)
+    # RETRY-STORM-2: capture the trade's identity for the in-memory cooldown
+    # fallback (below) so the cooldown can still engage even if the FAILED write is
+    # ultimately dropped. Populated from the row read on the first attempt.
+    cooldown_strategy = ""
+    cooldown_asset = ""
+    cooldown_direction = ""
+    marked_failed = False
+
+    # RETRY-STORM-2: the FAILED mark is safety-critical — it is the ONLY signal the
+    # scanner's failed-open cooldown reads to brake re-submission. A dropped write
+    # (busy/locked DB) leaves the trade OPEN/absent, the cooldown never engages, and
+    # the scanner fires a fresh REAL order every tick (retry-storm / duplicate
+    # exposure). So retry the write with backoff (blocking, mirroring how
+    # safety-critical risk transitions persist) before giving up.
+    last_exc: Exception | None = None
+    for attempt in range(3):
+        try:
+            with get_db() as conn:
+                row = conn.execute(
+                    "SELECT status, fill_entry_price, signal_data, "
+                    "COALESCE(NULLIF(strategy_id, ''), strategy) AS sid, asset, direction "
+                    "FROM trades WHERE id = ?",
+                    (tid,),
+                ).fetchone()
+                if not row:
+                    return  # gone — nothing to fail
+                cooldown_strategy = str(row["sid"] or "").strip()
+                cooldown_asset = str(row["asset"] or "").strip()
+                cooldown_direction = str(row["direction"] or "long").strip().lower() or "long"
+                if str(row["status"] or "").strip().upper() != "OPEN":
+                    return  # already resolved — idempotent
+                fill_entry = row["fill_entry_price"]
+                try:
+                    if fill_entry is not None and float(fill_entry) > 0:
+                        return  # entry actually filled → real position, do not fail it
+                except (TypeError, ValueError):
+                    pass
+                try:
+                    signal_data = json.loads(row["signal_data"]) if row["signal_data"] else {}
+                except Exception:
+                    signal_data = {}
+                if not isinstance(signal_data, dict):
+                    signal_data = {}
+                signal_data.update(
+                    {
+                        "open_execution_failed": True,
+                        "open_execution_failure_reason": str(reason or "execution open failed"),
+                        "open_execution_failed_at": get_now().isoformat(),
+                    }
+                )
+                conn.execute(
+                    "UPDATE trades SET status = 'FAILED', closed_at = ?, failure_reason = ?, signal_data = ? "
+                    "WHERE id = ? AND status = 'OPEN'",
+                    (
+                        get_now().isoformat(),
+                        str(reason or "execution open failed"),
+                        json.dumps(signal_data),
+                        tid,
+                    ),
+                )
+            marked_failed = True
+            break
+        except Exception as exc:  # noqa: PERF203 — retry loop is the point
+            last_exc = exc
+            if attempt < 2:
+                time.sleep(0.25 * (2 ** attempt))  # 0.25s, 0.5s backoff
+                continue
+
+    # RETRY-STORM-2: when the durable FAILED write could NOT be confirmed, register
+    # the process-local cooldown so re-submission is still braked within this
+    # process. On a successful write we DON'T register it — the DB row is the
+    # authoritative cooldown source and behavior stays identical to today.
+    if not marked_failed and cooldown_strategy and cooldown_asset:
+        try:
+            from forven.exchange.risk import register_failed_open_inmem_cooldown
+            register_failed_open_inmem_cooldown(cooldown_strategy, cooldown_asset, cooldown_direction)
+        except Exception:
+            log.debug("Open-failure cleanup: could not register in-memory cooldown", exc_info=True)
+
+    if not marked_failed:
+        log.error(
+            "Open-failure cleanup: could NOT persist FAILED mark for trade %s after retries (%s). "
+            "Relying on the in-memory failed-open cooldown (%s %s %s) to brake re-submission "
+            "until the process restarts or the DB write recovers.",
+            tid, last_exc, cooldown_strategy or "?", cooldown_asset or "?", cooldown_direction or "?",
+            exc_info=last_exc is not None,
+        )
         return
     # release() takes the position lock and opens its own connection, so call it
     # outside the update transaction above to avoid nested-connection lock contention.

--- a/tests/test_book_equity_robust.py
+++ b/tests/test_book_equity_robust.py
@@ -108,3 +108,112 @@ def test_substitution_is_logged_for_diagnosis(monkeypatch, caplog):
     msgs = " ".join(r.getMessage() for r in caplog.records)
     assert "SUBSTITUTED" in msgs and "__master__" in msgs  # names the failing wallet + cached value
     assert "DEGRADED" in msgs  # full per-wallet composition evidence line
+
+
+# ---------------------------------------------- DRAIN-1: clean-zero wallet drains
+
+
+@pytest.fixture(autouse=True)
+def _reset_clean_zero_streaks():
+    dmn._BOOK_CLEAN_ZERO_STREAK.clear()
+    yield
+    dmn._BOOK_CLEAN_ZERO_STREAK.clear()
+
+
+def test_transient_failed_read_still_substitutes_no_drain(monkeypatch):
+    # A RAISED read (timeout) must NEVER count toward the clean-zero drain streak —
+    # even repeatedly. It stays on the last-known-good substitution path forever so
+    # a persistent transient glitch can't fake an accepted drain.
+    _stub_reads(monkeypatch, {"__master__": 316.0, "0xlong": 329.0, "0xshort": 30.0})
+    dmn._book_aware_account_value(testnet=True)  # seed cache
+    for _ in range(6):
+        _stub_reads(monkeypatch, {"__master__": RuntimeError("read timeout"), "0xlong": 329.0, "0xshort": 30.0})
+        out = dmn._book_aware_account_value(testnet=True)
+    assert out is not None
+    assert out["accountValue"] == pytest.approx(675.0)  # still substituted, never drained
+    assert out.get("drain_accepted") is False
+    assert dmn._BOOK_EQUITY_CACHE.get("__master__") == pytest.approx(316.0)  # cache intact
+
+
+def test_clean_zero_streak_accepts_drain_and_purges_cache(monkeypatch):
+    # A read that SUCCEEDS and reports 0 is a CLEAN zero. After N consecutive clean
+    # zeros the drain is accepted: the cache entry is purged and the aggregate
+    # reflects the drain (no longer inflated by the substituted balance).
+    _stub_reads(monkeypatch, {"__master__": 316.0, "0xlong": 329.0, "0xshort": 30.0})
+    assert dmn._book_aware_account_value(testnet=True)["accountValue"] == pytest.approx(675.0)
+
+    # Ticks 1..2: master reads clean 0 -> still substituted (streak building).
+    for expected_streak in (1, 2):
+        _stub_reads(monkeypatch, {"__master__": 0.0, "0xlong": 329.0, "0xshort": 30.0})
+        out = dmn._book_aware_account_value(testnet=True)
+        assert out["accountValue"] == pytest.approx(675.0)  # cached $316 still in
+        assert out.get("drain_accepted") is False
+        assert dmn._BOOK_CLEAN_ZERO_STREAK.get("__master__") == expected_streak
+
+    # Tick 3: streak hits the confirm threshold -> ACCEPT the drain.
+    _stub_reads(monkeypatch, {"__master__": 0.0, "0xlong": 329.0, "0xshort": 30.0})
+    out = dmn._book_aware_account_value(testnet=True)
+    assert out["accountValue"] == pytest.approx(359.0)  # 329 + 30, master drained
+    assert out.get("drain_accepted") is True
+    assert "__master__" not in dmn._BOOK_EQUITY_CACHE  # cache purged
+    assert "__master__" not in dmn._BOOK_CLEAN_ZERO_STREAK  # streak reset
+
+
+def test_positive_read_resets_clean_zero_streak(monkeypatch):
+    # A drain streak that is INTERRUPTED by a real positive read must reset — funds
+    # came back, so it was never a drain.
+    _stub_reads(monkeypatch, {"__master__": 316.0, "0xlong": 329.0, "0xshort": 30.0})
+    dmn._book_aware_account_value(testnet=True)
+    for _ in range(2):
+        _stub_reads(monkeypatch, {"__master__": 0.0, "0xlong": 329.0, "0xshort": 30.0})
+        dmn._book_aware_account_value(testnet=True)
+    assert dmn._BOOK_CLEAN_ZERO_STREAK.get("__master__") == 2
+    # Funds return -> streak clears, cache re-seeded.
+    _stub_reads(monkeypatch, {"__master__": 300.0, "0xlong": 329.0, "0xshort": 30.0})
+    out = dmn._book_aware_account_value(testnet=True)
+    assert out["accountValue"] == pytest.approx(659.0)
+    assert "__master__" not in dmn._BOOK_CLEAN_ZERO_STREAK
+    # A later single clean-zero must NOT immediately drain (streak restarts at 1).
+    _stub_reads(monkeypatch, {"__master__": 0.0, "0xlong": 329.0, "0xshort": 30.0})
+    out = dmn._book_aware_account_value(testnet=True)
+    assert out["accountValue"] == pytest.approx(659.0)  # substituted $300 again
+    assert out.get("drain_accepted") is False
+
+
+def test_genuine_partial_loss_still_flows_no_drain(monkeypatch):
+    # A clean read that is LOWER but non-zero is a real trading loss, not a drain:
+    # it flows straight through as the aggregate with no cache purge / drain flag.
+    _stub_reads(monkeypatch, {"__master__": 316.0, "0xlong": 329.0, "0xshort": 30.0})
+    dmn._book_aware_account_value(testnet=True)
+    _stub_reads(monkeypatch, {"__master__": 316.0, "0xlong": 150.0, "0xshort": 30.0})  # long lost half
+    out = dmn._book_aware_account_value(testnet=True)
+    assert out["accountValue"] == pytest.approx(496.0)  # reflects the loss
+    assert out.get("drain_accepted") is False
+    assert not dmn._BOOK_CLEAN_ZERO_STREAK  # a non-zero read never advances the streak
+
+
+def test_accepted_drain_is_logged(monkeypatch, caplog):
+    _stub_reads(monkeypatch, {"__master__": 316.0, "0xlong": 329.0, "0xshort": 30.0})
+    dmn._book_aware_account_value(testnet=True)
+    for _ in range(2):
+        _stub_reads(monkeypatch, {"__master__": 0.0, "0xlong": 329.0, "0xshort": 30.0})
+        dmn._book_aware_account_value(testnet=True)
+    _stub_reads(monkeypatch, {"__master__": 0.0, "0xlong": 329.0, "0xshort": 30.0})
+    with caplog.at_level("WARNING"):
+        dmn._book_aware_account_value(testnet=True)
+    msgs = " ".join(r.getMessage() for r in caplog.records)
+    assert "DRAIN" in msgs and "__master__" in msgs
+
+
+def test_clear_book_equity_cache_purges_everything(monkeypatch):
+    _stub_reads(monkeypatch, {"__master__": 316.0, "0xlong": 329.0, "0xshort": 30.0})
+    dmn._book_aware_account_value(testnet=True)
+    assert dmn._BOOK_EQUITY_CACHE  # seeded
+    # Seed a partial clean-zero streak too.
+    _stub_reads(monkeypatch, {"__master__": 0.0, "0xlong": 329.0, "0xshort": 30.0})
+    dmn._book_aware_account_value(testnet=True)
+    assert dmn._BOOK_CLEAN_ZERO_STREAK
+    n = dmn.clear_book_equity_cache()
+    assert n >= 1
+    assert not dmn._BOOK_EQUITY_CACHE
+    assert not dmn._BOOK_CLEAN_ZERO_STREAK

--- a/tests/test_equity_anchors.py
+++ b/tests/test_equity_anchors.py
@@ -13,6 +13,7 @@ import pytest
 
 from forven.db import kv_get, kv_set
 from forven.exchange import risk
+from forven.sim.clock import get_today
 
 
 # ---------------------------------------------------------------- jump guard
@@ -70,6 +71,70 @@ def test_basis_change_rebaselines_poisoned_hwm(forven_db):
     assert state["high_water_mark"] == pytest.approx(610.0)
     daily = kv_get("daily_risk", {})
     assert daily["start_equity"] == pytest.approx(610.0)
+
+
+# ------------------------------------------------- DRAIN-1: accepted wallet drain
+
+
+def _seed_live_state(hwm, last, *, source="books_only", kill=False, halt=False):
+    kv_set("risk_state", {
+        "high_water_mark": hwm,
+        "last_equity": last,
+        "equity_source": source,
+        "kill_switch_active": kill,
+        "daily_loss_halt": halt,
+        "drawdown_pct": 0.0,
+    })
+
+
+def test_drain_rebaseline_reanchors_step_down_no_killswitch(forven_db):
+    """An accepted clean-zero DRAIN (same basis, lower equity) re-anchors the HWM to
+    the drained equity instead of computing a drawdown against the pre-drain peak —
+    so the step-down can't trip the kill-switch."""
+    _seed_live_state(675.0, 675.0, source="books_only")
+    result = risk.update_equity(359.0, "books_only", rebaseline=True)  # master drained
+    assert result.get("action") is None and result.get("kill_switch") is False
+    assert result["high_water_mark"] == pytest.approx(359.0)
+    assert result["drawdown_pct"] == pytest.approx(0.0)
+    daily = kv_get("daily_risk", {})
+    assert daily["start_equity"] == pytest.approx(359.0)
+
+
+def test_same_basis_drop_without_drain_flag_still_draws_down(forven_db):
+    """Without the drain flag, the SAME lower reading is a genuine loss: it computes
+    drawdown against the peak (and a large enough drop fires the kill-switch). This
+    is the contrast that proves the drain path doesn't blanket-suppress losses."""
+    _seed_live_state(675.0, 675.0, source="books_only")
+    result = risk.update_equity(359.0, "books_only")  # rebaseline defaults False
+    # 47% drawdown on the 10% testnet cap -> kill-switch fires.
+    assert result["high_water_mark"] == pytest.approx(675.0)  # peak NOT moved
+    assert result["drawdown_pct"] == pytest.approx((675.0 - 359.0) / 675.0, rel=1e-3)
+    assert result.get("kill_switch") is True
+
+
+def test_drain_rebaseline_preserves_fired_daily_halt(forven_db):
+    """A drain re-baseline must NEVER lift an already-fired daily-loss halt
+    (RISK-STATE-1) — only an initial paper->live connect clears halts."""
+    kv_set("risk_state", {  # keep halt dated today so it isn't cleared on rollover
+        "high_water_mark": 675.0, "last_equity": 675.0, "equity_source": "books_only",
+        "kill_switch_active": False, "daily_loss_halt": True,
+        "daily_loss_halt_date": get_today().isoformat(),
+        "drawdown_pct": 0.0,
+    })
+    risk.update_equity(359.0, "books_only", rebaseline=True)
+    state = kv_get("risk_state", {})
+    assert state["daily_loss_halt"] is True  # halt held through the drain re-baseline
+
+
+def test_drain_flag_ignored_for_paper_basis(forven_db):
+    """A paper/sim 'drain' has no real-capital meaning — the rebaseline hook is only
+    honored for real-capital sources, so a paper source never re-anchors off it."""
+    _seed_live_state(10_000.0, 10_000.0, source="paper")
+    result = risk.update_equity(5_000.0, "paper", rebaseline=True)
+    # Paper still tracks drawdown for display but the HWM is NOT re-anchored by the
+    # drain flag (and paper never halts anyway — PAPER-HALT-2).
+    assert result["high_water_mark"] == pytest.approx(10_000.0)
+    assert result.get("kill_switch") is False
 
 
 # ------------------------------------------------- operator re-baseline
@@ -198,7 +263,7 @@ def test_risk_cycle_drops_rejected_sample_from_mirrors(forven_db, daemon_books, 
 
     monkeypatch.setattr(
         daemon, "update_equity",
-        lambda eq, src: {"rejected": True, "reject_reason": "test", "kill_switch": False},
+        lambda eq, src, **_kw: {"rejected": True, "reject_reason": "test", "kill_switch": False},
     )
     snapshot = asyncio.run(daemon._run_risk_cycle())
     assert snapshot["equity"] is None

--- a/tests/test_failed_open_retry_brake.py
+++ b/tests/test_failed_open_retry_brake.py
@@ -12,9 +12,19 @@ from __future__ import annotations
 import json
 from datetime import timedelta
 
+import pytest
+
 from forven.db import get_db, kv_set
 from forven.exchange import risk
 from forven.sim.clock import get_now
+
+
+@pytest.fixture(autouse=True)
+def _reset_inmem_cooldown():
+    """RETRY-STORM-2: the in-memory failed-open cooldown is module-level state."""
+    risk._FAILED_OPEN_INMEM_COOLDOWN.clear()
+    yield
+    risk._FAILED_OPEN_INMEM_COOLDOWN.clear()
 
 
 def _skip_margin_fetch(monkeypatch):
@@ -187,3 +197,128 @@ def test_paper_failed_rows_do_not_count(forven_db, monkeypatch):
                             execution_type="paper")
     allowed, _, why = risk.can_open("BTC", "long", "S-A", execution_type="live")
     assert allowed, why
+
+
+# ----------------------------------------------- RETRY-STORM-2: durable-or-loud
+
+
+def test_dropped_failed_write_falls_back_to_inmem_cooldown(forven_db, monkeypatch, caplog):
+    """If the durable FAILED mark can't be persisted (busy/locked DB), the scanner's
+    failed-open cooldown must STILL engage via the process-local fallback so the
+    kernel doesn't retry a real order every tick. And it must log an error."""
+    from forven import scanner
+
+    _skip_margin_fetch(monkeypatch)
+    _set_brake_settings(cooldown_minutes=15, max_attempts=3)
+    # A live OPEN trade that the exchange open failed on.
+    with get_db() as conn:
+        conn.execute(
+            "INSERT INTO trades (id, strategy, strategy_id, asset, direction, entry_price, size, "
+            "status, execution_type, signal_data, opened_at) "
+            "VALUES ('E-DROP', 'S-Z', 'S-Z', 'BTC', 'long', 100.0, 1.0, 'OPEN', 'live', '{}', ?)",
+            (get_now().isoformat(),),
+        )
+
+    # Force the FAILED UPDATE to fail while letting the identity SELECT succeed: wrap
+    # the real connection so its execute() raises only on the FAILED write. This
+    # simulates a busy/locked DB dropping the safety-critical mark. sqlite3.Cursor is
+    # immutable, so proxy at the connection level via scanner.get_db instead.
+    import contextlib
+    import sqlite3 as _sqlite3
+    from forven import db as _dbmod
+
+    class _FlakyConn:
+        def __init__(self, real):
+            self._real = real
+
+        def execute(self, sql, *a, **kw):
+            if sql.strip().upper().startswith("UPDATE TRADES SET STATUS = 'FAILED'"):
+                raise _sqlite3.OperationalError("database is locked")
+            return self._real.execute(sql, *a, **kw)
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+    @contextlib.contextmanager
+    def flaky_get_db():
+        with _dbmod.get_db() as real:
+            yield _FlakyConn(real)
+
+    monkeypatch.setattr("forven.scanner.get_db", flaky_get_db)
+    monkeypatch.setattr("forven.scanner.time.sleep", lambda *_a, **_k: None)  # no real backoff wait
+
+    with caplog.at_level("ERROR"):
+        scanner._fail_unfilled_open_trade("E-DROP", "exchange rejected order")
+
+    # The trade is still OPEN (write dropped) — proving the DB cooldown would NOT
+    # engage on its own — but the failure path logged loud AND registered the
+    # process-local fallback keyed to the dropped trade's identity.
+    with get_db() as conn:
+        row = dict(conn.execute("SELECT status FROM trades WHERE id='E-DROP'").fetchone())
+    assert row["status"] == "OPEN"  # durable mark never landed
+    msgs = " ".join(r.getMessage() for r in caplog.records)
+    assert "could NOT persist FAILED mark" in msgs  # logged loud
+    assert risk._failed_open_inmem_key("S-Z", "BTC", "long") in risk._FAILED_OPEN_INMEM_COOLDOWN
+
+    # can_open is braked by the IN-MEMORY cooldown even though NO FAILED row exists
+    # for S-Z/BTC/long. Provide a live aggregate equity so any upstream fail-closed
+    # equity gate passes and we reach the failed-open cooldown gate.
+    monkeypatch.setattr(risk, "_live_aggregate_equity", lambda *a, **k: 10_000.0)
+    allowed, _, why = risk.can_open("BTC", "long", "S-Z", execution_type="live")
+    assert not allowed
+    assert "Failed-open cooldown" in why and "in-memory" in why
+
+
+def test_inmem_cooldown_scoped_and_expires(forven_db, monkeypatch):
+    _skip_margin_fetch(monkeypatch)
+    _set_brake_settings(cooldown_minutes=15, max_attempts=0)
+    # Register directly with a stale timestamp -> already expired.
+    risk.register_failed_open_inmem_cooldown(
+        "S-Z", "BTC", "long", when=get_now() - timedelta(minutes=30)
+    )
+    allowed, _, _why = risk.can_open("BTC", "long", "S-Z", execution_type="live")
+    assert allowed  # expired entry does not block
+
+    # Fresh entry blocks, but only the exact strategy+asset+direction.
+    risk.register_failed_open_inmem_cooldown("S-Z", "BTC", "long")
+    blocked, _, _ = risk.can_open("BTC", "long", "S-Z", execution_type="live")
+    assert not blocked
+    for asset, direction, strat in [("ETH", "long", "S-Z"), ("BTC", "short", "S-Z"), ("BTC", "long", "S-Y")]:
+        ok, _, why = risk.can_open(asset, direction, strat, execution_type="live")
+        assert ok, why
+
+
+def test_inmem_cooldown_not_used_when_write_succeeds(forven_db, monkeypatch):
+    """When the FAILED write DOES persist, behavior is identical to today: the DB
+    cooldown engages and NO in-memory entry is registered (the DB is authoritative)."""
+    from forven import scanner
+
+    _skip_margin_fetch(monkeypatch)
+    _set_brake_settings(cooldown_minutes=15, max_attempts=3)
+    with get_db() as conn:
+        conn.execute(
+            "INSERT INTO trades (id, strategy, strategy_id, asset, direction, entry_price, size, "
+            "status, execution_type, signal_data, opened_at) "
+            "VALUES ('E-OK', 'S-W', 'S-W', 'BTC', 'long', 100.0, 1.0, 'OPEN', 'live', '{}', ?)",
+            (get_now().isoformat(),),
+        )
+    scanner._fail_unfilled_open_trade("E-OK", "exchange rejected")
+
+    with get_db() as conn:
+        row = dict(conn.execute("SELECT status FROM trades WHERE id='E-OK'").fetchone())
+    assert row["status"] == "FAILED"  # durable mark landed
+    assert not risk._FAILED_OPEN_INMEM_COOLDOWN  # no fallback registered on success
+
+    allowed, _, why = risk.can_open("BTC", "long", "S-W", execution_type="live")
+    assert not allowed and "Failed-open cooldown" in why  # DB path blocks as before
+
+
+def test_inmem_cooldown_bounded_prune(forven_db):
+    """The in-memory map prunes expired entries so it can't grow without bound."""
+    stale = get_now() - timedelta(hours=48)
+    for i in range(50):
+        risk.register_failed_open_inmem_cooldown(f"S-{i}", "BTC", "long", when=stale)
+    # A fresh registration prunes the 48h-stale entries (register prunes at 24h).
+    risk.register_failed_open_inmem_cooldown("S-FRESH", "BTC", "long")
+    assert len(risk._FAILED_OPEN_INMEM_COOLDOWN) == 1
+    assert risk._failed_open_inmem_key("S-FRESH", "BTC", "long") in risk._FAILED_OPEN_INMEM_COOLDOWN


### PR DESCRIPTION
Two P1 operational-integrity fixes in the real-capital risk path. Both harden a place where a *transient* state (an in-memory cache / a single DB write) silently distorts a safety mechanism.

## FIX 1 — Book-equity cache now understands an intentional wallet drain (DRAIN-1)

`daemon._book_aware_account_value()` substitutes each sub-account's last-known-good equity (`_BOOK_EQUITY_CACHE`) whenever a read returns `<= 0` or raises. That guard is correct for **transient** glitches — a momentary $0 must not fake a drawdown and trip the kill-switch. But it treated an **operator draining/defunding a wallet** the same way: every honest $0 read was substituted away, the aggregate stayed inflated, the HWM stayed high, and when the cache eventually cleared (restart) the sudden step-down computed a phantom drawdown → false kill-switch.

**Mechanism:** distinguish a CLEAN zero from a FAILED read.
- A read that **succeeds and reports ~0** is truth. Per-account, a consecutive **clean-zero streak** is tracked (`_BOOK_CLEAN_ZERO_CONFIRM_TICKS = 3`, mirroring the existing `_BOOKS_OFF_CONFIRM_TICKS` idiom in the same function).
- A **raised/errored** read never advances the streak — it keeps riding last-known-good (transient glitches are still fully covered).
- A **positive** read resets the streak (funds returned → never a drain).
- After the streak confirms, the daemon **accepts the zero, purges that account's cache entry**, and flags the tick (`drain_accepted`). `update_equity(..., rebaseline=True)` then re-anchors the HWM / daily-start to the drained equity — the same re-baseline mechanism a books-composition/basis change already uses — instead of computing a drawdown. It **never lifts an already-fired daily-loss halt** (RISK-STATE-1) and is honored **only for real-capital sources**.
- The operator equity re-baseline endpoint (`POST /api/risk/equity/rebaseline`) now also calls a new `daemon.clear_book_equity_cache()`, so the documented recovery path fully resets stale substitution state (otherwise a re-baselined-away drain gets re-inflated from cache on the very next tick).

### Drain vs. loss — the distinguishing signal is the STREAK, not the magnitude
A genuine trading loss arrives as a **lower-but-nonzero clean read**. That never advances the clean-zero streak, never sets `rebaseline`, and flows straight through the normal drawdown math — so real losses still count toward drawdown and still arm the kill-switch. Only a confirmed run of clean **zeros** (which a loss can't produce without actually being a total wipeout, at which point the whole book reads unreliable and the tick is skipped) is read as an intentional defund. A single or transient zero never re-baselines.

## FIX 2 — Failed-open cooldown no longer depends on one transient DB write (RETRY-STORM-2)

`_is_strategy_in_failed_open_cooldown()` reads `trades WHERE status='FAILED'` to brake re-submission after a failed live open. That FAILED mark is written by `scanner._fail_unfilled_open_trade()`. If that single write hit a busy/locked DB and silently failed (the old code swallowed the exception), the trade stayed OPEN/absent, the cooldown never engaged, and the scanner re-submitted a **real** order every tick — a retry-storm with possible duplicate exposure.

**Mechanism: durable-or-loud.**
- The FAILED mark now **retries with backoff** (blocking, since it is safety-critical — mirroring how kill-switch/daily-halt fire transitions use a blocking persist).
- If it **still** can't be persisted, the failure path records a **bounded, process-local in-memory cooldown** (`_FAILED_OPEN_INMEM_COOLDOWN`, keyed by `(strategy, asset, direction)` → timestamp) and **logs an error**. `_is_strategy_in_failed_open_cooldown` consults this fallback alongside the DB query — and also when the DB **read** itself fails — so the cooldown holds within the process exactly across the window the DB write was meant to cover (a restart both wipes the map and re-reads the DB).
- The map is pruned on every read/write and hard-capped (oldest-evicted) so it can't grow without bound.
- When the write **succeeds**, behavior is identical to today: the DB row is authoritative and no in-memory entry is registered.

## Tests
- `tests/test_book_equity_robust.py`: transient failed read still substitutes (never drains); 3-tick clean-zero streak accepts the drain, purges cache, sets `drain_accepted`; positive read resets the streak; genuine partial loss still flows with no drain; drain is logged; `clear_book_equity_cache` purges cache + streaks.
- `tests/test_equity_anchors.py`: `rebaseline=True` re-anchors a same-basis step-down with no kill-switch; the **same** drop **without** the flag still draws down and fires the kill-switch (the drain path doesn't blanket-suppress losses); drain re-baseline preserves a fired daily halt; the flag is ignored for a paper basis.
- `tests/test_failed_open_retry_brake.py`: dropped FAILED write → error logged + in-memory cooldown registered + `can_open` still blocked via the fallback; scoping/expiry; bounded prune; write-succeeds path unchanged (no in-memory entry, DB blocks as before).

Full required suite green (`test_book_equity_robust`, `test_risk_module`, `test_risk_drawdown_math`, `test_equity_anchors`, `test_equity_sanity_guard`, `test_paper_no_global_halts`, `test_kill_switch_close_integrity`, `test_direction_books`, `test_risk_reconciliation`, `test_failed_open_retry_brake` — 171 passed) and `ruff check forven tests` clean. Did not disturb `_REAL_CAPITAL_EQUITY_SOURCES` (PAPER-HALT-2), KS-TIMEOUT-1 / UNRESOLVABLE-ROUTE-1. The one `test_daemon_startup_recovery` failure is the pre-existing exchange_account snapshot schema drift.

## Files
- `forven/daemon.py` — clean-zero streak + drain accept/purge; `clear_book_equity_cache()`; wire `drain_accepted` → `update_equity(rebaseline=...)`.
- `forven/exchange/risk.py` — `rebaseline` kwarg + drain re-baseline branch; in-memory failed-open cooldown map + register/check/prune; DB-read-failure fallthrough.
- `forven/scanner.py` — `_fail_unfilled_open_trade` blocking retry + in-memory fallback registration on persistent failure (minimal edit to the failure-marking call site).
- `forven/control_plane/ops.py` — rebaseline endpoint also purges the book-equity cache.
- tests as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CBHuQy6taZsvWNwsKig2N