### PR TITLE
fix(policy): carry evidence-absence reason codes structurally + drift tripwire

### DIFF
--- a/forven/policy.py
+++ b/forven/policy.py
@@ -16,6 +16,38 @@ from forven.util import normalize_stage
 
 log = logging.getLogger("forven.policy")
 
+
+class GateRejection(str):
+    """A gate-rejection reason string that carries its taxonomy code STRUCTURALLY.
+
+    Rejection reasons flow from ~84 ``return False, "<reason>"`` sites through the
+    gate-evaluation tuples into ``_log_gate_rejection_record``, which decides via
+    ``_check_repeated_failure_auto_archive`` whether the rejection COUNTS toward the
+    5-strike auto-archive or is EXEMPT (evidence-absence: tests not run, work in
+    flight, stale/pending artifacts). That decision historically rode on SUBSTRING
+    MATCHING of the human prose (``_extract_reason_code``) — so any reword of an
+    exempt rejection silently reclassified it as a COUNTING merit failure and
+    wrongly archived healthy strategies (S06127 fold-density 2026-07-06; the
+    source-reconciliation-pending case 2026-07-10).
+
+    This subclass is a drop-in ``str`` (wire-compatible with every f-string, DB
+    binding, ``.lower()`` and comparison downstream), so existing tuple consumers
+    are unaffected. Evidence-absence sites construct it with an explicit
+    ``reason_code=`` so classification travels with the value and never depends on
+    prose. Plain-string sites keep working through the text-matcher fallback in
+    ``_resolve_reason_code``. The tripwire test in tests/test_reason_code_drift.py
+    fails if an exempt rejection is reworded without carrying its code.
+    """
+
+    __slots__ = ("reason_code",)
+    reason_code: str | None
+
+    def __new__(cls, text: str, reason_code: str | None = None) -> "GateRejection":
+        obj = super().__new__(cls, text)
+        obj.reason_code = reason_code
+        return obj
+
+
 DEFAULT_PIPELINE_CONFIG = {
     # Active stance preset (relaxed | default | strict | custom). The Default preset
     # IS this DEFAULT_PIPELINE_CONFIG; relaxed/strict are deltas applied in
@@ -1044,7 +1076,10 @@ def _check_artifact_ordering(strategy_id: str, required_types: list[str] | None 
     for vt in validation_types:
         vt_time = timestamps.get(vt, "")
         if vt_time and opt_time and vt_time < opt_time:
-            return False, f"Ordering violation: {vt} was run before optimization — re-run after optimization"
+            return False, GateRejection(
+                f"Ordering violation: {vt} was run before optimization — re-run after optimization",
+                reason_code="stale_validation",
+            )
 
     return True, "Artifact ordering is correct"
 
@@ -1095,7 +1130,10 @@ def _check_validation_freshness(strategy_id: str, required_types: list[str] | No
     if stale:
         return (
             False,
-            f"Stale validation tests (run before latest optimization): {', '.join(stale)}",
+            GateRejection(
+                f"Stale validation tests (run before latest optimization): {', '.join(stale)}",
+                reason_code="stale_validation",
+            ),
         )
     return True, "All validation tests are fresh"
 
@@ -1141,8 +1179,11 @@ def _check_engine_artifact_freshness(strategy_id: str, required_types: list[str]
     if stale:
         return (
             False,
-            f"Validation artifacts predate the current engine version "
-            f"(v{BACKTEST_ENGINE_VERSION}) and are queued for re-validation: {', '.join(stale)}",
+            GateRejection(
+                f"Validation artifacts predate the current engine version "
+                f"(v{BACKTEST_ENGINE_VERSION}) and are queued for re-validation: {', '.join(stale)}",
+                reason_code="stale_engine_artifacts",
+            ),
         )
     return True, "All validation artifacts match the current engine version"
 
@@ -1208,8 +1249,11 @@ def _check_validation_in_flight(strategy_id: str, config: dict | None = None) ->
     if in_flight:
         return (
             False,
-            f"Validation in flight: {', '.join(in_flight)} still running — "
-            f"promotion deferred until the verdict lands",
+            GateRejection(
+                f"Validation in flight: {', '.join(in_flight)} still running — "
+                f"promotion deferred until the verdict lands",
+                reason_code="validation_in_flight",
+            ),
         )
     return True, "No validation tests in flight"
 
@@ -1228,8 +1272,11 @@ def _check_artifact_rows_exist(strategy_id: str, required_types: list[str]) -> t
     if missing:
         return (
             False,
-            f"Missing passing persisted artifact rows for: {', '.join(missing)}. "
-            f"Run or rerun these tests until the saved verdicts pass.",
+            GateRejection(
+                f"Missing passing persisted artifact rows for: {', '.join(missing)}. "
+                f"Run or rerun these tests until the saved verdicts pass.",
+                reason_code="missing_evidence",
+            ),
         )
     # Two-tier transparency: a walk_forward row can pass the PAPER tier (fold
     # pass-rate over judgeable folds) while its strict artifact verdict is FAIL
@@ -1396,7 +1443,10 @@ def _check_paper_duration(strategy_id: str) -> tuple:
         extra = {"current": days, "threshold": min_days, "direction": "gte", "unit": "days"}
         if days >= min_days:
             return True, f"Paper duration: {days}/{min_days} days", extra
-        return False, f"Insufficient paper duration: {days}/{min_days} days", extra
+        return False, GateRejection(
+            f"Insufficient paper duration: {days}/{min_days} days",
+            reason_code="insufficient_paper_evidence",
+        ), extra
     except Exception:
         return False, "Could not parse stage timestamp"
 
@@ -1441,7 +1491,10 @@ def _check_paper_trades(strategy_id: str) -> tuple:
     extra = {"current": total, "threshold": min_trades, "direction": "gte", "unit": "trades"}
     if total >= min_trades:
         return True, f"Paper trades: {total}/{min_trades}", extra
-    return False, f"Insufficient paper trades: {total}/{min_trades}", extra
+    return False, GateRejection(
+        f"Insufficient paper trades: {total}/{min_trades}",
+        reason_code="insufficient_paper_evidence",
+    ), extra
 
 
 def _check_paper_return(strategy_id: str) -> tuple:
@@ -2243,9 +2296,10 @@ def _evaluate_source_divergence_gate(strategy_id: str, general_settings: Any) ->
 
     def _missing(reason: str) -> tuple[bool, str]:
         if block_when_missing:
-            return False, (
+            return False, GateRejection(
                 f"Source reconciliation pending ({reason}) — divergence not yet "
-                f"computed for {symbol} {timeframe}"
+                f"computed for {symbol} {timeframe}",
+                reason_code="source_reconciliation_pending",
             )
         return True, f"source reconciliation unavailable ({reason}) — allowing"
 
@@ -2546,6 +2600,13 @@ def _extract_reason_code(reason_text: str) -> str:
     # threshold still counts below.
     if "source reconciliation pending" in text or "source reconciliation unavailable" in text:
         return "source_reconciliation_pending"
+    # "Gauntlet missing (verdict evidence|required verdict tests)": absence of a
+    # persisted verdict, not a walk-forward MERIT reject. Matched before the "walk"
+    # +"forward" branch below, which would otherwise text-match the test-name list
+    # (e.g. "...: walk_forward") to the COUNTING wfa_reject code. Live sites carry
+    # missing_evidence structurally; this protects historical prose-only DB rows.
+    if "missing" in text and "verdict" in text:
+        return "missing_evidence"
     if "divergence" in text:
         return "source_divergence_reject"
     if "overfit" in text:
@@ -2592,6 +2653,20 @@ def _extract_reason_code(reason_text: str) -> str:
     return "gate_reject"
 
 
+def _resolve_reason_code(reason: str) -> str:
+    """Resolve a rejection's taxonomy code, preferring a STRUCTURAL code.
+
+    A :class:`GateRejection` carries its code from the rejection site, so an
+    evidence-absence classification never depends on prose matching (goal 1/2).
+    Plain strings — including historical ``gate_rejections`` DB rows, which store
+    prose only — fall back to the ``_extract_reason_code`` text matcher (goal 4).
+    """
+    code = getattr(reason, "reason_code", None)
+    if code:
+        return code
+    return _extract_reason_code(str(reason))
+
+
 def _load_metrics_snapshot_for_rejection(strategy_id: str) -> dict | None:
     """Load a compact metrics snapshot for rejection logging."""
     try:
@@ -2619,7 +2694,9 @@ def _log_gate_rejection_record(strategy_id: str, gate: str, reason_text: str, co
     """P0-2/P3-1: Log structured gate rejection with failure taxonomy fields."""
     from forven.engine_provenance import BACKTEST_ENGINE_VERSION
 
-    reason_code = _extract_reason_code(reason_text)
+    # Prefer the structural code carried by a GateRejection (exempt-class rejections
+    # never re-parse prose); fall back to text matching for plain strings.
+    reason_code = _resolve_reason_code(reason_text)
     metrics_snapshot = _load_metrics_snapshot_for_rejection(strategy_id)
     # Provenance: which engine produced the numbers this rejection judged. Lets
     # triage distinguish "rejected by the current engine" from "rejected on
@@ -3407,7 +3484,9 @@ def _evaluate_quick_screen_gate(strategy_id: str, config: dict) -> tuple[bool, s
 
     metrics = _load_metrics_blob(row)
     if not metrics:
-        return False, "No quick-screen metrics available"
+        return False, GateRejection(
+            "No quick-screen metrics available", reason_code="no_metrics_error"
+        )
 
     # Fast sanity check: reject strategies with zero trades (can't produce signals)
     total_trades = int(metrics.get("total_trades", 0) or 0)
@@ -3770,7 +3849,10 @@ def _evaluate_gauntlet_gate(strategy_id: str, config: dict) -> tuple[bool, str]:
     if artifact_counts["optimization"] <= 0 and artifact_counts["walk_forward"] <= 0:
         return (
             False,
-            "Gauntlet requires at least one persisted optimization or walk-forward run before promotion to paper",
+            GateRejection(
+                "Gauntlet requires at least one persisted optimization or walk-forward run before promotion to paper",
+                reason_code="artifacts_pending",
+            ),
         )
     inflight_ok, inflight_msg = _check_validation_in_flight(strategy_id, config)
     if not inflight_ok:
@@ -3787,7 +3869,9 @@ def _evaluate_gauntlet_gate(strategy_id: str, config: dict) -> tuple[bool, str]:
 
     metrics = _load_metrics_blob(row)
     if not metrics:
-        return False, "No gauntlet metrics available"
+        return False, GateRejection(
+            "No gauntlet metrics available", reason_code="no_metrics_error"
+        )
 
     target_metrics = _unwrap_metrics_dict(metrics.get("out_of_sample", metrics))
 
@@ -3912,9 +3996,10 @@ def _evaluate_gauntlet_gate(strategy_id: str, config: dict) -> tuple[bool, str]:
             # trade-frequency-aware default window (forven.wfa_window) makes the
             # re-run produce judgeable folds.
             _min_fold_trades_msg = int((rob_thresholds or {}).get("wfa_min_fold_trades", 5) or 5)
-            return False, (
+            return False, GateRejection(
                 "S00552 BLOCK: walk-forward window insufficient — no OOS fold reached "
-                f"{_min_fold_trades_msg} trades; re-run WFA on the trade-frequency-aware window"
+                f"{_min_fold_trades_msg} trades; re-run WFA on the trade-frequency-aware window",
+                reason_code="wfa_window_insufficient",
             )
         # F4(b): at the paper gate the WFA fold-consistency floor fires whenever
         # walk_forward actually ran — narrowing required_tests must NOT disable a
@@ -3933,9 +4018,10 @@ def _evaluate_gauntlet_gate(strategy_id: str, config: dict) -> tuple[bool, str]:
             # above (only N-of-min judgeable folds instead of zero): actionable
             # re-run, not a merit failure — taxonomy maps it to the counter-exempt
             # wfa_window_insufficient code.
-            return False, (
+            return False, GateRejection(
                 f"S00552 REJECT: Walk-forward has {wfa_folds} folds, requires minimum "
-                f"{wfa_thresholds['min_folds']}; re-run WFA on the trade-frequency-aware window"
+                f"{wfa_thresholds['min_folds']}; re-run WFA on the trade-frequency-aware window",
+                reason_code="wfa_window_insufficient",
             )
         # Single source of truth for the WFA fold-pass-rate floor: the same
         # robustness_thresholds.wfa_fold_pass_rate_min the composite scorer uses
@@ -4048,10 +4134,16 @@ def _evaluate_gauntlet_gate(strategy_id: str, config: dict) -> tuple[bool, str]:
     available_tests = set(verdict_payloads)
     if not available_tests:
         missing = ", ".join(sorted(required_tests))
-        return False, f"Gauntlet missing verdict evidence for required tests: {missing}"
+        return False, GateRejection(
+            f"Gauntlet missing verdict evidence for required tests: {missing}",
+            reason_code="missing_evidence",
+        )
     missing = sorted(required_tests.difference(available_tests))
     if missing:
-        return False, f"Gauntlet missing required verdict tests: {', '.join(missing)}"
+        return False, GateRejection(
+            f"Gauntlet missing required verdict tests: {', '.join(missing)}",
+            reason_code="missing_evidence",
+        )
     failing = sorted(
         test_name
         for test_name in required_tests
@@ -4169,13 +4261,17 @@ def _evaluate_paper_gate(strategy_id: str, config: dict) -> tuple[bool, str]:
         except Exception:
             started = None
     if started is None:
-        return False, (
+        return False, GateRejection(
             "Paper stage entry time unknown (stage_changed_at missing or unparseable) — "
-            "failing closed: paper duration and trade-evidence window cannot be verified"
+            "failing closed: paper duration and trade-evidence window cannot be verified",
+            reason_code="insufficient_paper_evidence",
         )
     days_in_stage = (datetime.now(timezone.utc) - started).days
     if days_in_stage < min_days:
-        return False, f"Insufficient paper duration: {days_in_stage}/{min_days} days"
+        return False, GateRejection(
+            f"Insufficient paper duration: {days_in_stage}/{min_days} days",
+            reason_code="insufficient_paper_evidence",
+        )
 
     params: list[object] = [strategy_id, stage_since]
     where_since = " AND datetime(closed_at) >= datetime(?)"
@@ -4211,7 +4307,10 @@ def _evaluate_paper_gate(strategy_id: str, config: dict) -> tuple[bool, str]:
     )
 
     if total_trades < min_trades:
-        return False, f"Insufficient paper sample: {total_trades}/{min_trades} closed trades"
+        return False, GateRejection(
+            f"Insufficient paper sample: {total_trades}/{min_trades} closed trades",
+            reason_code="insufficient_paper_evidence",
+        )
 
     # === S00152: Load and validate backtest metrics for overfitting guardrails ===
     # Only evaluate these once the strategy has accumulated sufficient forward paper evidence.

--- a/tests/test_pipeline_hardening.py
+++ b/tests/test_pipeline_hardening.py
@@ -594,7 +594,12 @@ def test_transition_stage_keeps_paper_when_live_graduation_gate_fails(forven_db)
     assert transition["from"] == "paper"
     assert transition["to"] == "paper"
     assert transition["requested_to"] == "live_graduated"
-    assert "Insufficient paper duration" in str(transition["blocked_reason"])
+    # PR#60 (strict-live robustness battery) now fires BEFORE the paper-duration
+    # check: a paper->live promotion with no usable gauntlet verdict artifacts is
+    # blocked on absent robustness evidence, not on warm-up duration. The contract
+    # this test locks is unchanged — a not-ready promotion is blocked and stays
+    # paper — only the (correct, earlier) reason moved.
+    assert "Live gate" in str(transition["blocked_reason"])
 
     with get_db() as conn:
         row = conn.execute(
@@ -610,7 +615,7 @@ def test_transition_stage_keeps_paper_when_live_graduation_gate_fails(forven_db)
     assert row["status"] == "paper"
     assert event["from_state"] == "paper"
     assert event["to_state"] == "paper"
-    assert event["reason"].startswith("Gate failure: Insufficient paper duration:")
+    assert event["reason"].startswith("Gate failure: Live gate")
     details = json.loads(event["details_json"] or "{}")
     assert details["motion"] == "gate_failure"
     assert details["requested_stage"] == "live_graduated"
@@ -635,7 +640,10 @@ def test_brain_promote_strategy_returns_false_when_live_gate_blocks(forven_db):
     success, reason = brain_promote_strategy("s-brain-paper-blocked", "live_graduated")
 
     assert success is False
-    assert "paper" in reason.lower()
+    # PR#60 strict-live gate: no gauntlet verdict artifacts -> blocked on absent
+    # robustness evidence (fires before the warm-up checks). The contract is the
+    # block + stay-in-paper below, not the specific gate wording.
+    assert "live gate" in reason.lower()
 
     with get_db() as conn:
         row = conn.execute(
@@ -744,7 +752,10 @@ def test_gate_rejection_does_not_fetch_market_data(forven_db, monkeypatch):
     ok, reason = evaluate_promotion("s-reject-no-fetch", "paper", "live_graduated")
 
     assert ok is False
-    assert "paper" in reason.lower()
+    # The strategy has no gauntlet verdict artifacts, so the strict-live gate blocks
+    # it (PR#60); the exact reason is incidental to this test — the invariant is that
+    # rejection logging performed no market-data fetch.
+    assert "live gate" in reason.lower()
     assert fetch_calls == [], (
         f"gate rejection performed {len(fetch_calls)} market-data fetch(es); "
         "regime enrichment must be cache-only"

--- a/tests/test_reason_code_drift.py
+++ b/tests/test_reason_code_drift.py
@@ -1,0 +1,376 @@
+"""Drift tripwire for evidence-absence gate-rejection classification.
+
+Whether a gate rejection COUNTS toward the 5-strike auto-archive or is EXEMPT
+(evidence-absence: tests not run / in flight / stale / missing / pending) is decided
+by its taxonomy code. Historically that code was recovered by SUBSTRING MATCHING on
+the human prose (``_extract_reason_code``), so rewording an exempt rejection silently
+reclassified it as a COUNTING merit failure and wrongly archived healthy strategies
+(S06127 fold-density 2026-07-06; source-reconciliation-pending 2026-07-10).
+
+The exempt-class sites now carry their code STRUCTURALLY via ``GateRejection`` so the
+classification never depends on prose. This module is the tripwire:
+
+  * ``test_structural_codes_resolve_and_are_exempt`` — the structural contract:
+    every exempt code round-trips through ``_resolve_reason_code`` and belongs to
+    ``_EVIDENCE_ABSENCE_REASON_CODES``.
+  * ``test_producer_*`` — drive each REAL producer function/gate and assert the
+    reason it returns still classifies to its exempt code. These FAIL if someone
+    rewords (and drops the structural code from) an exempt rejection — the exact
+    regression that archived S06127.
+  * ``test_historical_prose_rows_still_classify`` — the literal prose templates
+    still text-match through the ``_extract_reason_code`` fallback, so pre-existing
+    ``gate_rejections`` DB rows (prose only) keep their exempt codes.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import forven.policy as policy
+from forven.db import get_db
+from forven.policy import (
+    DEFAULT_PIPELINE_CONFIG,
+    GateRejection,
+    _EVIDENCE_ABSENCE_REASON_CODES,
+    _check_artifact_ordering,
+    _check_artifact_rows_exist,
+    _check_engine_artifact_freshness,
+    _check_paper_duration,
+    _check_paper_trades,
+    _check_validation_freshness,
+    _check_validation_in_flight,
+    _evaluate_gauntlet_gate,
+    _evaluate_quick_screen_gate,
+    _evaluate_source_divergence_gate,
+    _extract_reason_code,
+    _resolve_reason_code,
+)
+
+
+def _insert_strategy(
+    strategy_id: str,
+    *,
+    stage: str = "gauntlet",
+    symbol: str = "BTC",
+    timeframe: str = "1h",
+    metrics: dict | None = None,
+    stage_changed_at: str | None = None,
+) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    with get_db() as conn:
+        conn.execute(
+            """
+            INSERT INTO strategies
+            (id, name, type, symbol, timeframe, params, metrics, status, owner, stage,
+             stage_changed_at, created_at, updated_at)
+            VALUES (?, ?, 'rsi_momentum', ?, ?, '{}', ?, ?, 'brain', ?, ?, ?, ?)
+            """,
+            (
+                strategy_id,
+                strategy_id,
+                symbol,
+                timeframe,
+                json.dumps(metrics or {}),
+                stage,
+                stage,
+                stage_changed_at or now,
+                now,
+                now,
+            ),
+        )
+
+
+def _insert_result(
+    strategy_id: str,
+    result_type: str,
+    *,
+    metrics: dict | None = None,
+    config: dict | None = None,
+    created_at: str | None = None,
+) -> None:
+    rid = f"{strategy_id}-{result_type}-{int(datetime.now(timezone.utc).timestamp() * 1e6)}"
+    ts = created_at or datetime.now(timezone.utc).isoformat()
+    with get_db() as conn:
+        conn.execute(
+            """INSERT INTO backtest_results
+               (result_id, strategy_id, result_type, symbol, timeframe,
+                metrics_json, config_json, created_at)
+               VALUES (?, ?, ?, 'BTC', '1h', ?, ?, ?)""",
+            (rid, strategy_id, result_type, json.dumps(metrics or {}), json.dumps(config or {}), ts),
+        )
+
+
+def _config() -> dict:
+    return json.loads(json.dumps(DEFAULT_PIPELINE_CONFIG))
+
+
+# --------------------------------------------------------------------------------------
+# Structural contract: every exempt code round-trips and is registered exempt.
+# --------------------------------------------------------------------------------------
+
+def test_structural_codes_resolve_and_are_exempt():
+    for code in _EVIDENCE_ABSENCE_REASON_CODES:
+        rej = GateRejection("any reworded prose whatsoever", reason_code=code)
+        # The structural code wins over prose (which here matches nothing).
+        assert _resolve_reason_code(rej) == code
+        assert code in _EVIDENCE_ABSENCE_REASON_CODES
+
+
+def test_resolve_falls_back_to_text_for_plain_strings():
+    # Plain strings (historical DB rows) keep the text-matcher path.
+    assert _resolve_reason_code("No gauntlet metrics available") == "no_metrics_error"
+    assert _resolve_reason_code("Sharpe too low") == "sharpe_reject"
+
+
+# --------------------------------------------------------------------------------------
+# Producer-driven tripwire: each real site's rejection must classify exempt.
+#
+# ``expected`` is the exempt code the site is contractually required to carry. The
+# assertion checks the FULL resolution path (structural code first, prose fallback
+# second), so it fails if a reword drops the structural code AND breaks the substring
+# pattern — the S06127 regression class.
+# --------------------------------------------------------------------------------------
+
+def _assert_exempt(reason, expected: str):
+    assert reason is not None
+    code = _resolve_reason_code(reason)
+    assert code == expected, f"reason {reason!r} classified as {code!r}, expected {expected!r}"
+    assert code in _EVIDENCE_ABSENCE_REASON_CODES
+
+
+def test_producer_no_metrics_quick_screen(forven_db):
+    _insert_strategy("S-NOMETRICS-QS", stage="quick_screen", metrics={})
+    ok, reason = _evaluate_quick_screen_gate("S-NOMETRICS-QS", _config())
+    assert ok is False
+    _assert_exempt(reason, "no_metrics_error")
+
+
+def test_producer_artifacts_pending_gauntlet(forven_db):
+    # No optimization/walk_forward rows at all -> "requires at least one persisted..."
+    _insert_strategy(
+        "S-ARTIFACTS-PENDING",
+        stage="gauntlet",
+        metrics={"total_trades": 40, "sharpe": 1.5, "profit_factor": 1.4},
+    )
+    ok, reason = _evaluate_gauntlet_gate("S-ARTIFACTS-PENDING", _config())
+    assert ok is False
+    _assert_exempt(reason, "artifacts_pending")
+
+
+def test_producer_validation_in_flight(forven_db):
+    _insert_strategy("S-INFLIGHT", stage="gauntlet")
+    _insert_result("S-INFLIGHT", "walk_forward", metrics={"status": "running"})
+    ok, reason = _check_validation_in_flight("S-INFLIGHT", _config())
+    assert ok is False
+    _assert_exempt(reason, "validation_in_flight")
+
+
+def test_producer_ordering_violation(forven_db):
+    _insert_strategy("S-ORDER", stage="gauntlet")
+    # walk_forward BEFORE optimization -> ordering violation.
+    early = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+    late = datetime.now(timezone.utc).isoformat()
+    _insert_result("S-ORDER", "walk_forward", created_at=early)
+    _insert_result("S-ORDER", "optimization", created_at=late)
+    ok, reason = _check_artifact_ordering("S-ORDER", ["walk_forward"])
+    assert ok is False
+    _assert_exempt(reason, "stale_validation")
+
+
+def test_producer_stale_validation_freshness(forven_db):
+    _insert_strategy("S-STALE", stage="gauntlet")
+    # optimization AFTER the (stale) walk_forward -> validation predates optimization.
+    stale = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+    fresh_opt = datetime.now(timezone.utc).isoformat()
+    _insert_result("S-STALE", "walk_forward", created_at=stale)
+    _insert_result("S-STALE", "optimization", created_at=fresh_opt)
+    ok, reason = _check_validation_freshness("S-STALE", ["walk_forward"])
+    assert ok is False
+    _assert_exempt(reason, "stale_validation")
+
+
+def test_producer_stale_engine_artifacts(forven_db):
+    from forven.engine_provenance import BACKTEST_ENGINE_VERSION
+
+    _insert_strategy("S-ENGINE", stage="gauntlet")
+    # A walk_forward stamped with a lower engine version -> predates current engine.
+    _insert_result(
+        "S-ENGINE",
+        "walk_forward",
+        config={"engine_version": max(BACKTEST_ENGINE_VERSION - 1, 0)},
+    )
+    ok, reason = _check_engine_artifact_freshness("S-ENGINE", ["walk_forward"])
+    assert ok is False
+    _assert_exempt(reason, "stale_engine_artifacts")
+
+
+def test_producer_missing_artifact_rows(forven_db):
+    _insert_strategy("S-MISSING-ROWS", stage="gauntlet")
+    # Required tests but no passing persisted verdict payloads.
+    ok, reason = _check_artifact_rows_exist("S-MISSING-ROWS", ["walk_forward", "monte_carlo"])
+    assert ok is False
+    _assert_exempt(reason, "missing_evidence")
+
+
+def test_producer_insufficient_paper_duration(forven_db):
+    _insert_strategy(
+        "S-PAPER-DUR",
+        stage="paper",
+        stage_changed_at=datetime.now(timezone.utc).isoformat(),
+    )
+    result = _check_paper_duration("S-PAPER-DUR")
+    ok, reason = result[0], result[1]
+    assert ok is False
+    _assert_exempt(reason, "insufficient_paper_evidence")
+
+
+def test_producer_insufficient_paper_trades(forven_db):
+    _insert_strategy(
+        "S-PAPER-TR",
+        stage="paper",
+        stage_changed_at=datetime.now(timezone.utc).isoformat(),
+    )
+    result = _check_paper_trades("S-PAPER-TR")
+    ok, reason = result[0], result[1]
+    assert ok is False
+    _assert_exempt(reason, "insufficient_paper_evidence")
+
+
+def test_producer_source_reconciliation_pending(forven_db):
+    _insert_strategy("S-RECON", stage="gauntlet")
+    settings = {
+        "data_engine_settings": {
+            "source_reconciliation": {"enabled": True, "block_when_missing": True}
+        }
+    }
+    # No divergence reading in KV -> _missing("no data") -> pending.
+    ok, reason = _evaluate_source_divergence_gate("S-RECON", settings)
+    assert ok is False
+    _assert_exempt(reason, "source_reconciliation_pending")
+
+
+def _stub_gauntlet_prereqs(monkeypatch, walk_forward_payload: dict):
+    """Stub the gauntlet gate's artifact prerequisites so the WFA-window branch is
+    reachable in isolation (mirrors tests/test_gauntlet_paper_bypass_fix.py)."""
+    payloads = {
+        "walk_forward": walk_forward_payload,
+        "monte_carlo": {"status": "pass", "passed": True, "max_dd_p95": 0.2, "n_trades": 60},
+        "param_jitter": {"status": "pass", "passed": True, "pass_rate": 0.9},
+        "cost_stress": {"status": "pass", "passed": True},
+        "regime_split": {"status": "pass", "passed": True},
+    }
+    monkeypatch.setattr(policy, "_load_gauntlet_artifact_counts", lambda sid: {"optimization": 1, "walk_forward": 1})
+    monkeypatch.setattr(policy, "_check_artifact_ordering", lambda sid, req=None: (True, "ok"))
+    monkeypatch.setattr(policy, "_check_validation_freshness", lambda sid, req=None: (True, "ok"))
+    monkeypatch.setattr(policy, "_check_validation_in_flight", lambda sid, cfg=None: (True, "ok"))
+    monkeypatch.setattr(
+        policy, "_extract_gauntlet_verdict_payloads", lambda sid, row, metrics: (payloads, "pass")
+    )
+    monkeypatch.setattr(
+        policy, "_load_pipeline_settings",
+        lambda: {"gate_multi_tf_sweep_enabled": False, "gate_require_artifact_rows_enabled": False},
+    )
+
+
+def test_producer_wfa_window_insufficient_fold_evidence(forven_db, monkeypatch):
+    # Every OOS fold below wfa_min_fold_trades -> insufficient_fold_evidence branch.
+    _stub_gauntlet_prereqs(monkeypatch, {
+        "status": "insufficient", "passed": False, "verdict": "INSUFFICIENT",
+        "folds": 0, "pass_rate": 0.0, "insufficient_fold_evidence": True,
+    })
+    _insert_strategy(
+        "S-WFA-INSUFF", stage="gauntlet",
+        metrics={"robustness_score": 80, "total_trades": 60,
+                 "out_of_sample": {"sharpe": 1.0, "profit_factor": 1.3, "win_rate": 55.0,
+                                   "total_return_pct": 12.0, "max_drawdown_pct": 0.10}},
+    )
+    ok, reason = _evaluate_gauntlet_gate("S-WFA-INSUFF", _config())
+    assert ok is False
+    _assert_exempt(reason, "wfa_window_insufficient")
+
+
+def test_producer_wfa_window_insufficient_too_few_folds(forven_db, monkeypatch):
+    # A ran walk_forward with 1 fold (< min_folds 2) but passing pass_rate -> the
+    # "requires minimum" fold-count branch.
+    _stub_gauntlet_prereqs(monkeypatch, {
+        "status": "pass", "passed": True, "folds": 1, "pass_rate": 1.0,
+    })
+    _insert_strategy(
+        "S-WFA-FOLDS", stage="gauntlet",
+        metrics={"robustness_score": 80, "total_trades": 60,
+                 "out_of_sample": {"sharpe": 1.0, "profit_factor": 1.3, "win_rate": 55.0,
+                                   "total_return_pct": 12.0, "max_drawdown_pct": 0.10}},
+    )
+    ok, reason = _evaluate_gauntlet_gate("S-WFA-FOLDS", _config())
+    assert ok is False
+    _assert_exempt(reason, "wfa_window_insufficient")
+
+
+# --------------------------------------------------------------------------------------
+# Historical rows: the prose templates the sites emit must still text-match exempt via
+# the _extract_reason_code fallback (protects old gate_rejections rows that store prose
+# with no structural code).
+# --------------------------------------------------------------------------------------
+
+_HISTORICAL_PROSE = [
+    ("No quick-screen metrics available", "no_metrics_error"),
+    ("No gauntlet metrics available", "no_metrics_error"),
+    (
+        "Gauntlet requires at least one persisted optimization or walk-forward run "
+        "before promotion to paper",
+        "artifacts_pending",
+    ),
+    (
+        "Validation in flight: walk_forward still running — promotion deferred until "
+        "the verdict lands",
+        "validation_in_flight",
+    ),
+    (
+        "Ordering violation: walk_forward was run before optimization — re-run after "
+        "optimization",
+        "stale_validation",
+    ),
+    (
+        "Stale validation tests (run before latest optimization): walk_forward",
+        "stale_validation",
+    ),
+    (
+        "Validation artifacts predate the current engine version (v9) and are queued "
+        "for re-validation: walk_forward (engine v8)",
+        "stale_engine_artifacts",
+    ),
+    (
+        "Missing passing persisted artifact rows for: monte_carlo. Run or rerun these "
+        "tests until the saved verdicts pass.",
+        "missing_evidence",
+    ),
+    ("Gauntlet missing verdict evidence for required tests: walk_forward", "missing_evidence"),
+    ("Gauntlet missing required verdict tests: monte_carlo", "missing_evidence"),
+    ("Insufficient paper duration: 3/14 days", "insufficient_paper_evidence"),
+    ("Insufficient paper trades: 10/50", "insufficient_paper_evidence"),
+    ("Insufficient paper sample: 10/50 closed trades", "insufficient_paper_evidence"),
+    (
+        "Source reconciliation pending (no data) — divergence not yet computed for BTC 1h",
+        "source_reconciliation_pending",
+    ),
+    (
+        "S00552 BLOCK: walk-forward window insufficient — no OOS fold reached 5 trades; "
+        "re-run WFA on the trade-frequency-aware window",
+        "wfa_window_insufficient",
+    ),
+    (
+        "S00552 REJECT: Walk-forward has 1 folds, requires minimum 2; re-run WFA on the "
+        "trade-frequency-aware window",
+        "wfa_window_insufficient",
+    ),
+]
+
+
+@pytest.mark.parametrize("prose,expected", _HISTORICAL_PROSE)
+def test_historical_prose_rows_still_classify(prose, expected):
+    code = _extract_reason_code(prose)
+    assert code == expected, f"prose {prose!r} text-matched to {code!r}, expected {expected!r}"
+    assert code in _EVIDENCE_ABSENCE_REASON_CODES


### PR DESCRIPTION
## Problem

The pipeline auto-archives a strategy that fails the same gate 5 times (`_check_repeated_failure_auto_archive`). Whether a rejection COUNTS toward that archive or is EXEMPT (evidence-absence: tests not yet run, work in flight, stale/pending/missing artifacts) was decided entirely by **substring matching on the human rejection prose** (`_extract_reason_code`). policy.py has ~84 `return False, "<reason>"` sites; any reason wording that didn't match an exemption pattern silently became a COUNTING merit failure.

This caused at least three wrongly-archived incidents: S06127 fold-density (2026-07-06), the source-reconciliation-pending case (2026-07-10, caught during PR#60 verification), and earlier `wfa_reject` misclassifications.

## Mechanism

`GateRejection(str)` — a rejection reason that carries its taxonomy code **structurally** from the rejection site. It is a drop-in `str` subclass, so it is wire-compatible with every f-string, DB binding, `.lower()`, comparison, dict-key and JSON path the ~84 `(bool, reason)` tuple consumers use (verified across `copy.deepcopy`, `json.dumps`, `==`, `.startswith`). No consumer changed.

`_log_gate_rejection_record` now resolves the code via a new `_resolve_reason_code(reason)`:
1. **structural code first** — `getattr(reason, "reason_code", None)`; an exempt-class rejection never depends on prose again (design goals 1 & 2).
2. **prose text-matcher fallback** — `_extract_reason_code(str(reason))` for plain-string sites and, crucially, for historical prose-only `gate_rejections` DB rows (design goal 4).

Text matching stays for MERIT rejections (they count anyway — misclassification among counting codes is cosmetic).

No gate or threshold semantics changed. Exempt stays exempt, counting stays counting — only **how** the classification travels, plus the tripwire.

## Migrated site inventory (18 sites, 9 exempt codes)

| Code | Sites |
|---|---|
| `no_metrics_error` | "No quick-screen metrics available", "No gauntlet metrics available" |
| `artifacts_pending` | "Gauntlet requires at least one persisted optimization or walk-forward run…" |
| `validation_in_flight` | "Validation in flight: … still running…" |
| `stale_validation` | "Ordering violation: … before optimization", "Stale validation tests (run before latest optimization)…" |
| `stale_engine_artifacts` | "Validation artifacts predate the current engine version…" |
| `missing_evidence` | "Missing passing persisted artifact rows for…", "Gauntlet missing verdict evidence…", "Gauntlet missing required verdict tests…" |
| `insufficient_paper_evidence` | `_check_paper_duration` / `_check_paper_trades` helpers, `_evaluate_paper_gate` duration / sample / entry-time-unknown |
| `source_reconciliation_pending` | `_evaluate_source_divergence_gate._missing(...)` |
| `wfa_window_insufficient` | "walk-forward window insufficient" (insufficient_fold_evidence), "Walk-forward has N folds, requires minimum" |

The 10th exempt code `stale_data_artifacts` has no producer — data-semantics staleness flows through the `missing_evidence` "absent test" path; its text patterns remain in the fallback matcher for any external/historical rows.

Also hoisted a `"missing"+"verdict"` fallback pattern in `_extract_reason_code` **before** the `walk`+`forward` branch: the historical prose "Gauntlet missing verdict evidence for required tests: walk_forward" text-matched to the COUNTING `wfa_reject` (the test-name list contains "walk_forward"). Live sites now carry `missing_evidence` structurally; this protects prose-only DB rows. It only affects strings containing both "missing" and "verdict" — no genuine `wfa_reject` reclassifies.

## Tripwire design (`tests/test_reason_code_drift.py`, 30 cases)

- **Producer-driven** (`test_producer_*`): DB-seeds each real producer so the actual gate function returns its `GateRejection`, then asserts the reason still resolves to its exempt code via the full `_resolve_reason_code` path. Fails if someone rewords **and** drops the structural code from an exempt rejection — the S06127/reconciliation regression class.
- **Structural contract**: every code in `_EVIDENCE_ABSENCE_REASON_CODES` round-trips through `_resolve_reason_code` and is registered exempt.
- **Historical prose** (16 parametrized): the literal templates the sites emit still text-match to their exempt code via the fallback, protecting old DB rows.

**Fail-before proof**: temporarily rewording the reconciliation-pending reason without its code makes `test_producer_source_reconciliation_pending` fail — the reworded prose text-matched into the counting `source_divergence_reject` bucket, i.e. the exact 2026-07-10 incident.

## Drifted-test diagnosis (Task 2)

The 3 named tests failed on clean base c3f16d01 because **PR#60 ("Harden Forge lifecycle correctness", 2026-07-10)** added the strict-live robustness battery (`_strict_robustness_reject`) at the **top** of `_evaluate_paper_gate`, before the warm-up duration/sample checks. The three tests seed a paper-stage strategy with only top-level metrics and **no gauntlet verdict artifacts**, so the strict-live gate correctly blocks with `"Live gate: robustness evidence unavailable (no usable gauntlet artifacts)"` — which fires before the "Insufficient paper duration" / "paper"-substring reasons the tests asserted.

**The code is correct** (a paper→live promotion with no usable robustness evidence should block on that, before capital). The tests asserted a now-superseded reason. Fixed by updating only the reason assertions to the correct live-gate block; every structural assertion (blocked, stays paper, `strategy_events` recorded, no promotion/activity row) is unchanged.

## Out-of-scope note

`tests/test_paper_gate_s00152.py` has 14 failures from the **same** PR#60 strict-live drift (identical `"Live gate: robustness evidence unavailable"` cause). They are **pre-existing on clean base** (14 failed / 2 passed both before and after this branch) and live in a file outside this task's 3-named-test scope, so they are untouched here.

## Tests

- `tests/test_pipeline_hardening.py` — 120 passed (incl. the 3 fixed)
- `tests/test_reason_code_drift.py` (new) — 30 passed
- `tests/test_two_tier_gate.py`, `tests/test_gauntlet_paper_bypass_fix.py`, `tests/test_policy_evidence_absence.py` — all passed
- `tests/test_source_reconciliation_gate.py` — 21 passed; the 3 `reconcile_one_*` producer failures are the known-environmental ones (pre-existing, `source_reconciliation.py` internals — out of scope)
- `ruff check forven tests` — clean

Touched only `forven/policy.py` and test files. `brain.py` unchanged (no rejection site or drifted test required it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CBHuQy6taZsvWNwsKig2N
