### PR TITLE
fix(hygiene): surface swallowed errors, guard ops poll, index settings-save query

### DIFF
--- a/forven/db.py
+++ b/forven/db.py
@@ -1328,6 +1328,12 @@ POST_MIGRATION_INDEXES_SQL = """
 CREATE INDEX IF NOT EXISTS idx_trades_strategy_id ON trades (strategy_id);
 CREATE INDEX IF NOT EXISTS idx_trades_strategy ON trades (strategy);
 CREATE INDEX IF NOT EXISTS idx_trades_status ON trades (status);
+-- Partial composite index for _has_open_book_routed_trades(), which runs on
+-- every settings mutation: SELECT 1 FROM trades WHERE status = 'OPEN' AND book
+-- IS NOT NULL AND book != '' AND book != 'main'. idx_trades_status alone forces
+-- a scan of all OPEN rows; this partial index restricts to OPEN rows and orders
+-- them by book so the residual book filters resolve without a full-open scan.
+CREATE INDEX IF NOT EXISTS idx_trades_open_book ON trades (status, book) WHERE status = 'OPEN';
 CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks (status);
 CREATE INDEX IF NOT EXISTS idx_tasks_type_status ON tasks (type, status);
 CREATE INDEX IF NOT EXISTS idx_agent_tasks_status ON agent_tasks (status);

--- a/frontend/src/routes/data/+page.svelte
+++ b/frontend/src/routes/data/+page.svelte
@@ -649,9 +649,16 @@
 
 		// Keep the maintenance operations panels live while a long job runs
 		// (universe seed / deep-history backfill) — per-symbol progress updates.
+		// In-flight guard mirrors `polling` above so a load that runs longer than
+		// the 4s interval can't stack overlapping requests.
+		let opsPolling = false;
 		const opsInterval = setInterval(() => {
-			if (isDestroyed || activeTab !== 'maintenance') return;
-			if (universe?.seed?.running || bvStatus?.running) void loadOpsPanels();
+			if (isDestroyed || opsPolling || activeTab !== 'maintenance') return;
+			if (!(universe?.seed?.running || bvStatus?.running)) return;
+			opsPolling = true;
+			loadOpsPanels().finally(() => {
+				opsPolling = false;
+			});
 		}, 4000);
 
 		return () => {

--- a/frontend/src/routes/strategy-creator/+page.svelte
+++ b/frontend/src/routes/strategy-creator/+page.svelte
@@ -574,6 +574,35 @@ TYPE_NAME = "my_strategy"
 		};
 	}
 
+	// Persist the "tested" library status optimistically: flip the local card to
+	// 'tested' immediately so the UI reflects the just-run backtest, then reconcile
+	// with the backend. If the persist fails, revert the optimistic status and warn
+	// so the card can't show 'tested' while the backend still holds the old status.
+	async function persistTestedStatus(libraryId: string, resultId: string) {
+		const idx = library.findIndex((l) => l.id === libraryId);
+		const previousStatus = idx >= 0 ? library[idx].status : null;
+		if (idx >= 0 && library[idx].status !== 'tested') {
+			library[idx] = { ...library[idx], status: 'tested', last_result_id: resultId };
+			library = library;
+		}
+		try {
+			const updated = await updateLibraryStrategy(libraryId, { status: 'tested', last_result_id: resultId });
+			const i = library.findIndex((l) => l.id === libraryId);
+			if (i >= 0) {
+				library[i] = updated;
+				library = library;
+			}
+		} catch (err) {
+			const i = library.findIndex((l) => l.id === libraryId);
+			if (i >= 0 && previousStatus !== null) {
+				library[i] = { ...library[i], status: previousStatus };
+				library = library;
+			}
+			console.warn('Failed to persist library status', err);
+			addToast('Could not persist library status — the card status may be out of date', 'warning');
+		}
+	}
+
 	async function runBacktest() {
 		const error = validateRun();
 		if (error) {
@@ -593,7 +622,7 @@ TYPE_NAME = "my_strategy"
 			addToast(`Backtest ${job.status === 'succeeded' ? 'completed' : 'queued'}`, job.status === 'succeeded' ? 'success' : 'info');
 			if (job.result_id) {
 				lastResultId = job.result_id;
-				if (currentLibraryId) updateLibraryStrategy(currentLibraryId, { status: 'tested', last_result_id: job.result_id }).catch(() => {});
+				if (currentLibraryId) void persistTestedStatus(currentLibraryId, job.result_id);
 				resultLoading = true;
 				try {
 					inlineResult = await getResult(job.result_id);
@@ -616,7 +645,17 @@ TYPE_NAME = "my_strategy"
 
 	onMount(async () => {
 		try {
-			const [inds, syms] = await Promise.all([getIndicators(), getSymbols().catch(() => [])]);
+			// Symbol suggestions are non-essential: keep the empty-array fallback so the
+			// page still renders, but surface the failure instead of silently showing an
+			// empty dropdown with no signal.
+			const [inds, syms] = await Promise.all([
+				getIndicators(),
+				getSymbols().catch((err) => {
+					console.warn('Failed to load symbol suggestions', err);
+					addToast('Could not load symbol suggestions — you can still type a symbol manually', 'warning');
+					return [] as string[];
+				}),
+			]);
 			indicators = inds;
 			symbolSuggestions = syms;
 		} catch (err) {

--- a/tests/test_db_indexes.py
+++ b/tests/test_db_indexes.py
@@ -22,6 +22,81 @@ def test_status_indexes_exist_after_init(forven_db):
     assert "idx_scheduler_jobs_last_status" in scheduler_indexes
 
 
+def test_open_book_partial_index_exists_after_init(forven_db):
+    """The settings-save hot query index is created and is a partial index.
+
+    _has_open_book_routed_trades() runs on every settings mutation and only
+    reads OPEN rows; idx_trades_open_book restricts to those and orders by book.
+    """
+    with get_db() as conn:
+        trade_indexes = {
+            row["name"] for row in conn.execute("PRAGMA index_list('trades')").fetchall()
+        }
+        assert "idx_trades_open_book" in trade_indexes
+
+        # Columns, in order: (status, book).
+        cols = [
+            str(row["name"])
+            for row in conn.execute(
+                "PRAGMA index_info('idx_trades_open_book')"
+            ).fetchall()
+        ]
+        assert cols == ["status", "book"]
+
+        # It must be a partial index (has a WHERE clause on status = 'OPEN'),
+        # so it stays small and only covers the rows the query touches.
+        sql = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'index' "
+            "AND name = 'idx_trades_open_book'"
+        ).fetchone()["sql"]
+        assert "WHERE" in sql.upper()
+        assert "'OPEN'" in sql
+
+
+def test_open_book_partial_index_idempotent_and_used_by_hot_query(forven_db):
+    """The index applies idempotently and the settings-save hot query uses it.
+
+    Re-running init_db() on an already-initialized DB (the common every-boot
+    path for existing installs) must be a clean no-op, and the planner must pick
+    idx_trades_open_book for _has_open_book_routed_trades()'s query.
+    """
+    # Re-running the whole schema/migration/index bootstrap on an existing DB
+    # must not raise (all statements are IF NOT EXISTS / additive).
+    init_db()
+
+    with get_db() as conn:
+        conn.executescript(
+            """
+            INSERT INTO trades (id, strategy, asset, direction, status, book) VALUES
+                ('t1', 's1', 'BTC/USDT', 'long', 'OPEN', 'long'),
+                ('t2', 's1', 'ETH/USDT', 'long', 'OPEN', 'main'),
+                ('t3', 's1', 'SOL/USDT', 'long', 'OPEN', ''),
+                ('t4', 's1', 'BTC/USDT', 'short', 'CLOSED', 'short');
+            """
+        )
+
+        trade_indexes = {
+            row["name"] for row in conn.execute("PRAGMA index_list('trades')").fetchall()
+        }
+        assert "idx_trades_open_book" in trade_indexes
+
+        # The hot query returns the routed-open row (t1) — 'main'/''/CLOSED excluded.
+        row = conn.execute(
+            "SELECT 1 FROM trades WHERE status = 'OPEN' AND book IS NOT NULL "
+            "AND book != '' AND book != 'main' LIMIT 1"
+        ).fetchone()
+        assert row is not None
+
+        # And the planner uses the new partial index for that query.
+        plan = conn.execute(
+            "EXPLAIN QUERY PLAN "
+            "SELECT 1 FROM trades WHERE status = 'OPEN' AND book IS NOT NULL "
+            "AND book != '' AND book != 'main' LIMIT 1"
+        ).fetchall()
+        plan_text = " ".join(str(r["detail"]) for r in plan)
+        assert "idx_trades_open_book" in plan_text
+
+
 def test_init_db_bootstraps_hypothesis_indexes_for_legacy_strategies_table(tmp_path):
     db_path = cfg.FORVEN_DB
     conn = sqlite3.connect(str(db_path))


### PR DESCRIPTION
P2 hygiene batch: three small, independent fixes (two frontend, one DB-side index). No behavior changes to the trading pipeline.

## FIX 1 — Error swallowing in strategy-creator
`frontend/src/routes/strategy-creator/+page.svelte`

- **Symbol load (`getSymbols().catch(() => [])`)** rendered an empty dropdown with no signal on failure. Now keeps the empty-array fallback (page still renders) but adds `console.warn` + a non-blocking warning toast ("Could not load symbol suggestions — you can still type a symbol manually"), so the operator knows suggestions failed rather than assuming there are none.
- **Library status persist (`updateLibraryStrategy(...).catch(() => {})`)** was fire-and-forget with no local state update. Reworked into an **optimistic-with-revert** helper `persistTestedStatus`: the library card flips to `'tested'` immediately, reconciles with the returned row on success, and **on failure reverts the card to its prior status + warns** ("Could not persist library status …"). The card can no longer show `'tested'` while the backend still holds the old status.

## FIX 2 — Polling leaks
`frontend/src/routes/data/+page.svelte`

- `opsInterval` fired `loadOpsPanels()` every 4s with **no in-flight guard** — a load exceeding 4s could stack overlapping calls. Added an `opsPolling` flag that mirrors the sibling `interval`'s existing `polling` guard pattern (set before the call, cleared in `.finally()`). Behavior-preserving otherwise.
- **Note:** `DataInspector.svelte`'s `backfillPollTimer` already had an `onDestroy` `clearInterval` cleanup at the base commit (`63568547`), so no change was needed there. (See deviations.)

## FIX 3 — Composite index for the settings-save hot query
`forven/db.py`

`_has_open_book_routed_trades()` (in `api_core.py`, unchanged) runs on **every settings mutation**:
```sql
SELECT 1 FROM trades WHERE status = 'OPEN' AND book IS NOT NULL AND book != '' AND book != 'main' LIMIT 1
```
Only `idx_trades_status` existed, so all OPEN rows were scanned. Added a partial composite index alongside the sibling trade indexes in `POST_MIGRATION_INDEXES_SQL` (which runs on every `init_db()`, so existing installs pick it up additively — the established pattern):
```sql
CREATE INDEX IF NOT EXISTS idx_trades_open_book ON trades (status, book) WHERE status = 'OPEN';
```
It restricts the index to OPEN rows and orders them by `book`, so the residual `book` filters resolve without a full-open scan. This codebase already uses SQLite partial indexes (e.g. `idx_trades_unique_open`), so the syntax is supported. **The query and `api_core.py` are untouched — this is DB-side only.**

Regression tests in `tests/test_db_indexes.py`:
- index exists + is a partial index (`WHERE ... 'OPEN'`) after `init_db()`, columns are `(status, book)`;
- `init_db()` is idempotent (clean re-run on an already-initialized DB);
- `EXPLAIN QUERY PLAN` confirms the planner actually picks `idx_trades_open_book` for the hot query.

## Verification
- **Frontend:** `npm run check` → 0 errors (2 pre-existing warnings in untouched files); `npm test` → **411 passed / 65 files**.
- **Backend:** `tests/test_db_indexes.py` → 4 passed (2 new); `tests/test_migrations.py` + `tests/test_db_migration_safety.py` → 21 passed; `ruff check forven tests` → clean.

## Deviations / limitations
- **FIX 2 (DataInspector):** already fixed at the base commit — verified `onDestroy` cleanup for `backfillPollTimer` is present in `63568547`. No change made.
- **Component tests:** the codebase's test idiom is overwhelmingly pure-logic unit tests; only one small self-contained component (`RuleBuilder`) uses the `@testing-library/svelte` mount harness. Mounting the full `strategy-creator`/`data` **pages** would require extensive brittle mocking of `\$app/navigation`, ~15 API modules, and network-firing `onMount` side-effects — disproportionate for these fixes. The frontend changes are verified via `npm run check` + `npm test` + careful review; the DB fix carries full regression coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CBHuQy6taZsvWNwsKig2N