### PR TITLE
fix(p2): offload MC + regime-split compute off the API GIL; fix s00152 test drift

### DIFF
--- a/forven/routers/robustness.py
+++ b/forven/routers/robustness.py
@@ -977,6 +977,204 @@ def _run_walk_forward_analysis(body: WalkForwardBody) -> dict:
     return result
 
 
+def _monte_carlo_bootstrap_worker(
+    returns: list[float],
+    *,
+    original_sharpe: float,
+    original_return: float,
+    n_simulations: int,
+    initial_capital: float,
+    mc_profitable_min: float,
+    max_dd_p95_limit_pct: float,
+) -> dict:
+    """Pure numpy bootstrap of realized trade returns — the Monte Carlo compute core.
+
+    This is the GIL-bound hotspot of the MC step: ``n_simulations`` (default 1000)
+    seeded resamples over the realized trade returns, each doing cumprod / drawdown /
+    percentile numpy work. It touches NO database, lake, or global state, and all of
+    its inputs are plain floats/lists, so it is offloaded to an isolated subprocess by
+    ``_run_monte_carlo_analysis`` (mirroring the isolated backtest workers). It is a
+    MODULE-LEVEL function precisely so spawn-based ProcessPoolExecutor can pickle it on
+    Windows. The RNG is seeded (42) inside the function, so the result is bit-identical
+    whether it runs in-thread or in a child process.
+    """
+    rng = np.random.default_rng(42)
+    returns_arr = _finite_array(returns)
+    n_trades = len(returns)
+    # Preserve the original loop/output semantics exactly: the loop is clamped to >=1
+    # iteration, while the path-sampling stride and the reported n_simulations use the
+    # RAW requested count (so a degenerate 0 request reports 0, as before).
+    n_simulations = int(n_simulations)
+    n_iterations = max(n_simulations, 1)
+    initial_capital = float(initial_capital)
+    final_returns: list[float] = []
+    max_drawdowns: list[float] = []
+    sharpes: list[float] = []
+    equity_paths: list[list[float]] = []
+    max_paths = 50
+
+    for sim_idx in range(n_iterations):
+        sampled = rng.choice(returns_arr, size=n_trades, replace=True)
+        equity_factors = np.cumprod(1.0 + sampled)
+        equity = equity_factors * initial_capital
+        final_return_pct = ((equity[-1] - initial_capital) / initial_capital) * 100.0
+        final_returns.append(float(final_return_pct))
+
+        # Include the pre-trade starting balance in the peak path. Otherwise a loss
+        # on the first sampled trade becomes the initial peak and its drawdown vanishes.
+        equity_with_initial = np.concatenate(([initial_capital], equity))
+        peak = np.maximum.accumulate(equity_with_initial)
+        drawdown_pct = np.where(
+            peak > 0,
+            (peak - equity_with_initial) / peak * 100.0,
+            0.0,
+        )
+        max_drawdowns.append(float(np.nanmax(drawdown_pct)) if drawdown_pct.size else 0.0)
+
+        if len(sampled) > 1 and np.std(sampled) > 0:
+            # Per-TRADE Sharpe of the bootstrapped path. (Was * sqrt(252), which
+            # annualizes as if these were daily returns — they are per-trade returns at
+            # an arbitrary frequency, so the 252 factor was a meaningless scale. This is
+            # a diagnostic only; the MC verdict uses prob_profitable + the drawdown cap.)
+            sharpes.append(float(np.mean(sampled) / np.std(sampled)))
+        else:
+            sharpes.append(0.0)
+
+        if n_simulations <= max_paths or sim_idx % max(1, n_simulations // max_paths) == 0:
+            if len(equity_paths) < max_paths:
+                equity_paths.append([initial_capital] + equity.tolist())
+
+    final_returns_arr = _finite_array(final_returns)
+    max_drawdowns_arr = _finite_array(max_drawdowns)
+    sharpes_arr = _finite_array(sharpes)
+    percentile_rank = (
+        float(np.mean(final_returns_arr <= original_return) * 100.0)
+        if final_returns_arr.size
+        else 0.0
+    )
+    max_dd_percentiles = _percentile_distribution(max_drawdowns_arr)
+    prob_profitable = round(float(np.mean(final_returns_arr > 0) * 100.0), 1) if final_returns_arr.size else 0.0
+    max_dd_p95 = float(max_dd_percentiles.get("p95", 0.0) or 0.0)
+    verdict_reasons: list[str] = []
+    if prob_profitable < mc_profitable_min:
+        verdict_reasons.append(
+            f"probability profitable {prob_profitable:.1f}% below {mc_profitable_min:.1f}% threshold"
+        )
+    if max_dd_p95 > max_dd_p95_limit_pct:
+        verdict_reasons.append(
+            f"95th percentile drawdown {max_dd_p95:.1f}% exceeds {max_dd_p95_limit_pct:.1f}% limit"
+        )
+
+    return {
+        "method": "trade_bootstrap",
+        # Interpretation guard (issue #19): this test bootstraps the trades the
+        # baseline ALREADY produced, so a PASS certifies sequencing/tail-risk
+        # stability of that trade set — it is not evidence the edge is real.
+        "scope_note": (
+            "Bootstrap of realized trade returns: tests stability of the trade "
+            "sequence and bounds tail risk. It does not test whether the "
+            "underlying edge is real — walk-forward and regime-split do that."
+        ),
+        "original_sharpe": round(original_sharpe, 3),
+        "original_return": round(original_return, 2),
+        "n_simulations": int(n_simulations),
+        "n_trades": n_trades,
+        "percentile_rank": round(percentile_rank, 1),
+        "percentile_score": round(prob_profitable / 100.0, 5),
+        "return_distribution": _percentile_distribution(final_returns_arr),
+        "drawdown_distribution": max_dd_percentiles,
+        "sharpe_distribution": _percentile_distribution(sharpes_arr),
+        "prob_profitable": prob_profitable,
+        "prob_loss_gt_10": round(float(np.mean(final_returns_arr < -10) * 100.0), 1) if final_returns_arr.size else 0.0,
+        "verdict": "FAIL" if verdict_reasons else "PASS",
+        "verdict_reasons": verdict_reasons,
+        "verdict_threshold": round(mc_profitable_min, 1),
+        "verdict_thresholds": {
+            "min_prob_profitable": round(mc_profitable_min, 1),
+            "max_dd_p95": round(max_dd_p95_limit_pct, 1),
+        },
+        "equity_paths": equity_paths,
+        "return_histogram": _make_histogram(final_returns_arr),
+        "drawdown_histogram": _make_histogram(max_drawdowns_arr),
+        "sharpe_histogram": _make_histogram(sharpes_arr),
+        "max_dd_p95_ratio": round(float(max_dd_p95 / 100.0), 5),
+    }
+
+
+# Wall-clock ceiling for the offloaded Monte Carlo bootstrap subprocess. The compute
+# is bounded by n_simulations (default 1000) x n_trades numpy ops — seconds in
+# practice — so this is a leak/hang backstop, not a normal-path limit.
+_MONTE_CARLO_ISOLATION_TIMEOUT = 300
+
+
+def _run_monte_carlo_bootstrap(
+    returns: list[float],
+    *,
+    original_sharpe: float,
+    original_return: float,
+    n_simulations: int,
+    initial_capital: float,
+    mc_profitable_min: float,
+    max_dd_p95_limit_pct: float,
+) -> dict:
+    """Run the Monte Carlo bootstrap, offloaded to an isolated subprocess.
+
+    The bootstrap is a self-contained, DB-free numpy hotspot (see
+    ``_monte_carlo_bootstrap_worker``) that otherwise burns the GIL on an API worker
+    thread for the duration of ``n_simulations`` resamples — one of the multi-second
+    event-loop stalls attributed to gauntlet/validation compute. It queues on the
+    process-wide subprocess budget (``strategies/concurrency.py``) exactly like every
+    isolated backtest, so peak child-process memory stays bounded no matter how the
+    parallel levers stack. Falls back to running inline (identical result — the RNG is
+    seeded inside the worker) under pytest, when isolation is disabled, or if the child
+    process cannot be spawned; a subprocess timeout/crash is a real failure and raised.
+    """
+    kwargs = {
+        "original_sharpe": original_sharpe,
+        "original_return": original_return,
+        "n_simulations": n_simulations,
+        "initial_capital": initial_capital,
+        "mc_profitable_min": mc_profitable_min,
+        "max_dd_p95_limit_pct": max_dd_p95_limit_pct,
+    }
+
+    from forven.strategies.backtest import _should_use_process_isolation
+
+    if not _should_use_process_isolation():
+        return _monte_carlo_bootstrap_worker(returns, **kwargs)
+
+    import concurrent.futures
+    import multiprocessing
+
+    from forven.strategies.backtest import _kill_executor_processes
+    from forven.strategies.concurrency import backtest_subprocess_slot
+
+    try:
+        with backtest_subprocess_slot("monte_carlo"), concurrent.futures.ProcessPoolExecutor(
+            max_workers=1,
+            mp_context=multiprocessing.get_context("spawn"),
+        ) as executor:
+            future = executor.submit(_monte_carlo_bootstrap_worker, returns, **kwargs)
+            try:
+                return future.result(timeout=_MONTE_CARLO_ISOLATION_TIMEOUT)
+            except concurrent.futures.TimeoutError:
+                log.error(
+                    "ISOLATION: Monte Carlo bootstrap timed out after %ds (%d simulations, %d returns)",
+                    _MONTE_CARLO_ISOLATION_TIMEOUT, int(n_simulations), len(returns),
+                )
+                _kill_executor_processes(executor)
+                raise HTTPException(
+                    500,
+                    f"Monte Carlo bootstrap timed out after {_MONTE_CARLO_ISOLATION_TIMEOUT}s.",
+                )
+    except (OSError, concurrent.futures.BrokenExecutor) as exc:
+        # The child process could not be spawned (fork/exec failure, broken pool):
+        # degrade to inline compute rather than fail the required test. The result is
+        # identical — the RNG is seeded inside the worker.
+        log.warning("Monte Carlo isolation unavailable (%s) — running inline", exc)
+        return _monte_carlo_bootstrap_worker(returns, **kwargs)
+
+
 def _run_monte_carlo_analysis(body: MonteCarloBody) -> dict:
     context = _result_context_from_detail(body.result_id)
     trades = context["trades"]
@@ -1013,101 +1211,18 @@ def _run_monte_carlo_analysis(body: MonteCarloBody) -> dict:
     max_dd_p95_limit_raw = float(gauntlet_cfg.get("mc_max_dd_p95", 0.40))
     max_dd_p95_limit_pct = max_dd_p95_limit_raw * 100.0 if abs(max_dd_p95_limit_raw) <= 1.0 else max_dd_p95_limit_raw
 
-    rng = np.random.default_rng(42)
-    returns_arr = _finite_array(returns)
-    n_trades = len(returns)
-    final_returns: list[float] = []
-    max_drawdowns: list[float] = []
-    sharpes: list[float] = []
-    equity_paths: list[list[float]] = []
-    max_paths = 50
-
-    for sim_idx in range(max(int(body.n_simulations), 1)):
-        sampled = rng.choice(returns_arr, size=n_trades, replace=True)
-        equity_factors = np.cumprod(1.0 + sampled)
-        equity = equity_factors * body.initial_capital
-        final_return_pct = ((equity[-1] - body.initial_capital) / body.initial_capital) * 100.0
-        final_returns.append(float(final_return_pct))
-
-        # Include the pre-trade starting balance in the peak path. Otherwise a loss
-        # on the first sampled trade becomes the initial peak and its drawdown vanishes.
-        equity_with_initial = np.concatenate(([float(body.initial_capital)], equity))
-        peak = np.maximum.accumulate(equity_with_initial)
-        drawdown_pct = np.where(
-            peak > 0,
-            (peak - equity_with_initial) / peak * 100.0,
-            0.0,
-        )
-        max_drawdowns.append(float(np.nanmax(drawdown_pct)) if drawdown_pct.size else 0.0)
-
-        if len(sampled) > 1 and np.std(sampled) > 0:
-            # Per-TRADE Sharpe of the bootstrapped path. (Was * sqrt(252), which
-            # annualizes as if these were daily returns — they are per-trade returns at
-            # an arbitrary frequency, so the 252 factor was a meaningless scale. This is
-            # a diagnostic only; the MC verdict uses prob_profitable + the drawdown cap.)
-            sharpes.append(float(np.mean(sampled) / np.std(sampled)))
-        else:
-            sharpes.append(0.0)
-
-        if body.n_simulations <= max_paths or sim_idx % max(1, body.n_simulations // max_paths) == 0:
-            if len(equity_paths) < max_paths:
-                equity_paths.append([float(body.initial_capital)] + equity.tolist())
-
-    final_returns_arr = _finite_array(final_returns)
-    max_drawdowns_arr = _finite_array(max_drawdowns)
-    sharpes_arr = _finite_array(sharpes)
-    percentile_rank = (
-        float(np.mean(final_returns_arr <= original_return) * 100.0)
-        if final_returns_arr.size
-        else 0.0
+    # The bootstrap itself is a DB-free numpy hotspot: offload it to an isolated
+    # subprocess (queued on the process-wide budget) so it no longer holds the GIL on
+    # an API worker thread. All the DB/config reads above stay in-thread.
+    return _run_monte_carlo_bootstrap(
+        returns,
+        original_sharpe=original_sharpe,
+        original_return=original_return,
+        n_simulations=int(body.n_simulations),
+        initial_capital=float(body.initial_capital),
+        mc_profitable_min=mc_profitable_min,
+        max_dd_p95_limit_pct=max_dd_p95_limit_pct,
     )
-    max_dd_percentiles = _percentile_distribution(max_drawdowns_arr)
-    prob_profitable = round(float(np.mean(final_returns_arr > 0) * 100.0), 1) if final_returns_arr.size else 0.0
-    max_dd_p95 = float(max_dd_percentiles.get("p95", 0.0) or 0.0)
-    verdict_reasons: list[str] = []
-    if prob_profitable < mc_profitable_min:
-        verdict_reasons.append(
-            f"probability profitable {prob_profitable:.1f}% below {mc_profitable_min:.1f}% threshold"
-        )
-    if max_dd_p95 > max_dd_p95_limit_pct:
-        verdict_reasons.append(
-            f"95th percentile drawdown {max_dd_p95:.1f}% exceeds {max_dd_p95_limit_pct:.1f}% limit"
-        )
-
-    return {
-        "method": "trade_bootstrap",
-        # Interpretation guard (issue #19): this test bootstraps the trades the
-        # baseline ALREADY produced, so a PASS certifies sequencing/tail-risk
-        # stability of that trade set — it is not evidence the edge is real.
-        "scope_note": (
-            "Bootstrap of realized trade returns: tests stability of the trade "
-            "sequence and bounds tail risk. It does not test whether the "
-            "underlying edge is real — walk-forward and regime-split do that."
-        ),
-        "original_sharpe": round(original_sharpe, 3),
-        "original_return": round(original_return, 2),
-        "n_simulations": int(body.n_simulations),
-        "n_trades": n_trades,
-        "percentile_rank": round(percentile_rank, 1),
-        "percentile_score": round(prob_profitable / 100.0, 5),
-        "return_distribution": _percentile_distribution(final_returns_arr),
-        "drawdown_distribution": max_dd_percentiles,
-        "sharpe_distribution": _percentile_distribution(sharpes_arr),
-        "prob_profitable": prob_profitable,
-        "prob_loss_gt_10": round(float(np.mean(final_returns_arr < -10) * 100.0), 1) if final_returns_arr.size else 0.0,
-        "verdict": "FAIL" if verdict_reasons else "PASS",
-        "verdict_reasons": verdict_reasons,
-        "verdict_threshold": round(mc_profitable_min, 1),
-        "verdict_thresholds": {
-            "min_prob_profitable": round(mc_profitable_min, 1),
-            "max_dd_p95": round(max_dd_p95_limit_pct, 1),
-        },
-        "equity_paths": equity_paths,
-        "return_histogram": _make_histogram(final_returns_arr),
-        "drawdown_histogram": _make_histogram(max_drawdowns_arr),
-        "sharpe_histogram": _make_histogram(sharpes_arr),
-        "max_dd_p95_ratio": round(float(max_dd_p95 / 100.0), 5),
-    }
 
 
 def _run_param_jitter_analysis(body: ParamJitterBody, *, outer_budget_s: float | None = None) -> dict:
@@ -1514,35 +1629,22 @@ def _run_cost_stress_analysis(body: CostStressBody) -> dict:
     }
 
 
-def _run_regime_split_analysis(body: RegimeSplitBody) -> dict:
-    from forven.strategies.backtest import _detect_entry_regime, load_backtest_candles
+def _regime_classify_trades_worker(candles: "pd.DataFrame", trades: list[dict]) -> dict:
+    """Classify each trade by its entry-bar regime — the regime-split compute core.
 
-    context = _result_context_from_detail(body.result_id)
-    trades = context["trades"]
-    if int(context.get("trade_count") or 0) <= 0:
-        _raise_zero_trade_prerequisite("Baseline backtest")
-    if not trades:
-        _raise_missing_trade_artifacts("Regime split")
-    if not context["symbol"] or not context["timeframe"]:
-        raise HTTPException(400, "Baseline backtest is missing symbol/timeframe metadata.")
+    This is the GIL-bound hotspot of the regime-split step: for every trade it slices
+    the candle frame up to the entry bar and runs ``_detect_entry_regime`` (RSI/ADX/EMA
+    over the prefix). It touches no database and its inputs (a candles frame + plain
+    trade dicts) are picklable, so ``_run_regime_split_analysis`` offloads it to an
+    isolated subprocess (mirroring the isolated backtest workers). MODULE-LEVEL so
+    spawn-based ProcessPoolExecutor can pickle it on Windows. Deterministic — same
+    inputs yield the same buckets in either process.
 
-    entry_times = [ts for ts in (_coerce_trade_timestamp(trade) for trade in trades) if ts is not None]
-    if not entry_times:
-        raise HTTPException(400, "Regime split requires trade entry timestamps.")
+    Returns the by-regime return/PnL buckets and the unresolved tally; the (light)
+    per-regime aggregation + verdict stay in the caller so its logic is unchanged.
+    """
+    from forven.strategies.backtest import _detect_entry_regime
 
-    candles = load_backtest_candles(
-        asset=context["symbol"],
-        timeframe=context["timeframe"],
-        bars=720,
-        start_date=(min(entry_times) - pd.Timedelta(days=60)).isoformat(),
-        end_date=context["end_date"] or max(entry_times).isoformat(),
-    )
-    if candles.empty:
-        raise HTTPException(400, "No candle data available for regime classification.")
-
-    # Bucket trades by regime using *return* (dimensionless, position-size-invariant)
-    # rather than absolute PnL dollars. Absolute PnL double-counts position sizing
-    # decisions and is misleading when comparing regime profitability.
     by_regime_returns: dict[str, list[float]] = defaultdict(list)
     by_regime_pnl: dict[str, list[float]] = defaultdict(list)
     unresolved_trades = 0
@@ -1571,6 +1673,101 @@ def _run_regime_split_analysis(body: RegimeSplitBody) -> dict:
             ret_ratio = pnl_val / 10_000.0 if pnl_val else 0.0
         by_regime_returns[regime].append(float(ret_ratio))
         by_regime_pnl[regime].append(_coerce_trade_pnl(trade))
+
+    return {
+        "by_regime_returns": {k: list(v) for k, v in by_regime_returns.items()},
+        "by_regime_pnl": {k: list(v) for k, v in by_regime_pnl.items()},
+        "unresolved_trades": unresolved_trades,
+        "unresolved_reasons": dict(unresolved_reasons),
+    }
+
+
+# Wall-clock ceiling for the offloaded regime classification subprocess. Bounded by
+# n_trades x per-trade RSI/ADX/EMA over the (≤720-bar) window — a leak/hang backstop.
+_REGIME_SPLIT_ISOLATION_TIMEOUT = 300
+
+
+def _run_regime_classification(candles: "pd.DataFrame", trades: list[dict]) -> dict:
+    """Run the per-trade regime classification, offloaded to an isolated subprocess.
+
+    The classification loop is a self-contained, DB-free pandas/numpy hotspot (see
+    ``_regime_classify_trades_worker``) that otherwise burns the GIL on an API worker
+    thread for the duration of the per-trade RSI/ADX/EMA passes. It queues on the
+    process-wide subprocess budget (``strategies/concurrency.py``) exactly like every
+    isolated backtest. Falls back to running inline (identical result — the compute is
+    deterministic) under pytest, when isolation is disabled, or if the child process
+    cannot be spawned; a subprocess timeout/crash is a real failure and raised.
+    """
+    from forven.strategies.backtest import _should_use_process_isolation
+
+    if not _should_use_process_isolation():
+        return _regime_classify_trades_worker(candles, trades)
+
+    import concurrent.futures
+    import multiprocessing
+
+    from forven.strategies.backtest import _kill_executor_processes
+    from forven.strategies.concurrency import backtest_subprocess_slot
+
+    try:
+        with backtest_subprocess_slot("regime_split"), concurrent.futures.ProcessPoolExecutor(
+            max_workers=1,
+            mp_context=multiprocessing.get_context("spawn"),
+        ) as executor:
+            future = executor.submit(_regime_classify_trades_worker, candles, trades)
+            try:
+                return future.result(timeout=_REGIME_SPLIT_ISOLATION_TIMEOUT)
+            except concurrent.futures.TimeoutError:
+                log.error(
+                    "ISOLATION: Regime classification timed out after %ds (%d trades, %d bars)",
+                    _REGIME_SPLIT_ISOLATION_TIMEOUT, len(trades), len(candles),
+                )
+                _kill_executor_processes(executor)
+                raise HTTPException(
+                    500,
+                    f"Regime classification timed out after {_REGIME_SPLIT_ISOLATION_TIMEOUT}s.",
+                )
+    except (OSError, concurrent.futures.BrokenExecutor) as exc:
+        log.warning("Regime-split isolation unavailable (%s) — running inline", exc)
+        return _regime_classify_trades_worker(candles, trades)
+
+
+def _run_regime_split_analysis(body: RegimeSplitBody) -> dict:
+    from forven.strategies.backtest import load_backtest_candles
+
+    context = _result_context_from_detail(body.result_id)
+    trades = context["trades"]
+    if int(context.get("trade_count") or 0) <= 0:
+        _raise_zero_trade_prerequisite("Baseline backtest")
+    if not trades:
+        _raise_missing_trade_artifacts("Regime split")
+    if not context["symbol"] or not context["timeframe"]:
+        raise HTTPException(400, "Baseline backtest is missing symbol/timeframe metadata.")
+
+    entry_times = [ts for ts in (_coerce_trade_timestamp(trade) for trade in trades) if ts is not None]
+    if not entry_times:
+        raise HTTPException(400, "Regime split requires trade entry timestamps.")
+
+    candles = load_backtest_candles(
+        asset=context["symbol"],
+        timeframe=context["timeframe"],
+        bars=720,
+        start_date=(min(entry_times) - pd.Timedelta(days=60)).isoformat(),
+        end_date=context["end_date"] or max(entry_times).isoformat(),
+    )
+    if candles.empty:
+        raise HTTPException(400, "No candle data available for regime classification.")
+
+    # Bucket trades by regime using *return* (dimensionless, position-size-invariant)
+    # rather than absolute PnL dollars. Absolute PnL double-counts position sizing
+    # decisions and is misleading when comparing regime profitability. The per-trade
+    # classification (the RSI/ADX/EMA hotspot) is offloaded to an isolated subprocess;
+    # the light aggregation + verdict below stay in-thread.
+    classified = _run_regime_classification(candles, trades)
+    by_regime_returns: dict[str, list[float]] = defaultdict(list, classified["by_regime_returns"])
+    by_regime_pnl: dict[str, list[float]] = defaultdict(list, classified["by_regime_pnl"])
+    unresolved_trades = int(classified["unresolved_trades"])
+    unresolved_reasons: dict[str, int] = defaultdict(int, classified["unresolved_reasons"])
 
     if not by_regime_returns:
         raise HTTPException(

--- a/tests/test_paper_gate_s00152.py
+++ b/tests/test_paper_gate_s00152.py
@@ -53,6 +53,59 @@ def _insert_legacy_margin_trades(conn, sid, pnls, *, flag=None):
     conn.commit()
 
 
+def _insert_robustness_result(sid, result_type, metrics):
+    """Persist a passing gauntlet robustness artifact for ``sid`` (mirrors
+    tests/test_two_tier_gate.py::_insert_result)."""
+    with get_db() as conn:
+        conn.execute(
+            "INSERT INTO backtest_results (result_id, strategy_id, result_type, symbol, timeframe, "
+            "metrics_json, config_json, created_at) "
+            "VALUES (?, ?, ?, 'BTC/USDT', '1h', ?, '{\"status\":\"succeeded\"}', datetime('now'))",
+            (f"{result_type}-{sid}", sid, result_type, json.dumps(metrics)),
+        )
+        conn.commit()
+
+
+def _wf_pass():
+    """A clean, passing walk-forward payload (low degradation, ample OOS Sharpe/trades)."""
+    return {
+        "verdict": "PASS",
+        "degradation": 0.10,
+        "avg_oos_sharpe": 1.0,
+        "total_oos_trades": 40,
+        "splits": [
+            {"out_of_sample": {"sharpe": 1.2, "total_trades": 20}},
+            {"out_of_sample": {"sharpe": 0.9, "total_trades": 18}},
+            {"out_of_sample": {"sharpe": 0.7, "total_trades": 15}},
+        ],
+    }
+
+
+def _seed_clean_robustness_evidence(sid):
+    """Seed the minimal set of PASSING gauntlet artifacts the paper->live gate's
+    strict-live robustness battery requires (PR#60 'Harden Forge lifecycle
+    correctness', commit 1c40bcc3 — made unconditional by a97942ac).
+
+    Without these, ``_strict_robustness_reject`` at the TOP of ``_evaluate_paper_gate``
+    short-circuits with "Live gate: robustness evidence unavailable (no usable gauntlet
+    artifacts)" BEFORE any S00152 reason is reached. Seeding clean walk_forward +
+    cost_stress + regime_split + monte_carlo evidence (param_jitter is not checked by
+    the battery) lets these tests exercise their ORIGINAL S00152 assertions again
+    without weakening the gate. Values match tests/test_two_tier_gate.py's proven
+    clean-pass set."""
+    _insert_robustness_result(sid, "walk_forward", _wf_pass())
+    _insert_robustness_result(
+        sid, "cost_stress", {"verdict": "PASS", "degradation_pct": 20.0, "stressed_sharpe": 0.6}
+    )
+    _insert_robustness_result(
+        sid, "regime_split", {"verdict": "PASS", "n_regimes": 3, "profitable_regime_share": 0.75}
+    )
+    _insert_robustness_result(
+        sid, "monte_carlo",
+        {"verdict": "PASS", "n_trades": 40, "percentile_score": 0.8, "max_dd_p95_ratio": 0.15},
+    )
+
+
 def test_gate_excludes_non_equity_fraction_rows(forven_db):
     """PROMOTION-GATE-PARITY-2/3: only kernel equity-fraction paper rows (flagged
     pnl_is_equity_fraction) count toward the promotion gate. Legacy/margin-scale rows
@@ -63,12 +116,15 @@ def test_gate_excludes_non_equity_fraction_rows(forven_db):
         # 5 legacy margin-scale rows + a converge artifact — none flagged.
         _insert_legacy_margin_trades(conn, "s-mixed", [0.30] * 5, flag={"non_vectorizable_legacy": True})
 
-    # Sample counts ONLY the 12 flagged rows (not 17).
-    _, msg = _check_paper_trades("s-mixed")
+    # Sample counts ONLY the 12 flagged rows (not 17). _check_paper_trades returns a
+    # 3-tuple (passed, msg, extra) — the trailing `extra` dict predates PR#60; the old
+    # 2-value unpack raised "too many values to unpack".
+    _, msg, _ = _check_paper_trades("s-mixed")
     assert "12/" in msg, msg
 
     # And the excluded +30% margin rows can't inflate the compounded paper return.
-    passed, ret_msg = _check_paper_return("s-mixed")
+    # _check_paper_return also returns a 3-tuple (passed, msg, extra) on this path.
+    passed, ret_msg, _ = _check_paper_return("s-mixed")
     assert passed  # the 12 small positive equity-fraction trades are net positive
     # 12 * +1% compounded ≈ +12.7%, NOT the ~3700% five +30% margin rows would add.
     pct = float(ret_msg.split(":")[1].strip().rstrip("%"))
@@ -88,6 +144,7 @@ def test_oos_sharpe_much_higher_than_is_sharpe_rejects(forven_db):
             "oos_sharpe": 2.0,  # 2.0x IS → exceeds 1.5x limit
         })
         _insert_paper_trades(conn, "s-overfit", [1.0] * 60)
+    _seed_clean_robustness_evidence("s-overfit")
 
     passed, msg = _evaluate_paper_gate("s-overfit", DEFAULT_PIPELINE_CONFIG)
     assert not passed
@@ -104,6 +161,7 @@ def test_oos_sharpe_within_ratio_passes(forven_db):
             "profit_factor": 3.0,
         })
         _insert_paper_trades(conn, "s-ok-sharpe", [1.0] * 60)
+    _seed_clean_robustness_evidence("s-ok-sharpe")
 
     passed, msg = _evaluate_paper_gate("s-ok-sharpe", DEFAULT_PIPELINE_CONFIG)
     assert passed
@@ -118,6 +176,7 @@ def test_oos_sharpe_check_skipped_when_is_zero(forven_db):
             "profit_factor": 3.0,
         })
         _insert_paper_trades(conn, "s-zero-is", [1.0] * 60)
+    _seed_clean_robustness_evidence("s-zero-is")
 
     passed, msg = _evaluate_paper_gate("s-zero-is", DEFAULT_PIPELINE_CONFIG)
     assert passed
@@ -135,6 +194,7 @@ def test_profit_factor_below_1_5_rejects(forven_db):
             "profit_factor": 1.2,
         })
         _insert_paper_trades(conn, "s-low-pf", [1.0] * 60)
+    _seed_clean_robustness_evidence("s-low-pf")
 
     passed, msg = _evaluate_paper_gate("s-low-pf", DEFAULT_PIPELINE_CONFIG)
     assert not passed
@@ -149,6 +209,7 @@ def test_profit_factor_between_1_5_and_2_0_passes_with_size_reduction(forven_db)
             "profit_factor": 1.7,
         })
         _insert_paper_trades(conn, "s-mid-pf", [1.0] * 60)
+    _seed_clean_robustness_evidence("s-mid-pf")
 
     passed, msg = _evaluate_paper_gate("s-mid-pf", DEFAULT_PIPELINE_CONFIG)
     assert passed
@@ -163,6 +224,7 @@ def test_profit_factor_above_2_0_passes_normally(forven_db):
             "profit_factor": 2.5,
         })
         _insert_paper_trades(conn, "s-good-pf", [1.0] * 60)
+    _seed_clean_robustness_evidence("s-good-pf")
 
     passed, msg = _evaluate_paper_gate("s-good-pf", DEFAULT_PIPELINE_CONFIG)
     assert passed
@@ -179,6 +241,7 @@ def test_insufficient_paper_trades_rejects(forven_db):
     with get_db() as conn:
         _insert_strategy(conn, "s-few-trades", metrics={"profit_factor": 3.0})
         _insert_paper_trades(conn, "s-few-trades", [1.0] * 5)
+    _seed_clean_robustness_evidence("s-few-trades")
 
     passed, msg = _evaluate_paper_gate("s-few-trades", DEFAULT_PIPELINE_CONFIG)
     assert not passed
@@ -190,6 +253,7 @@ def test_insufficient_paper_sample_precedes_static_pf_reject(forven_db):
     with get_db() as conn:
         _insert_strategy(conn, "s-few-trades-low-pf", metrics={"profit_factor": 1.2})
         _insert_paper_trades(conn, "s-few-trades-low-pf", [1.0] * 5)
+    _seed_clean_robustness_evidence("s-few-trades-low-pf")
 
     passed, msg = _evaluate_paper_gate("s-few-trades-low-pf", DEFAULT_PIPELINE_CONFIG)
     assert not passed
@@ -201,6 +265,7 @@ def test_exactly_50_trades_passes(forven_db):
     with get_db() as conn:
         _insert_strategy(conn, "s-fifty", metrics={"profit_factor": 3.0})
         _insert_paper_trades(conn, "s-fifty", [1.0] * 50)
+    _seed_clean_robustness_evidence("s-fifty")
 
     passed, msg = _evaluate_paper_gate("s-fifty", DEFAULT_PIPELINE_CONFIG)
     assert passed
@@ -218,6 +283,7 @@ def test_negative_paper_return_rejects(forven_db):
         # 30 wins + 30 losses that net to negative
         pnls = [2.0] * 25 + [-2.5] * 25 + [-1.0] * 10
         _insert_paper_trades(conn, "s-neg-return", pnls)
+    _seed_clean_robustness_evidence("s-neg-return")
 
     passed, msg = _evaluate_paper_gate("s-neg-return", DEFAULT_PIPELINE_CONFIG)
     assert not passed
@@ -232,6 +298,7 @@ def test_zero_paper_return_rejects(forven_db):
         # 50 trades that net to exactly zero
         pnls = [1.0] * 25 + [-1.0] * 25
         _insert_paper_trades(conn, "s-zero-return", pnls)
+    _seed_clean_robustness_evidence("s-zero-return")
 
     passed, msg = _evaluate_paper_gate("s-zero-return", DEFAULT_PIPELINE_CONFIG)
     assert not passed
@@ -250,6 +317,7 @@ def test_paper_drawdown_exceeding_limit_rejects(forven_db):
         # PnL values are fractional (e.g., 0.02 = +2%, -0.20 = -20%)
         pnls = [0.02] * 20 + [-0.20] + [0.02] * 39
         _insert_paper_trades(conn, "s-high-dd", pnls)
+    _seed_clean_robustness_evidence("s-high-dd")
 
     passed, msg = _evaluate_paper_gate("s-high-dd", DEFAULT_PIPELINE_CONFIG)
     assert not passed
@@ -281,6 +349,7 @@ def test_oos_profit_factor_used_when_available(forven_db):
             "oos_profit_factor": 1.2,  # but OOS PF is below 1.5
         })
         _insert_paper_trades(conn, "s-oos-pf", [1.0] * 60)
+    _seed_clean_robustness_evidence("s-oos-pf")
 
     passed, msg = _evaluate_paper_gate("s-oos-pf", DEFAULT_PIPELINE_CONFIG)
     assert not passed
@@ -294,6 +363,7 @@ def test_general_pf_fallback_when_no_oos(forven_db):
             "profit_factor": 1.7,  # between 1.5-2.0 → 50% reduction
         })
         _insert_paper_trades(conn, "s-gen-pf", [1.0] * 60)
+    _seed_clean_robustness_evidence("s-gen-pf")
 
     passed, msg = _evaluate_paper_gate("s-gen-pf", DEFAULT_PIPELINE_CONFIG)
     assert passed

--- a/tests/test_robustness_compute_offload.py
+++ b/tests/test_robustness_compute_offload.py
@@ -1,0 +1,152 @@
+"""Isolated-subprocess offload of the GIL-bound robustness compute hotspots.
+
+Two robustness steps do heavy pandas/numpy work in-thread on an API worker (the
+multi-second event-loop stalls attributed to gauntlet compute):
+
+  * Monte Carlo bootstrap — ``n_simulations`` (default 1000) seeded resamples.
+  * Regime split classification — per-trade RSI/ADX/EMA over the entry-bar prefix.
+
+Both are now routed through the SAME process-wide subprocess budget/isolation the
+isolated backtests use (``strategies/concurrency.py``). These tests pin the contract
+the offload relies on: the module-level worker is deterministic and correct, the
+dispatcher runs inline under pytest (so the rest of the gauntlet stays deterministic),
+and — most importantly — the subprocess path produces a BIT-IDENTICAL result to the
+inline path (the seeds/compute live inside the worker, so isolation cannot change the
+verdict).
+"""
+from __future__ import annotations
+
+import json
+import os
+
+import numpy as np
+import pandas as pd
+
+from forven.routers import robustness as R
+
+
+def _sample_returns(n: int = 120, seed: int = 7) -> list[float]:
+    rng = np.random.default_rng(seed)
+    return [max(float(x), -0.999) for x in rng.normal(0.01, 0.05, n)]
+
+
+_MC_KW = dict(
+    original_sharpe=1.2,
+    original_return=15.0,
+    n_simulations=250,
+    initial_capital=10000.0,
+    mc_profitable_min=65.0,
+    max_dd_p95_limit_pct=40.0,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Monte Carlo bootstrap worker
+# --------------------------------------------------------------------------- #
+def test_monte_carlo_worker_is_deterministic_and_well_formed():
+    returns = _sample_returns()
+    a = R._monte_carlo_bootstrap_worker(returns, **_MC_KW)
+    b = R._monte_carlo_bootstrap_worker(returns, **_MC_KW)
+    # Seeded inside the worker -> byte-identical across calls.
+    assert json.dumps(a, default=str, sort_keys=True) == json.dumps(b, default=str, sort_keys=True)
+    assert a["method"] == "trade_bootstrap"
+    assert a["verdict"] in {"PASS", "FAIL"}
+    assert a["n_simulations"] == _MC_KW["n_simulations"]
+    assert a["n_trades"] == len(returns)
+    # equity_paths are capped so the offload payload stays bounded.
+    assert len(a["equity_paths"]) <= 50
+
+
+def test_monte_carlo_verdict_thresholds_are_honored():
+    returns = _sample_returns()
+    # An unreachable probability floor forces FAIL; a trivially-met one allows PASS.
+    fail = R._monte_carlo_bootstrap_worker(returns, **{**_MC_KW, "mc_profitable_min": 200.0})
+    assert fail["verdict"] == "FAIL"
+    assert any("probability profitable" in r for r in fail["verdict_reasons"])
+
+
+def test_monte_carlo_dispatch_runs_inline_under_pytest():
+    # Under pytest _should_use_process_isolation() is False, so the dispatcher must
+    # run inline and match the worker exactly (no subprocess spawned).
+    assert "PYTEST_CURRENT_TEST" in os.environ
+    returns = _sample_returns()
+    dispatched = R._run_monte_carlo_bootstrap(returns, **_MC_KW)
+    inline = R._monte_carlo_bootstrap_worker(returns, **_MC_KW)
+    assert json.dumps(dispatched, default=str, sort_keys=True) == json.dumps(
+        inline, default=str, sort_keys=True
+    )
+
+
+def test_monte_carlo_subprocess_path_is_bit_identical(monkeypatch):
+    # Force real process isolation and prove the child-process result is byte-identical
+    # to the inline result — the offload must never change a verdict.
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setenv("FORVEN_BACKTEST_PROCESS_ISOLATION", "1")
+    returns = _sample_returns()
+    inline = R._monte_carlo_bootstrap_worker(returns, **_MC_KW)
+    isolated = R._run_monte_carlo_bootstrap(returns, **_MC_KW)
+    assert json.dumps(isolated, default=str, sort_keys=True) == json.dumps(
+        inline, default=str, sort_keys=True
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Regime-split classification worker
+# --------------------------------------------------------------------------- #
+def _regime_fixture(n_trades: int = 40, seed: int = 3):
+    idx = pd.date_range("2024-01-01", periods=720, freq="h", tz="UTC")
+    close = 100 + np.cumsum(np.random.default_rng(seed).normal(0, 1, 720))
+    candles = pd.DataFrame(
+        {"open": close, "high": close + 1, "low": close - 1, "close": close, "volume": 1000.0},
+        index=idx,
+    )
+    trades = [
+        {
+            "entry_time": idx[300 + i].isoformat(),
+            "return_pct": float(np.random.default_rng(i).normal(0.5, 2)),
+            "pnl": 10.0,
+        }
+        for i in range(n_trades)
+    ]
+    return candles, trades
+
+
+def test_regime_worker_classifies_and_is_deterministic():
+    candles, trades = _regime_fixture()
+    a = R._regime_classify_trades_worker(candles, trades)
+    b = R._regime_classify_trades_worker(candles, trades)
+    assert json.dumps(a, default=str, sort_keys=True) == json.dumps(b, default=str, sort_keys=True)
+    # Every trade is either classified into a regime or counted as unresolved.
+    classified = sum(len(v) for v in a["by_regime_returns"].values())
+    assert classified + a["unresolved_trades"] == len(trades)
+    assert set(a["by_regime_pnl"].keys()) == set(a["by_regime_returns"].keys())
+
+
+def test_regime_dispatch_runs_inline_under_pytest():
+    assert "PYTEST_CURRENT_TEST" in os.environ
+    candles, trades = _regime_fixture()
+    dispatched = R._run_regime_classification(candles, trades)
+    inline = R._regime_classify_trades_worker(candles, trades)
+    assert json.dumps(dispatched, default=str, sort_keys=True) == json.dumps(
+        inline, default=str, sort_keys=True
+    )
+
+
+def test_regime_subprocess_path_is_bit_identical(monkeypatch):
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setenv("FORVEN_BACKTEST_PROCESS_ISOLATION", "1")
+    candles, trades = _regime_fixture()
+    inline = R._regime_classify_trades_worker(candles, trades)
+    isolated = R._run_regime_classification(candles, trades)
+    assert json.dumps(isolated, default=str, sort_keys=True) == json.dumps(
+        inline, default=str, sort_keys=True
+    )
+
+
+def test_regime_worker_counts_missing_entry_time_as_unresolved():
+    candles, _ = _regime_fixture(n_trades=1)
+    trades = [{"return_pct": 1.0, "pnl": 5.0}]  # no entry_time
+    out = R._regime_classify_trades_worker(candles, trades)
+    assert out["unresolved_trades"] == 1
+    assert out["unresolved_reasons"].get("missing_entry_time") == 1
+    assert out["by_regime_returns"] == {}


### PR DESCRIPTION
Two P2 tasks in one PR. Touches only `forven/routers/robustness.py` and test files.

## Task 1 — route remaining gauntlet/validation compute off the API GIL

### Investigation: the compute-hotspot map

The subprocess-isolated backtest paths (`backtest_strategy`, `walk_forward`) already offload their heavy simulation to child processes queued on the process-wide budget (`strategies/concurrency.backtest_subprocess_slot`). Tracing the gauntlet/validation call paths (`forven/gauntlet/tasks.py` steps → `forven/routers/robustness.py` `_run_*_analysis`), the remaining **in-thread, GIL-bound numpy/pandas hotspots** are the two robustness steps whose compute does **not** flow through `backtest_strategy`:

| Step | In-thread compute | Cost | Isolatable? |
|---|---|---|---|
| **Monte Carlo** (`_run_monte_carlo_analysis`) | `n_simulations` (default 1000) seeded numpy bootstrap resamples (cumprod / drawdown / percentile) | ~120ms/call, scales with sims × trades | **Yes → MOVED** |
| **Regime split** (`_run_regime_split_analysis`) | per-trade `_detect_entry_regime` (RSI/ADX/EMA over the entry-bar prefix) | ~7.5ms/trade, scales with trade count | **Yes → MOVED** |
| walk_forward | all folds run in ONE isolated subprocess already | light verdict math only | stays (already offloaded) |
| param_jitter | each rerun's `backtest_strategy` is process-isolated + fanned out on the budget | light verdict math only | stays (already offloaded) |
| cost_stress | 2 `backtest_strategy` calls, both process-isolated | light verdict math only | stays (already offloaded) |

### What moved

Both MC and regime-split compute cores are extracted to **module-level worker functions** (`_monte_carlo_bootstrap_worker`, `_regime_classify_trades_worker`) and dispatched through the **existing** isolation machinery — mirroring `_isolated_backtest_worker`: `ProcessPoolExecutor(max_workers=1, mp_context=spawn)` under `backtest_subprocess_slot(...)`, a timeout + `_kill_executor_processes` backstop, and an **inline fallback** (under pytest, when isolation is disabled, or if spawn fails). All DB/lake I/O (result-context reads, candle loading, config) stays in-thread — only the pure compute is offloaded.

**Behavior unchanged (proven):** the RNG is seeded *inside* the MC worker and the regime classification is deterministic, so subprocess output is **bit-identical** to inline. Verified by new tests that diff the inline vs forced-subprocess result, plus the full robustness math regression suite (`test_robustness_math_regression`, `test_robustness_suite_bugfixes`, `test_gauntlet_robustness_steps`) — all green. The MC extraction also preserves the original loop/output semantics exactly (raw `n_simulations` reported; loop clamped to ≥1).

### What stayed and why
- `walk_forward` / `param_jitter` / `cost_stress`: their heavy compute is **already** in isolated backtest subprocesses; only light verdict math remains in-thread.
- No new process architecture; **no changes** to `api.py` thread/loop topology or to `strategies/backtest.py` (engine owner).

## Task 2 — fix the 14 drifted tests in `tests/test_paper_gate_s00152.py`

**Diagnosis confirmed independently.** PR#60 "Harden Forge lifecycle correctness" (`1c40bcc3`), made unconditional by `a97942ac`, added a strict-live robustness-evidence battery (`_strict_robustness_reject`) at the **top** of `_evaluate_paper_gate` (`policy.py:4243`). Tests that seed strategies with **no** gauntlet artifacts now short-circuit with `"Live gate: robustness evidence unavailable (no usable gauntlet artifacts)"` (`policy.py:3731`) **before** reaching their S00152 assertions. The gate is correct (fail-closed before real capital); the tests predate it.

**Fix (no gate weakening):** a new `_seed_clean_robustness_evidence` helper seeds the minimal set of **passing** gauntlet artifacts the battery requires — `walk_forward` + `cost_stress` + `regime_split` + `monte_carlo` (param_jitter is not checked by the battery). Keys match the `_validation_row_to_verdict_payload` transform (`stressed_sharpe`, `profitable_regime_share`, `percentile_score`, `degradation`/`avg_oos_sharpe`/`total_oos_trades`); values mirror `test_two_tier_gate.py`'s proven clean-pass set. Each test now exercises its **original** S00152 assertion again.

One of the 14 (`test_gate_excludes_non_equity_fraction_rows`) was a **separate pre-existing test bug** (not PR#60): `_check_paper_trades` and `_check_paper_return` both return 3-tuples, but the test unpacked 2 values → `ValueError`. Fixed the unpacks. **No production code changed for Task 2.**

## Test results (repo `.venv`)
- `tests/test_paper_gate_s00152.py` — **16 passed** (was 14 failed / 2 passed)
- `tests/test_robustness_compute_offload.py` (new) — **8 passed** (incl. subprocess-vs-inline bit-identical checks)
- Regression set: `test_gauntlet_workflow_tasks`, `test_gauntlet_workflow_status`, `test_gauntlet_paper_bypass_fix`, `test_robustness_router`, `test_gauntlet_legitimacy`, `test_two_tier_gate`, `test_pipeline_hardening` + the s00152/offload files — **214 passed**
- Robustness math/suite: `test_robustness_math_regression`, `test_robustness_parallel`, `test_robustness_suite_bugfixes`, `test_gauntlet_robustness_steps`, `test_robustness_baseline_and_jitter_bounds` — **56 passed**
- `ruff check forven tests` — clean (one pre-existing unrelated `# noqa` warning in `test_assistant_session.py`, untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CBHuQy6taZsvWNwsKig2N