### PR TITLE
fix(dataeng): P2 data-engine hardening — phantom liquidations, catch-up starvation, WS durability, fallback parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
             tests/test_dataeng_foundation.py \
             tests/test_enrichment_causality.py \
             tests/test_enrich_backtest_frame.py \
+            tests/test_data_engine_p2_hardening.py \
             tests/test_orderflow_lookahead.py \
             tests/test_binance_vision.py \
             tests/test_keepalive_staleness.py \

--- a/forven/data_manager.py
+++ b/forven/data_manager.py
@@ -403,6 +403,30 @@ def _load_stream_parquet(path: Path) -> pd.DataFrame | None:
         return None
 
 
+class StreamUnreadableError(RuntimeError):
+    """A stream parquet file EXISTS but could not be read.
+
+    Distinct from an ABSENT file: absent means "not collected yet" (both
+    enrichment engines agree to skip the column), whereas unreadable means the
+    data is present but corrupt. Silently skipping an unreadable expected stream
+    lets a backtest run with a whole aux column NaN/absent, judged as if that
+    were the data — so the enrichment fails loudly instead, and the DataHub and
+    legacy paths fail IDENTICALLY on the same file (FIX 4 parity)."""
+
+
+def _stream_load_status(path: Path) -> str:
+    """Classify a stream parquet path: ``"absent"`` (missing/empty file — skip
+    gracefully), ``"unreadable"`` (present but corrupt — must fail), or ``"ok"``."""
+    try:
+        if not path.exists() or path.stat().st_size == 0:
+            return "absent"
+    except OSError:
+        return "absent"
+    if _load_stream_parquet(path) is None:
+        return "unreadable"
+    return "ok"
+
+
 _parquet_cache_lock = threading.Lock()
 _parquet_cache: dict[str, tuple[tuple[float, int], pd.DataFrame]] = {}
 _PARQUET_CACHE_MAX = 256
@@ -499,6 +523,13 @@ def _merge_asof_parquet(
     """
     src = _parquet_read_cache(path)
     if src is None or src.empty:
+        # Distinguish an ABSENT file (not collected yet — skip gracefully, both
+        # engines agree) from a PRESENT-BUT-UNREADABLE one (corrupt data). A
+        # corrupt expected stream must fail loudly so the legacy path does not
+        # silently no-op a column that would otherwise be judged as real data
+        # (FIX 4 parity — the DataHub path raises on the same file).
+        if _stream_load_status(path) == "unreadable":
+            raise StreamUnreadableError(f"stream parquet unreadable: {path}")
         _log_missing_stream_once(path)
         return df
     if not all(c in src.columns for c in cols):
@@ -1158,10 +1189,30 @@ class LiquidationCollector:
 
                 raw_df = pd.DataFrame(records)
                 raw_df = raw_df.set_index("timestamp")
-                # Bucket into 1h periods
-                long_liq = raw_df[raw_df["side"] == "SELL"].resample("1h")["qty_usd"].sum()
-                short_liq = raw_df[raw_df["side"] == "BUY"].resample("1h")["qty_usd"].sum()
-                liq_count = raw_df.resample("1h")["qty_usd"].count()
+                # Bucket into 1h periods on a CONTINUOUS hourly index spanning the
+                # fetched window, so interior hours with no liquidations become
+                # explicit ZERO rows rather than being absent. Absent rows let the
+                # backward-matching enrichment ASOF carry the previous bucket's
+                # stale aggregates across the gap (phantom values). Zero rows are
+                # values at their own bucket close — causal, not look-ahead.
+                bucket_index = pd.date_range(
+                    raw_df.index.min().floor("1h"),
+                    raw_df.index.max().floor("1h"),
+                    freq="1h",
+                    tz="UTC",
+                )
+                long_liq = (
+                    raw_df[raw_df["side"] == "SELL"].resample("1h")["qty_usd"].sum()
+                    .reindex(bucket_index, fill_value=0.0)
+                )
+                short_liq = (
+                    raw_df[raw_df["side"] == "BUY"].resample("1h")["qty_usd"].sum()
+                    .reindex(bucket_index, fill_value=0.0)
+                )
+                liq_count = (
+                    raw_df.resample("1h")["qty_usd"].count()
+                    .reindex(bucket_index, fill_value=0)
+                )
 
                 agg_df = pd.DataFrame({
                     "long_liq_usd": long_liq,
@@ -2200,51 +2251,44 @@ class DataManager:
 
         result = df.copy()
 
+        # FIX 4 parity: a per-stream error is swallowed (log + skip) EXCEPT
+        # StreamUnreadableError — a present-but-corrupt expected stream must fail
+        # the enrichment loudly, identically to the DataHub path, instead of
+        # silently no-op'ing a whole aux column that a backtest would then be
+        # judged on as if it were real data. An ABSENT file is still graceful.
+        def _run(stream_name: str, join):
+            nonlocal result
+            try:
+                result = join(result)
+            except StreamUnreadableError:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                log.warning("%s enrichment skipped for %s: %s", stream_name, symbol, exc)
+
         # Existing enrichment
         if "funding" not in excluded:
-            try:
-                result = self._enrich_funding(result, symbol)
-            except Exception as exc:
-                log.warning("Funding enrichment skipped for %s: %s", symbol, exc)
+            _run("Funding", lambda r: self._enrich_funding(r, symbol))
 
         if "oi" not in excluded:
-            try:
-                result = self._enrich_oi(result, symbol, timeframe)
-            except Exception as exc:
-                log.warning("OI enrichment skipped for %s/%s: %s", symbol, timeframe, exc)
+            _run("OI", lambda r: self._enrich_oi(r, symbol, timeframe))
 
         # Phase 1: Derivatives intelligence
         if "long_short_ratio" not in excluded:
-            try:
-                result = self._enrich_long_short_ratio(result, symbol)
-            except Exception as exc:
-                log.warning("LSR enrichment skipped for %s: %s", symbol, exc)
+            _run("LSR", lambda r: self._enrich_long_short_ratio(r, symbol))
 
         if "taker_volume" not in excluded:
-            try:
-                result = self._enrich_taker_volume(result, symbol)
-            except Exception as exc:
-                log.warning("Taker volume enrichment skipped for %s: %s", symbol, exc)
+            _run("Taker volume", lambda r: self._enrich_taker_volume(r, symbol))
 
         if "liquidations" not in excluded:
-            try:
-                result = self._enrich_liquidations(result, symbol)
-            except Exception as exc:
-                log.warning("Liquidation enrichment skipped for %s: %s", symbol, exc)
+            _run("Liquidation", lambda r: self._enrich_liquidations(r, symbol))
 
         # Run 3 crypto-native streams: per-symbol basis + market-wide implied
         # vol. Both are bar-aggregate series → bucket-close shifted.
         if "basis" not in excluded:
-            try:
-                result = self._enrich_basis(result, symbol)
-            except Exception as exc:
-                log.warning("Basis enrichment skipped for %s: %s", symbol, exc)
+            _run("Basis", lambda r: self._enrich_basis(r, symbol))
 
         if "iv" not in excluded:
-            try:
-                result = self._enrich_iv(result)
-            except Exception as exc:
-                log.warning("IV enrichment skipped: %s", exc)
+            _run("IV", lambda r: self._enrich_iv(r))
 
         # RESEARCH-ONLY daily macro / sentiment. These carry same-day-close
         # lookahead and weekend gaps, so they are NEVER joined on the strategy/

--- a/forven/dataeng/catchup.py
+++ b/forven/dataeng/catchup.py
@@ -20,8 +20,9 @@ class CatchUpTask:
     start_ts: str
     end_ts: str
     permanent: bool = False
-    # Why the task was planned: "stale" (series behind the latest closed bar)
-    # or "gaps" (current, but interior bars are missing).
+    # Why the task was planned: "stale" (series behind the latest closed bar),
+    # "gaps" (current, but interior bars are missing), or "bootstrap" (an active
+    # symbol/timeframe that has NO catalog row yet — never collected).
     reason: str = "stale"
 
 
@@ -40,11 +41,18 @@ class CatchUpPlanner:
     def plan(self, *, now: datetime | None = None) -> list[CatchUpTask]:
         now_ts = _as_utc(now or datetime.now(timezone.utc))
         tasks: list[CatchUpTask] = []
+        covered: set[tuple[str, str]] = set()
         for row in self.catalog.list_coverage():
             stream = str(row.get("stream") or "")
             end_raw = row.get("end_ts")
             timeframe = str(row.get("timeframe") or "")
-            if stream != "candles" or not end_raw or not timeframe:
+            if stream != "candles" or not timeframe:
+                continue
+            # Record every candle series already in the catalog so the bootstrap
+            # pre-stage below can tell an existing (possibly-stale) series from a
+            # newly-activated symbol that has never been collected.
+            covered.add((_canonical_symbol_key(str(row.get("symbol") or "")), timeframe))
+            if not end_raw:
                 continue
             end_ts = _as_utc(end_raw)
             tf_delta = _timeframe_delta(timeframe)
@@ -57,7 +65,67 @@ class CatchUpPlanner:
             # Current at the tail — but is it gap-complete inside its span?
             if _completeness(row, tf_delta) < COMPLETENESS_THRESHOLD:
                 tasks.append(_task_from_row(row, _as_utc(row.get("start_ts") or end_ts), end_ts, reason="gaps"))
+
+        # Symbol-inventory pre-stage: an active symbol that is in the trading
+        # universe but has NO catalog row produces zero rows above and is never
+        # planned — the gap-fill loop only keeps EXISTING series current. Emit a
+        # bootstrap task per active (symbol, timeframe) that is not yet covered.
+        # Bootstraps are APPENDED after the gap-fill tasks so a large newly-active
+        # set can never starve the existing series a running strategy depends on.
+        tasks.extend(self._bootstrap_tasks(now_ts, covered))
         return tasks
+
+    def _bootstrap_tasks(
+        self, now_ts: pd.Timestamp, covered: set[tuple[str, str]]
+    ) -> list[CatchUpTask]:
+        """One bootstrap CatchUpTask per active (symbol, timeframe) with no catalog
+        candle row. Fail-soft: any error resolving the universe yields no
+        bootstraps (never break the gap-fill plan on universe discovery)."""
+        out: list[CatchUpTask] = []
+        seen: set[tuple[str, str]] = set()
+        for symbol, timeframe in self._active_universe_pairs():
+            key = (_canonical_symbol_key(symbol), timeframe)
+            if key in covered or key in seen:
+                continue
+            seen.add(key)
+            source, market = _resolve_source_market(symbol)
+            out.append(
+                CatchUpTask(
+                    source=source,
+                    market=market,
+                    symbol=symbol,
+                    timeframe=timeframe,
+                    stream="candles",
+                    start_ts=_to_iso(now_ts),
+                    end_ts=_to_iso(now_ts),
+                    permanent=False,
+                    reason="bootstrap",
+                )
+            )
+        return out
+
+    def _active_universe_pairs(self) -> list[tuple[str, str]]:
+        """Active (fs-symbol, timeframe) pairs the pipeline collects on: the
+        active trading universe × the scan/sweep timeframes."""
+        try:
+            from forven.data import symbol_to_fs
+            from forven.data_manager import get_data_manager
+            from forven.dataeng.coverage import _scan_universe
+
+            _, timeframes = _scan_universe()
+            timeframes = [tf for tf in timeframes if tf] or ["1h"]
+            symbols = get_data_manager().get_active_symbols(include_recent_backtests=False)
+        except Exception:
+            return []
+
+        pairs: list[tuple[str, str]] = []
+        for sym in sorted(symbols):
+            fs = symbol_to_fs(sym)
+            if not fs:
+                continue
+            for tf in timeframes:
+                pairs.append((fs, tf))
+        return pairs
 
 
 def _completeness(row: dict[str, object], tf_delta: pd.Timedelta) -> float:
@@ -90,6 +158,30 @@ def _task_from_row(row: dict[str, object], start_ts: pd.Timestamp, end_ts: pd.Ti
         permanent=False,
         reason=reason,
     )
+
+
+def _canonical_symbol_key(symbol: str) -> str:
+    """Filesystem-canonical symbol key (``BTC-USDT``) for coverage/universe
+    comparison, so a catalog row keyed ``BTC-USDT`` and an active symbol keyed
+    ``BTC/USDT`` compare equal and a covered series is never re-bootstrapped."""
+    try:
+        from forven.dataeng.identity import to_ref
+
+        return to_ref(symbol).to_fs()
+    except Exception:
+        return str(symbol or "").strip().upper().replace("/", "-").replace("_", "-")
+
+
+def _resolve_source_market(symbol: str) -> tuple[str, str]:
+    """(source, market) for a bootstrap task. Mirrors the identity defaults
+    (binance/spot) used by the existing candle coverage rows."""
+    try:
+        from forven.dataeng.identity import to_ref
+
+        ref = to_ref(symbol)
+        return ref.source, ref.market
+    except Exception:
+        return "binance", "spot"
 
 
 def _timeframe_delta(timeframe: str) -> pd.Timedelta:

--- a/forven/dataeng/hub.py
+++ b/forven/dataeng/hub.py
@@ -100,6 +100,7 @@ class DataHub:
                 "DuckDB enrichment failed for %s/%s; falling back to legacy joins: %s",
                 symbol, timeframe, exc,
             )
+            from forven.data_manager import StreamUnreadableError as _LegacyUnreadable
             from forven.data_manager import get_data_manager
             dm = get_data_manager()
             result = df.copy()
@@ -115,6 +116,12 @@ class DataHub:
                     continue
                 try:
                     result = join(result)
+                except _LegacyUnreadable:
+                    # A present-but-corrupt expected stream must fail the enrich
+                    # loudly (FIX 4 parity), not be silently dropped like an
+                    # absent one — otherwise the backtest runs judged on an
+                    # absent aux column that DataHub would have surfaced.
+                    raise
                 except Exception as join_exc:
                     logging.getLogger("forven.dataeng.hub").warning(
                         "Legacy %s enrichment skipped for %s: %s", stream_name, symbol, join_exc
@@ -321,6 +328,13 @@ class _EnrichmentSpec:
     # announced (funding, OI, macro) -> no shift. Mirrors data_manager's
     # _merge_asof_parquet(shift_to_bucket_close=...).
     bucket_close_shift_seconds: int = 0
+    # PARITY with legacy _merge_asof_parquet(fill_coverage_only=True): restrict
+    # ``fill`` to bars AT/AFTER the stream's first covered timestamp. Bars before
+    # coverage stay NaN (unknown), not a fabricated 0 — otherwise the hub hands a
+    # backtest fake zeros where the legacy engine leaves NaN, and the two engines
+    # silently diverge on pre-coverage bars (the liquidations divergence FIX 4's
+    # parity test surfaced).
+    fill_coverage_only: bool = False
 
 
 def _available_enrichment_specs(
@@ -411,6 +425,10 @@ def _available_enrichment_specs(
             ("long_liq_usd", "short_liq_usd", "liq_imbalance"),
             {"long_liq_usd": 0.0, "short_liq_usd": 0.0, "liq_imbalance": 0.0},
             bucket_close_shift_seconds=3600,
+            # PARITY: legacy _enrich_liquidations uses fill_coverage_only=True — a
+            # blanket 0 fill before capture started would hand backtests years of
+            # fake zeros (the phantom-family 0-trade failure mode).
+            fill_coverage_only=True,
         ),
         # Run 3 crypto-native streams (strategy-path, bucket-close shifted; no
         # fill — NaN before coverage, matching the legacy joins).
@@ -481,15 +499,55 @@ def _first_existing_macro_path(macro_dir: Path, macro_name: str) -> Path | None:
     return None
 
 
+class StreamUnreadableError(RuntimeError):
+    """A stream parquet EXISTS but DuckDB could not read it.
+
+    Absent files are dropped from the plan (both engines skip the column);
+    a present-but-corrupt file that the plan needs must fail the enrich so the
+    DataHub and legacy paths fail IDENTICALLY on the same condition rather than
+    one silently running a backtest with a whole aux column absent (FIX 4)."""
+
+
 def _parquet_has_columns(path: Path, columns: list[str]) -> bool:
-    if not path.exists():
+    if not path.exists() or _empty_file(path):
         return False
     try:
         with duckdb.connect(":memory:") as con:
             names = {row[0] for row in con.execute("DESCRIBE SELECT * FROM read_parquet(?)", [str(path)]).fetchall()}
-        return all(column in names for column in columns)
+    except Exception as exc:
+        # Present but unreadable: fail loudly (parity with the legacy path's
+        # StreamUnreadableError) instead of silently dropping the stream.
+        raise StreamUnreadableError(f"stream parquet unreadable: {path}") from exc
+    return all(column in names for column in columns)
+
+
+def _empty_file(path: Path) -> bool:
+    try:
+        return path.stat().st_size == 0
+    except OSError:
+        return True
+
+
+def _stream_coverage_start(path: Path, shift_seconds: int) -> pd.Timestamp | None:
+    """First covered (bucket-close-shifted) timestamp of a stream parquet, ns UTC.
+
+    Used to gate coverage-only fills so pre-coverage bars stay NaN (parity with
+    the legacy engine). None when the file has no readable timestamps."""
+    try:
+        with duckdb.connect(":memory:") as con:
+            row = con.execute("SELECT min(timestamp) FROM read_parquet(?)", [str(path)]).fetchone()
     except Exception:
-        return False
+        return None
+    if not row or row[0] is None:
+        return None
+    ts = pd.Timestamp(row[0])
+    if ts.tzinfo is None:
+        ts = ts.tz_localize("UTC")
+    else:
+        ts = ts.tz_convert("UTC")
+    if shift_seconds > 0:
+        ts = ts + pd.Timedelta(seconds=shift_seconds)
+    return ts
 
 
 def _enrich_with_duckdb(df: pd.DataFrame, specs: list[_EnrichmentSpec]) -> pd.DataFrame:
@@ -527,11 +585,26 @@ def _enrich_with_duckdb(df: pd.DataFrame, specs: list[_EnrichmentSpec]) -> pd.Da
             f"ON b.timestamp >= {alias}.timestamp"
         )
         join_params.append(str(spec.path))
+        # For coverage-only fill, compute the stream's first covered (shifted)
+        # timestamp once and gate the default on it, so pre-coverage bars stay
+        # NaN instead of a fabricated 0 — parity with legacy fill_coverage_only.
+        cov_start = None
+        if spec.fill_coverage_only and spec.fill:
+            cov_start = _stream_coverage_start(spec.path, _shift)
         for output_col in spec.output_columns:
             joined = f"{alias}.{_quote_identifier(_joined_col(alias, output_col))}"
             if output_col in spec.fill:
-                select_parts.append(f"COALESCE({joined}, ?) AS {_quote_identifier(output_col)}")
-                select_params.append(spec.fill[output_col])
+                if cov_start is not None:
+                    # Fill only at/after coverage start; before it, leave NULL.
+                    select_parts.append(
+                        f"CASE WHEN b.timestamp >= ? THEN COALESCE({joined}, ?) "
+                        f"ELSE {joined} END AS {_quote_identifier(output_col)}"
+                    )
+                    select_params.append(cov_start)
+                    select_params.append(spec.fill[output_col])
+                else:
+                    select_parts.append(f"COALESCE({joined}, ?) AS {_quote_identifier(output_col)}")
+                    select_params.append(spec.fill[output_col])
             else:
                 select_parts.append(f"{joined} AS {_quote_identifier(output_col)}")
 

--- a/forven/dataeng/liquidations_ws.py
+++ b/forven/dataeng/liquidations_ws.py
@@ -14,12 +14,22 @@ unchanged from the retired Binance REST collector
 long_liq_usd, short_liq_usd, liq_count, liq_imbalance).
 
 Events aggregate into per-symbol 1h buckets in memory; a bucket is flushed
-only after its hour CLOSES. Partial buckets never touch parquet: the
-enrichment join re-stamps liquidations to bucket close, and
+only after its hour CLOSES. Partial (still-open) buckets never touch parquet:
+the enrichment join re-stamps liquidations to bucket close, and
 ``_combine_and_save`` keeps the FIRST row on timestamp collisions, so a
-premature partial row would permanently shadow the complete one. A lost
-partial hour on restart is acceptable — downtime events are unrecoverable
-anyway.
+premature partial row would permanently shadow the complete one.
+
+Closed hours with NO events are persisted as explicit ZERO rows (from the
+per-pair coverage start forward), not skipped: the enrichment ASOF join matches
+backward, so an event-less hour without a row would silently read the previous
+bucket's stale aggregates (phantom liquidation values indistinguishable from
+real ones). A zero row is a value AT its own bucket close, so it stays causal.
+
+The in-progress partial is CHECKPOINTED to a sidecar (``.liq_ws_checkpoint.json``,
+atomic write) every ~30s and restored on start, so an unexpected crash/kill
+resumes the current hour instead of dropping it. If the hour already closed
+while the process was down, the restored partial flushes as a completed bucket
+and the zero-fill cursor makes the intervening empty hours honest zeros.
 
 Runs in either of two mutually exclusive modes, arbitrated by a file lock so
 capture is single-instance across processes:
@@ -38,6 +48,7 @@ import asyncio
 import json
 import logging
 import os
+import random
 import threading
 import time
 from pathlib import Path
@@ -63,6 +74,21 @@ LOCK_RETRY_SECONDS = 300.0
 # Throttle instrument-table refreshes triggered by unknown instIds.
 CTVAL_REFRESH_MIN_SECONDS = 3600.0
 RECONNECT_BACKOFF_SECONDS = (1, 5, 15, 60, 300)
+# Fraction of ±jitter applied to each backoff step. Without it, many capture
+# processes that dropped together (a venue-wide blip) all reconnect at the same
+# ladder boundaries — a thundering herd that hammers the venue in lockstep and
+# re-triggers the same drop. ±20% de-syncs them.
+RECONNECT_JITTER_FRAC = 0.20
+# How often the in-memory partial buckets are checkpointed to disk so an
+# unexpected crash/kill (not a graceful shutdown) doesn't lose the current hour.
+CHECKPOINT_INTERVAL_SECONDS = 30.0
+
+
+def _backoff_delay(backoff_idx: int) -> float:
+    """Backoff step for ``backoff_idx`` with ±RECONNECT_JITTER_FRAC jitter."""
+    base = RECONNECT_BACKOFF_SECONDS[min(backoff_idx, len(RECONNECT_BACKOFF_SECONDS) - 1)]
+    jitter = base * RECONNECT_JITTER_FRAC
+    return max(0.0, base + random.uniform(-jitter, jitter))
 
 
 def _derivatives_dir() -> Path:
@@ -77,6 +103,10 @@ def _lock_path() -> Path:
 
 def _status_path() -> Path:
     return _derivatives_dir() / ".liq_ws_status.json"
+
+
+def _checkpoint_path() -> Path:
+    return _derivatives_dir() / ".liq_ws_checkpoint.json"
 
 
 def fetch_contract_values() -> dict[str, float]:
@@ -107,6 +137,17 @@ class LiquidationCapture:
         self._guard = threading.Lock()
         # (pair, bucket_start_ms) -> [long_liq_usd, short_liq_usd, liq_count]
         self._buckets: dict[tuple[str, int], list[float]] = {}
+        # Per-pair "gap-honest" cursor: buckets are only persisted when their hour
+        # HAD events, so the enrichment ASOF join carries a stale prior bucket
+        # forward across empty hours (phantom liquidation values). To make the
+        # stream gap-honest we ALSO write explicit zero rows for closed hours that
+        # had no events. ``_coverage_start_ms`` is the first bucket this capture
+        # ever saw for a pair (nothing before it is knowable — before capture the
+        # value is genuinely unknown, not zero) and ``_zero_cursor_ms`` is the next
+        # closed hour we still owe a row for (real or zero). Persisted to the
+        # checkpoint sidecar so a restart resumes without re-emitting or skipping.
+        self._coverage_start_ms: dict[str, int] = {}
+        self._zero_cursor_ms: dict[str, int] = {}
         self._ct_vals: dict[str, float] = {}
         self._ct_vals_fetched_at = 0.0
         self.events_total = 0
@@ -174,25 +215,75 @@ class LiquidationCapture:
                     bucket[2] += 1
                     self.events_total += 1
                     self.last_event_ms = max(self.last_event_ms or 0, event_ms)
+                    # First bucket seen for this pair anchors zero-fill coverage:
+                    # closed hours from here forward that stay empty become zeros.
+                    prior = self._coverage_start_ms.get(pair)
+                    if prior is None or bucket_ms < prior:
+                        self._coverage_start_ms[pair] = bucket_ms
+                    if pair not in self._zero_cursor_ms:
+                        self._zero_cursor_ms[pair] = bucket_ms
+
+    @staticmethod
+    def _row(bucket_ms: int, long_usd: float, short_usd: float, count: int) -> dict:
+        total = long_usd + short_usd
+        return {
+            "timestamp": bucket_ms,
+            "long_liq_usd": long_usd,
+            "short_liq_usd": short_usd,
+            "liq_count": int(count),
+            "liq_imbalance": ((long_usd - short_usd) / total) if total > 0 else 0.0,
+        }
+
+    def _latest_closed_bucket_ms(self, now_ms: int) -> int:
+        """Start-ms of the most recent hour that has fully CLOSED (incl. grace)."""
+        cutoff = now_ms - FLUSH_GRACE_MS
+        # A bucket B closes at B+BUCKET_MS; the newest closed bucket starts at the
+        # last hour boundary at or before (cutoff - BUCKET_MS).
+        closed_edge = cutoff - BUCKET_MS
+        return closed_edge - (closed_edge % BUCKET_MS)
 
     def _pop_completed(self, now_ms: int) -> dict[str, list[dict]]:
         cutoff = now_ms - FLUSH_GRACE_MS
+        latest_closed = self._latest_closed_bucket_ms(now_ms)
         by_pair: dict[str, list[dict]] = {}
         with self._guard:
             done_keys = [key for key in self._buckets if key[1] + BUCKET_MS <= cutoff]
+            real_by_pair: dict[str, dict[int, list[float]]] = {}
             for key in done_keys:
                 pair, bucket_ms = key
-                long_usd, short_usd, count = self._buckets.pop(key)
-                total = long_usd + short_usd
-                by_pair.setdefault(pair, []).append(
-                    {
-                        "timestamp": bucket_ms,
-                        "long_liq_usd": long_usd,
-                        "short_liq_usd": short_usd,
-                        "liq_count": int(count),
-                        "liq_imbalance": ((long_usd - short_usd) / total) if total > 0 else 0.0,
-                    }
-                )
+                real_by_pair.setdefault(pair, {})[bucket_ms] = self._buckets.pop(key)
+
+            # Every pair we have a zero-fill cursor for owes a continuous row per
+            # closed hour up to ``latest_closed`` — real where events landed, an
+            # explicit zero otherwise. This is what stops the ASOF join from
+            # carrying a stale prior bucket across an event-less hour. Zero rows
+            # are values AT their own bucket close, so they never move a value
+            # earlier in time (causal).
+            for pair, cursor in list(self._zero_cursor_ms.items()):
+                if cursor > latest_closed:
+                    continue
+                real = real_by_pair.get(pair, {})
+                rows = by_pair.setdefault(pair, [])
+                bucket_ms = cursor
+                while bucket_ms <= latest_closed:
+                    if bucket_ms in real:
+                        long_usd, short_usd, count = real[bucket_ms]
+                        rows.append(self._row(bucket_ms, long_usd, short_usd, int(count)))
+                    else:
+                        rows.append(self._row(bucket_ms, 0.0, 0.0, 0))
+                    bucket_ms += BUCKET_MS
+                self._zero_cursor_ms[pair] = bucket_ms
+
+            # A pair may have completed real buckets with no cursor yet (e.g. a
+            # restored-from-checkpoint partial whose coverage anchor was lost) —
+            # flush those directly so no data is dropped.
+            for pair, real in real_by_pair.items():
+                if pair in self._zero_cursor_ms:
+                    continue
+                rows = by_pair.setdefault(pair, [])
+                for bucket_ms in sorted(real):
+                    long_usd, short_usd, count = real[bucket_ms]
+                    rows.append(self._row(bucket_ms, long_usd, short_usd, int(count)))
         return by_pair
 
     def flush_completed(self, now_ms: int | None = None) -> int:
@@ -263,6 +354,85 @@ class LiquidationCapture:
         except Exception:
             log.debug("Liquidation status write failed", exc_info=True)
 
+    def save_checkpoint(self) -> None:
+        """Persist the in-progress partial buckets + zero-fill cursors atomically.
+
+        In-memory partials are otherwise lost on an unexpected crash/kill (only a
+        graceful shutdown flushes). Round-tripping them means a restart resumes
+        the current hour instead of dropping it, and the zero-fill cursors survive
+        so no closed hour is re-emitted or skipped. Best-effort — a failed write
+        just means the crash-recovery window reverts to the pre-fix behaviour."""
+        try:
+            with self._guard:
+                payload = {
+                    "buckets": [
+                        {"pair": pair, "bucket_ms": bucket_ms,
+                         "long_usd": vals[0], "short_usd": vals[1], "count": int(vals[2])}
+                        for (pair, bucket_ms), vals in self._buckets.items()
+                    ],
+                    "coverage_start_ms": dict(self._coverage_start_ms),
+                    "zero_cursor_ms": dict(self._zero_cursor_ms),
+                    "saved_ms": int(time.time() * 1000),
+                }
+            path = _checkpoint_path()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = Path(str(path) + ".tmp")
+            tmp.write_text(json.dumps(payload), encoding="utf-8")
+            os.replace(tmp, path)
+        except Exception:
+            log.debug("Liquidation checkpoint write failed", exc_info=True)
+
+    def restore_checkpoint(self) -> int:
+        """Restore partial buckets + cursors from the sidecar. Returns the number
+        of partial buckets restored.
+
+        Buckets whose hour already CLOSED while the process was down stay in the
+        in-memory map — the next flush picks them up as completed (real events),
+        and the zero-fill cursor makes the intervening empty hours honest zeros.
+        So a restart never leaves a silent gap that ASOF would paper over."""
+        path = _checkpoint_path()
+        if not path.exists():
+            return 0
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            log.debug("Liquidation checkpoint read failed", exc_info=True)
+            return 0
+        restored = 0
+        with self._guard:
+            for row in payload.get("buckets") or []:
+                try:
+                    pair = str(row["pair"])
+                    bucket_ms = int(row["bucket_ms"])
+                    vals = [float(row.get("long_usd") or 0.0),
+                            float(row.get("short_usd") or 0.0),
+                            int(row.get("count") or 0)]
+                except (KeyError, TypeError, ValueError):
+                    continue
+                self._buckets[(pair, bucket_ms)] = vals
+                restored += 1
+            for pair, ms in (payload.get("coverage_start_ms") or {}).items():
+                try:
+                    self._coverage_start_ms[str(pair)] = int(ms)
+                except (TypeError, ValueError):
+                    continue
+            for pair, ms in (payload.get("zero_cursor_ms") or {}).items():
+                try:
+                    self._zero_cursor_ms[str(pair)] = int(ms)
+                except (TypeError, ValueError):
+                    continue
+        if restored:
+            log.info("Restored %d partial liquidation bucket(s) from checkpoint", restored)
+        return restored
+
+    def clear_checkpoint(self) -> None:
+        """Remove the sidecar after a clean flush so a stale partial can't be
+        restored on the next start."""
+        try:
+            _checkpoint_path().unlink(missing_ok=True)
+        except Exception:
+            log.debug("Liquidation checkpoint clear failed", exc_info=True)
+
 
 async def _listen_once(capture: LiquidationCapture, shutdown: asyncio.Event) -> None:
     """One WS connection lifetime: subscribe, ingest until close or shutdown."""
@@ -270,6 +440,7 @@ async def _listen_once(capture: LiquidationCapture, shutdown: asyncio.Event) -> 
 
     await asyncio.to_thread(capture.refresh_contract_values, True)
     last_flush = time.time()
+    last_checkpoint = time.time()
     async with websockets.connect(WS_URL, max_queue=4096) as ws:
         await ws.send(SUBSCRIBE_MSG)
         log.info("Liquidation WS connected (OKX liquidation-orders, all swaps)")
@@ -295,6 +466,11 @@ async def _listen_once(capture: LiquidationCapture, shutdown: asyncio.Event) -> 
                 last_flush = now
                 await asyncio.to_thread(capture.flush_completed)
                 await asyncio.to_thread(capture.write_status, True)
+            # Checkpoint the in-progress hour so an unexpected kill doesn't lose
+            # it (a graceful shutdown flushes; a crash between hours would not).
+            if now - last_checkpoint >= CHECKPOINT_INTERVAL_SECONDS:
+                last_checkpoint = now
+                await asyncio.to_thread(capture.save_checkpoint)
 
 
 async def run_capture(shutdown: asyncio.Event | None = None) -> bool:
@@ -317,6 +493,10 @@ async def run_capture(shutdown: asyncio.Event | None = None) -> bool:
         return False
 
     capture = LiquidationCapture()
+    # Resume any partial hour a previous run checkpointed before it died. Buckets
+    # whose hour has since closed flush on the first pass; the zero-fill cursor
+    # makes the down-time hours honest zeros rather than an ASOF-papered gap.
+    capture.restore_checkpoint()
     backoff_idx = 0
     try:
         while not shutdown.is_set():
@@ -326,23 +506,26 @@ async def run_capture(shutdown: asyncio.Event | None = None) -> bool:
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
-                delay = RECONNECT_BACKOFF_SECONDS[
-                    min(backoff_idx, len(RECONNECT_BACKOFF_SECONDS) - 1)
-                ]
+                delay = _backoff_delay(backoff_idx)
                 backoff_idx += 1
-                log.warning("Liquidation WS dropped (%s) — reconnecting in %ss", exc, delay)
+                log.warning("Liquidation WS dropped (%s) — reconnecting in %.1fs", exc, delay)
                 await asyncio.to_thread(capture.write_status, False)
+                # Persist the partial so a crash during the backoff wait doesn't
+                # lose it (the reconnect might never come back).
+                await asyncio.to_thread(capture.save_checkpoint)
                 try:
                     await asyncio.wait_for(shutdown.wait(), timeout=delay)
                 except asyncio.TimeoutError:
                     pass
         return True
     finally:
-        # Completed buckets survive shutdown; the in-progress hour is dropped
-        # by design (its events would be incomplete either way).
+        # Flush completed buckets, then checkpoint whatever partial remains so an
+        # exception in the flush path (or a still-open hour) survives to the next
+        # start rather than being silently dropped.
         try:
             capture.flush_completed()
             capture.write_status(False)
+            capture.save_checkpoint()
         except Exception:
             log.debug("Final liquidation flush failed", exc_info=True)
         lock.release()

--- a/tests/test_data_engine_p2_hardening.py
+++ b/tests/test_data_engine_p2_hardening.py
@@ -1,0 +1,498 @@
+"""P2 data-engine hardening regressions (fix/p2-data-engine-hardening).
+
+Covers four independent fixes:
+
+FIX 1 — Phantom liquidation values via ASOF carry-forward on event-less hours.
+  Both collector write paths (REST resample + WS aggregator) now persist explicit
+  ZERO rows for closed hours with no events, so the enrichment ASOF join reads a
+  real zero instead of carrying the previous bucket's stale aggregates forward.
+
+FIX 2 — Catch-up planner starves symbols not yet in the catalog. plan() now emits
+  bootstrap fetch tasks for active (symbol, timeframe) pairs with no catalog row,
+  appended AFTER the gap-fill tasks so they can't starve existing series.
+
+FIX 3 — Liquidation WS daemon reconnect jitter + partial-bucket durability:
+  ±20% backoff jitter and a checkpoint sidecar that round-trips the in-progress
+  hour across a restart.
+
+FIX 4 — DataHub -> legacy fallback silent divergence. A present-but-unreadable
+  expected stream now fails the enrichment on BOTH engines (parity) instead of
+  the legacy path silently no-op'ing a whole aux column; an ABSENT file stays
+  graceful. Plus a hub/legacy join-semantics parity smoke test.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# FIX 1 — zero-rows for event-less liquidation buckets
+# ---------------------------------------------------------------------------
+
+
+class TestLiquidationZeroFill:
+    def _ct_val(self, cap):
+        cap._ct_vals = {"BTC-USDT-SWAP": 1.0}
+
+    def _event(self, cap, bucket_i, *, long: bool, usd: float):
+        from forven.dataeng.liquidations_ws import BUCKET_MS
+
+        cap.ingest(
+            {
+                "data": [
+                    {
+                        "instId": "BTC-USDT-SWAP",
+                        "details": [
+                            {
+                                "sz": "1",
+                                "bkPx": str(usd),
+                                "ts": str(bucket_i * BUCKET_MS + 60_000),
+                                "posSide": "long" if long else "short",
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+    def test_ws_emits_zero_rows_for_gap_between_events(self):
+        """Two events two buckets apart -> the empty interior hours flush as
+        explicit zero rows, not absent (which ASOF would paper over)."""
+        from forven.dataeng.liquidations_ws import (
+            BUCKET_MS,
+            FLUSH_GRACE_MS,
+            LiquidationCapture,
+        )
+
+        cap = LiquidationCapture()
+        self._ct_val(cap)
+        self._event(cap, 0, long=True, usd=100.0)
+        self._event(cap, 3, long=False, usd=200.0)
+
+        now_ms = 4 * BUCKET_MS + FLUSH_GRACE_MS + 1_000  # buckets 0..3 closed
+        by_pair = cap._pop_completed(now_ms)
+        rows = {r["timestamp"] // BUCKET_MS: r for r in by_pair["BTC-USDT"]}
+
+        assert set(rows) == {0, 1, 2, 3}
+        assert rows[0]["long_liq_usd"] == 100.0 and rows[0]["liq_count"] == 1
+        assert rows[1]["long_liq_usd"] == 0.0 and rows[1]["liq_count"] == 0
+        assert rows[2]["long_liq_usd"] == 0.0 and rows[2]["liq_count"] == 0
+        assert rows[3]["short_liq_usd"] == 200.0 and rows[3]["liq_count"] == 1
+
+    def test_ws_never_emits_before_coverage_start(self):
+        """No zero rows are invented before the first event a pair ever saw —
+        before capture the value is genuinely unknown, not zero."""
+        from forven.dataeng.liquidations_ws import (
+            BUCKET_MS,
+            FLUSH_GRACE_MS,
+            LiquidationCapture,
+        )
+
+        cap = LiquidationCapture()
+        self._ct_val(cap)
+        self._event(cap, 5, long=True, usd=100.0)  # first event at bucket 5
+
+        now_ms = 6 * BUCKET_MS + FLUSH_GRACE_MS + 1_000
+        by_pair = cap._pop_completed(now_ms)
+        buckets = {r["timestamp"] // BUCKET_MS for r in by_pair["BTC-USDT"]}
+        assert min(buckets) == 5  # nothing fabricated for buckets 0..4
+
+    def test_rest_collector_zero_fills_interior_gap(self, monkeypatch, tmp_path):
+        """The REST collector's resample spans a CONTINUOUS hourly index, so an
+        interior hour with no liquidations is written as an explicit zero row."""
+        import forven.data_manager as dm_mod
+        from forven.data_manager import LiquidationCollector, _load_stream_parquet
+
+        monkeypatch.setattr(dm_mod, "DERIVATIVES_DIR", tmp_path / "derivatives")
+
+        # Events at 00:xx and 03:xx only — 01:00 and 02:00 have none.
+        orders = [
+            {"time": int(pd.Timestamp("2026-01-01 00:10", tz="UTC").timestamp() * 1000),
+             "side": "SELL", "price": 10.0, "origQty": 10.0},
+            {"time": int(pd.Timestamp("2026-01-01 03:20", tz="UTC").timestamp() * 1000),
+             "side": "BUY", "price": 20.0, "origQty": 10.0},
+        ]
+
+        class _Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return orders
+
+        monkeypatch.setattr(dm_mod, "_http_session", lambda: type("S", (), {"get": lambda *a, **k: _Resp()})())
+
+        LiquidationCollector().collect("BTC/USDT")
+
+        saved = _load_stream_parquet(tmp_path / "derivatives" / "BTC-USDT" / "liquidations_1h.parquet")
+        ts = pd.to_datetime(saved["timestamp"], utc=True)
+        by_hour = dict(zip(ts.dt.strftime("%H"), saved["liq_count"]))
+        assert by_hour["01"] == 0 and by_hour["02"] == 0  # interior zeros present
+        assert by_hour["00"] == 1 and by_hour["03"] == 1
+
+    def test_enriched_frame_reads_zeros_not_stale_prior(self, tmp_path):
+        """End-to-end: a two-bucket gap between events -> the enriched frame reads
+        zeros for the empty hours, NOT the stale prior bucket (the phantom)."""
+        from forven.data_manager import _merge_asof_parquet
+
+        p = tmp_path / "liq.parquet"
+        # Gap-honest parquet the fixed collectors now write: zeros at 01:00/02:00.
+        pd.DataFrame(
+            {
+                "timestamp": pd.date_range("2026-01-01 00:00", periods=4, freq="1h", tz="UTC"),
+                "long_liq_usd": [100.0, 0.0, 0.0, 300.0],
+                "short_liq_usd": [0.0, 0.0, 0.0, 0.0],
+                "liq_imbalance": [1.0, 0.0, 0.0, 1.0],
+            }
+        ).to_parquet(p)
+
+        frame = pd.DataFrame(
+            {"timestamp": pd.date_range("2026-01-01 01:00", periods=3, freq="1h", tz="UTC"), "close": 1.0}
+        )
+        out = _merge_asof_parquet(
+            frame, p,
+            cols=["long_liq_usd", "short_liq_usd", "liq_imbalance"],
+            fill={"long_liq_usd": 0.0, "short_liq_usd": 0.0, "liq_imbalance": 0.0},
+            shift_to_bucket_close=True, fill_coverage_only=True,
+        )
+        # Bars at 02:00 / 03:00 read the shifted 01:00 / 02:00 buckets = zeros,
+        # not the 100.0 that carried forward before zero-rows existed.
+        vals = dict(zip(out["timestamp"].dt.strftime("%H"), out["long_liq_usd"]))
+        assert vals["02"] == 0.0
+        assert vals["03"] == 0.0
+
+    def test_stale_prior_carry_forward_without_zeros(self, tmp_path):
+        """Sanity: WITHOUT the zero rows the ASOF carries the prior bucket forward
+        (the phantom the fix removes)."""
+        from forven.data_manager import _merge_asof_parquet
+
+        p = tmp_path / "liq.parquet"
+        pd.DataFrame(
+            {
+                "timestamp": pd.to_datetime(["2026-01-01 00:00", "2026-01-01 03:00"], utc=True),
+                "long_liq_usd": [100.0, 300.0],
+                "short_liq_usd": [0.0, 0.0],
+                "liq_imbalance": [1.0, 1.0],
+            }
+        ).to_parquet(p)
+        frame = pd.DataFrame(
+            {"timestamp": pd.date_range("2026-01-01 01:00", periods=3, freq="1h", tz="UTC"), "close": 1.0}
+        )
+        out = _merge_asof_parquet(
+            frame, p,
+            cols=["long_liq_usd", "short_liq_usd", "liq_imbalance"],
+            fill={"long_liq_usd": 0.0, "short_liq_usd": 0.0, "liq_imbalance": 0.0},
+            shift_to_bucket_close=True, fill_coverage_only=True,
+        )
+        vals = dict(zip(out["timestamp"].dt.strftime("%H"), out["long_liq_usd"]))
+        assert vals["02"] == 100.0  # stale carry-forward = the bug
+
+
+# ---------------------------------------------------------------------------
+# FIX 2 — bootstrap tasks for active-but-uncatalogued symbols
+# ---------------------------------------------------------------------------
+
+
+class TestCatchupBootstrap:
+    def _catalog_with(self, tmp_path, rows: list[tuple[str, str]]):
+        from forven.dataeng.catalog import Catalog, CoverageRow
+
+        catalog = Catalog(tmp_path / "catalog.duckdb")
+        for symbol, timeframe in rows:
+            catalog.upsert_series_coverage(
+                CoverageRow(
+                    source="binance", market="spot", symbol=symbol, timeframe=timeframe,
+                    stream="candles",
+                    path=str(tmp_path / symbol / f"{timeframe}.parquet"),
+                    start_ts="2026-06-01T00:00:00Z", end_ts="2026-06-01T00:00:00Z",
+                    row_count=1,
+                )
+            )
+        return catalog
+
+    def _patch_universe(self, monkeypatch, symbols, timeframes):
+        import forven.data_manager as dm_mod
+
+        class _DM:
+            def get_active_symbols(self, *, include_recent_backtests=True):
+                return set(symbols)
+
+        monkeypatch.setattr(dm_mod, "get_data_manager", lambda: _DM())
+        monkeypatch.setattr(
+            "forven.dataeng.coverage._scan_universe",
+            lambda: (list(symbols), list(timeframes)),
+        )
+
+    def test_new_active_symbol_appears_as_bootstrap(self, monkeypatch, tmp_path):
+        from forven.dataeng.catchup import CatchUpPlanner
+
+        # BTC is covered; ETH is active but has no catalog row.
+        catalog = self._catalog_with(tmp_path, [("BTC-USDT", "1h")])
+        self._patch_universe(monkeypatch, ["BTC/USDT", "ETH/USDT"], ["1h"])
+
+        now = datetime(2026, 6, 1, 0, 30, tzinfo=timezone.utc)  # BTC still current
+        tasks = CatchUpPlanner(catalog).plan(now=now)
+
+        bootstraps = [t for t in tasks if t.reason == "bootstrap"]
+        assert len(bootstraps) == 1
+        assert bootstraps[0].symbol == "ETH-USDT"
+        assert bootstraps[0].timeframe == "1h"
+        assert bootstraps[0].stream == "candles"
+        assert bootstraps[0].source == "binance"
+
+    def test_covered_symbol_is_not_bootstrapped(self, monkeypatch, tmp_path):
+        from forven.dataeng.catchup import CatchUpPlanner
+
+        catalog = self._catalog_with(tmp_path, [("BTC-USDT", "1h")])
+        # Active universe uses slash form; catalog uses dash form — must compare equal.
+        self._patch_universe(monkeypatch, ["BTC/USDT"], ["1h"])
+
+        now = datetime(2026, 6, 1, 0, 30, tzinfo=timezone.utc)
+        tasks = CatchUpPlanner(catalog).plan(now=now)
+        assert [t for t in tasks if t.reason == "bootstrap"] == []
+
+    def test_bootstraps_are_ordered_after_gap_fill_tasks(self, monkeypatch, tmp_path):
+        from forven.dataeng.catchup import CatchUpPlanner
+
+        # BTC is STALE (end far behind now) -> a gap-fill task; ETH is a bootstrap.
+        catalog = self._catalog_with(tmp_path, [("BTC-USDT", "1h")])
+        self._patch_universe(monkeypatch, ["BTC/USDT", "ETH/USDT"], ["1h"])
+
+        now = datetime(2026, 6, 3, 0, 0, tzinfo=timezone.utc)  # ~2 days after BTC end
+        tasks = CatchUpPlanner(catalog).plan(now=now)
+
+        reasons = [t.reason for t in tasks]
+        assert "stale" in reasons and "bootstrap" in reasons
+        # every non-bootstrap task precedes every bootstrap task
+        last_non_bootstrap = max(i for i, r in enumerate(reasons) if r != "bootstrap")
+        first_bootstrap = min(i for i, r in enumerate(reasons) if r == "bootstrap")
+        assert last_non_bootstrap < first_bootstrap
+
+    def test_universe_discovery_failure_is_soft(self, monkeypatch, tmp_path):
+        """A universe-resolution error must not break the gap-fill plan."""
+        import forven.data_manager as dm_mod
+        from forven.dataeng.catchup import CatchUpPlanner
+
+        catalog = self._catalog_with(tmp_path, [("BTC-USDT", "1h")])
+
+        def _boom():
+            raise RuntimeError("universe unavailable")
+
+        monkeypatch.setattr(dm_mod, "get_data_manager", _boom)
+
+        now = datetime(2026, 6, 3, 0, 0, tzinfo=timezone.utc)
+        tasks = CatchUpPlanner(catalog).plan(now=now)  # must not raise
+        assert [t for t in tasks if t.reason == "bootstrap"] == []
+        assert any(t.reason == "stale" for t in tasks)  # gap-fill still planned
+
+
+# ---------------------------------------------------------------------------
+# FIX 3 — reconnect jitter + partial-bucket checkpoint durability
+# ---------------------------------------------------------------------------
+
+
+class TestReconnectJitterAndCheckpoint:
+    def test_backoff_jitter_stays_within_bounds(self):
+        from forven.dataeng import liquidations_ws as ws
+
+        for idx in range(len(ws.RECONNECT_BACKOFF_SECONDS) + 2):
+            base = ws.RECONNECT_BACKOFF_SECONDS[min(idx, len(ws.RECONNECT_BACKOFF_SECONDS) - 1)]
+            lo = base * (1 - ws.RECONNECT_JITTER_FRAC)
+            hi = base * (1 + ws.RECONNECT_JITTER_FRAC)
+            for _ in range(200):
+                delay = ws._backoff_delay(idx)
+                assert lo <= delay <= hi, (idx, delay, lo, hi)
+
+    def test_backoff_jitter_is_not_constant(self):
+        from forven.dataeng import liquidations_ws as ws
+
+        samples = {round(ws._backoff_delay(4), 6) for _ in range(50)}
+        assert len(samples) > 1  # de-synchronised, not a fixed ladder
+
+    def test_checkpoint_round_trip_and_restore(self, monkeypatch, tmp_path):
+        from forven.dataeng import liquidations_ws as ws
+        from forven.dataeng.liquidations_ws import BUCKET_MS, LiquidationCapture
+
+        monkeypatch.setattr(ws, "_derivatives_dir", lambda: tmp_path)
+
+        cap = LiquidationCapture()
+        cap._ct_vals = {"BTC-USDT-SWAP": 1.0}
+        cap.ingest(
+            {"data": [{"instId": "BTC-USDT-SWAP", "details": [
+                {"sz": "1", "bkPx": "100", "ts": str(2 * BUCKET_MS + 60_000), "posSide": "long"}]}]}
+        )
+        cap.save_checkpoint()
+        assert ws._checkpoint_path().exists()
+
+        # Simulate a restart: a fresh capture restores the partial + cursors.
+        revived = LiquidationCapture()
+        restored = revived.restore_checkpoint()
+        assert restored == 1
+        assert (("BTC-USDT", 2 * BUCKET_MS)) in revived._buckets
+        assert revived._buckets[("BTC-USDT", 2 * BUCKET_MS)][0] == 100.0
+        assert revived._coverage_start_ms["BTC-USDT"] == 2 * BUCKET_MS
+
+    def test_restored_closed_partial_flushes_as_completed(self, monkeypatch, tmp_path):
+        """A partial whose hour closed while the process was down flushes as a
+        completed bucket on the next pass (combined with zero-fill = gap-honest)."""
+        from forven.dataeng import liquidations_ws as ws
+        from forven.dataeng.liquidations_ws import BUCKET_MS, FLUSH_GRACE_MS, LiquidationCapture
+
+        monkeypatch.setattr(ws, "_derivatives_dir", lambda: tmp_path)
+
+        cap = LiquidationCapture()
+        cap._ct_vals = {"BTC-USDT-SWAP": 1.0}
+        cap.ingest(
+            {"data": [{"instId": "BTC-USDT-SWAP", "details": [
+                {"sz": "1", "bkPx": "500", "ts": str(1 * BUCKET_MS + 60_000), "posSide": "short"}]}]}
+        )
+        cap.save_checkpoint()
+
+        revived = LiquidationCapture()
+        revived.restore_checkpoint()
+        # Now the hour has long closed.
+        now_ms = 3 * BUCKET_MS + FLUSH_GRACE_MS + 1_000
+        by_pair = revived._pop_completed(now_ms)
+        rows = {r["timestamp"] // BUCKET_MS: r for r in by_pair["BTC-USDT"]}
+        assert rows[1]["short_liq_usd"] == 500.0  # the restored partial, now complete
+        assert rows[2]["liq_count"] == 0  # intervening empty hour is an honest zero
+
+    def test_clear_checkpoint_removes_sidecar(self, monkeypatch, tmp_path):
+        from forven.dataeng import liquidations_ws as ws
+        from forven.dataeng.liquidations_ws import LiquidationCapture
+
+        monkeypatch.setattr(ws, "_derivatives_dir", lambda: tmp_path)
+        cap = LiquidationCapture()
+        cap.save_checkpoint()
+        assert ws._checkpoint_path().exists()
+        cap.clear_checkpoint()
+        assert not ws._checkpoint_path().exists()
+
+
+# ---------------------------------------------------------------------------
+# FIX 4 — DataHub -> legacy fallback honesty + parity smoke
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackParity:
+    def _write(self, path: Path, df: pd.DataFrame):
+        from forven.data_manager import _save_stream_parquet
+
+        _save_stream_parquet(df, path, "test", "BTC-USDT")
+
+    def test_absent_stream_is_graceful_on_legacy(self, tmp_path):
+        """An ABSENT stream file stays graceful — the column is simply not joined
+        (both engines agree: not collected yet)."""
+        from forven.data_manager import _merge_asof_parquet
+
+        frame = pd.DataFrame(
+            {"timestamp": pd.date_range("2026-01-01", periods=3, freq="1h", tz="UTC"), "close": 1.0}
+        )
+        out = _merge_asof_parquet(
+            frame, tmp_path / "missing.parquet",
+            cols=["ls_ratio"], fill={"ls_ratio": 0.0},
+        )
+        assert "ls_ratio" not in out.columns  # graceful no-op, no raise
+
+    def test_unreadable_stream_raises_on_legacy(self, tmp_path):
+        """A present-but-corrupt stream file must FAIL loudly on the legacy path
+        instead of silently no-op'ing the column."""
+        from forven.data_manager import StreamUnreadableError, _merge_asof_parquet
+
+        corrupt = tmp_path / "ls.parquet"
+        corrupt.write_bytes(b"PAR1-not-a-real-parquet")
+
+        frame = pd.DataFrame(
+            {"timestamp": pd.date_range("2026-01-01", periods=3, freq="1h", tz="UTC"), "close": 1.0}
+        )
+        with pytest.raises(StreamUnreadableError):
+            _merge_asof_parquet(frame, corrupt, cols=["ls_ratio"], fill={"ls_ratio": 0.0})
+
+    def test_unreadable_stream_raises_on_datahub(self, tmp_path):
+        """DataHub fails identically on the same corrupt file (spec build raises)."""
+        pytest.importorskip("duckdb")
+        from forven.dataeng.hub import StreamUnreadableError, _parquet_has_columns
+
+        corrupt = tmp_path / "ls.parquet"
+        corrupt.write_bytes(b"PAR1-not-a-real-parquet")
+        with pytest.raises(StreamUnreadableError):
+            _parquet_has_columns(corrupt, ["timestamp", "ls_ratio"])
+
+    def test_datahub_enrich_swallows_unreadable_into_fallback_then_raises(self, tmp_path, monkeypatch):
+        """A corrupt expected stream fails the whole enrich (DataHub path), so a
+        backtest never silently runs on an absent aux column."""
+        pytest.importorskip("duckdb")
+        import forven.data_manager as dm_mod
+        from forven.dataeng.hub import DataHub, StreamUnreadableError
+
+        monkeypatch.setattr(dm_mod, "FUNDING_DIR", tmp_path / "funding")
+        monkeypatch.setattr(dm_mod, "OI_DIR", tmp_path / "oi")
+        monkeypatch.setattr(dm_mod, "DERIVATIVES_DIR", tmp_path / "derivatives")
+
+        corrupt = tmp_path / "derivatives" / "BTC-USDT" / "long_short_ratio_1h.parquet"
+        corrupt.parent.mkdir(parents=True)
+        corrupt.write_bytes(b"PAR1-not-a-real-parquet")
+
+        frame = pd.DataFrame(
+            {"timestamp": pd.date_range("2026-01-01", periods=3, freq="1h", tz="UTC"),
+             "open": 1.0, "high": 1.0, "low": 1.0, "close": 1.0, "volume": 1.0}
+        )
+        with pytest.raises(StreamUnreadableError):
+            DataHub().enrich(frame, "BTC/USDT", "1h")
+
+    def test_hub_and_legacy_agree_on_join_semantics(self, tmp_path, monkeypatch):
+        """Parity smoke: the same tiny synthetic lake enriched by DataHub and by
+        the legacy path produce identical values on the overlapping streams
+        (timestamps, bucket-close shift, and zero/coverage fill)."""
+        pytest.importorskip("duckdb")
+        import forven.data_manager as dm_mod
+        from forven.data_manager import DataManager
+        from forven.dataeng.hub import DataHub
+
+        monkeypatch.setattr(dm_mod, "FUNDING_DIR", tmp_path / "funding")
+        monkeypatch.setattr(dm_mod, "OI_DIR", tmp_path / "oi")
+        monkeypatch.setattr(dm_mod, "DERIVATIVES_DIR", tmp_path / "derivatives")
+        monkeypatch.setattr(dm_mod, "MACRO_DIR", tmp_path / "macro")
+
+        self._write(
+            tmp_path / "funding" / "BTC-USDT" / "history.parquet",
+            pd.DataFrame({"timestamp": pd.date_range("2026-05-01", periods=2, freq="2h", tz="UTC"),
+                          "funding_rate": [0.01, 0.02]}),
+        )
+        self._write(
+            tmp_path / "oi" / "BTC-USDT" / "1h.parquet",
+            pd.DataFrame({"timestamp": pd.date_range("2026-05-01", periods=4, freq="1h", tz="UTC"),
+                          "open_interest": [100.0, 110.0, 120.0, 130.0]}),
+        )
+        # Liquidations with an interior zero row (the FIX 1 shape) — parity must
+        # hold across the zero-fill + bucket-close shift on both engines.
+        self._write(
+            tmp_path / "derivatives" / "BTC-USDT" / "liquidations_1h.parquet",
+            pd.DataFrame({"timestamp": pd.date_range("2026-05-01", periods=4, freq="1h", tz="UTC"),
+                          "long_liq_usd": [100.0, 0.0, 0.0, 300.0],
+                          "short_liq_usd": [0.0, 0.0, 0.0, 0.0],
+                          "liq_imbalance": [1.0, 0.0, 0.0, 1.0]}),
+        )
+
+        base = pd.DataFrame(
+            {"timestamp": pd.date_range("2026-05-01", periods=6, freq="1h", tz="UTC"),
+             "open": 1.0, "high": 2.0, "low": 0.5, "close": 1.5, "volume": 10.0}
+        )
+
+        legacy = DataManager().enrich(base.copy(), "BTC/USDT", "1h")
+        hub = DataHub().enrich(base.copy(), "BTC/USDT", "1h")
+
+        shared = [c for c in ("funding_rate", "open_interest", "long_liq_usd",
+                              "short_liq_usd", "liq_imbalance") if c in legacy.columns and c in hub.columns]
+        assert "long_liq_usd" in shared  # the FIX-1 stream is actually exercised
+        for col in shared:
+            pd.testing.assert_series_equal(
+                legacy[col].reset_index(drop=True),
+                hub[col].reset_index(drop=True),
+                check_names=False, check_dtype=False,
+            )


### PR DESCRIPTION
Four independent P2 data-engine correctness fixes. Touches only `forven/dataeng/*`, `forven/data_manager.py`, `.github/workflows/ci.yml`, and tests.

## FIX 1 — Phantom liquidation values via ASOF carry-forward on event-less buckets
The enrichment ASOF join matches backward, so a backtest bar in an hour with **no stored liquidation bucket** read the **previous** bucket's aggregates — stale values indistinguishable from real ones. Root cause: collectors only persisted buckets that HAD events.

- **WS aggregator** (`liquidations_ws.py`): tracks a per-pair coverage cursor (first event ever seen) and, on flush, emits explicit **zero rows** for every closed hour from the cursor forward that had no events — real where events landed, zero otherwise.
- **REST collector** (`data_manager.py LiquidationCollector`): resamples on a **continuous hourly index** spanning the fetched window, so interior empty hours become explicit zero rows.
- **Bounded to liquidation-style event streams** — funding/OI are point-in-time reads where carry-forward is CORRECT and are untouched.
- Zero rows are values **AT their own bucket close**, so nothing moves earlier in time (causality preserved).

Regression: a two-bucket gap between events → the enriched frame shows zeros for the empty hours, not the stale prior value (plus a sanity test proving the phantom without the zeros).

## FIX 2 — Catch-up planner starves symbols not yet in the catalog
`CatchUpPlanner.plan()` only planned series already in the coverage catalog — a newly-activated symbol produced zero rows and was never planned. Added a **symbol-inventory pre-stage**: resolves the active universe (`get_active_symbols(include_recent_backtests=False)` × the scan/sweep timeframes) and emits `reason="bootstrap"` fetch tasks for active `(symbol, timeframe)` pairs with no catalog row. Bootstraps are **appended after** the gap-fill tasks so a large newly-active set can't starve existing series a running strategy depends on. Symbol keys are compared in fs-canonical form so `BTC/USDT` (universe) and `BTC-USDT` (catalog) match. Fail-soft: a universe-discovery error yields no bootstraps and never breaks the gap-fill plan.

Regression: an active pair absent from the catalog appears as a bootstrap task; a covered pair does not; bootstraps ordered strictly after gap-fill tasks; discovery failure is soft.

## FIX 3 — Liquidation WS daemon: reconnect jitter + partial-bucket durability
- **(a)** ±20% random jitter on each fixed backoff step (`_backoff_delay`) so simultaneous restarts don't thundering-herd the venue at identical ladder boundaries.
- **(b)** The in-progress partial bucket + zero-fill cursors are **checkpointed** to an atomic sidecar JSON (`.liq_ws_checkpoint.json`) every ~30s and on each backoff, and **restored on startup**. A restored partial whose hour already closed while down flushes as a completed bucket; combined with FIX 1's zero-rows the intervening down-time hours become honest zeros. No new deps.

Regression: checkpoint round-trip (write → simulate restart → restore → flush), restored-closed-partial flushes as completed with an honest interior zero, jitter bounds + non-constant.

## FIX 4 — DataHub → legacy enrichment fallback could silently diverge
Legacy `_load_stream_parquet` returned `None` on unreadable files, silently skipping a stream DataHub would have surfaced — a backtest then ran with a whole aux column NaN/absent, judged as if that were the data.

- Added `StreamUnreadableError` + `_stream_load_status()`: a **present-but-unreadable** expected stream now **raises on BOTH engines** (they fail identically); an **absent** file stays graceful on both. The per-stream swallow in the legacy path and the hub fallback loop re-raise `StreamUnreadableError` instead of no-op'ing.
- Fixed a **pre-existing pre-coverage divergence** the new parity test surfaced: the hub liquidations spec now uses **coverage-only fill** (matching legacy `fill_coverage_only=True`), so pre-coverage bars stay NaN instead of a fabricated 0.
- Added a **hub/legacy join-semantics parity smoke test** (timestamps, bucket-close shift, zero/coverage fill on the liquidations stream) and wired the new test file into the CI data-engine group in `ci.yml`.

## Testing
- New `tests/test_data_engine_p2_hardening.py` — 19 tests, all green.
- Full CI data-engine group (incl. the new file) — **271 passed**.
- `ruff check forven tests` — clean.
- Known-environmental failures (`test_source_reconciliation_gate`, `test_daemon_startup_recovery`, `test_paper_gate_s00152`) untouched and out of scope.

## Scoped limitation
The catch-up **executor** (`api_domains/data.py`, owned by another agent — not touched) routes candle tasks to `backfill_ohlcv_gaps`, which extends/gap-fills an existing series but does not bootstrap history for a brand-new symbol. FIX 2 makes the planner **surface** the starved symbols (the reported bug); wiring bootstrap execution to `ensure_coverage` is a follow-up in the api-domains file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CBHuQy6taZsvWNwsKig2N
