### PR TITLE
feat(engine): v5 metric-semantics re-baseline — bar Sharpe, funding-aware Kelly, regime-ATR, fixed-dollar

### DIFF
--- a/forven/engine_provenance.py
+++ b/forven/engine_provenance.py
@@ -46,7 +46,7 @@ import json
 # data-substrate rebuild that invalidates comparisons against prior verdicts
 # (verdicts are only evidence relative to the data they were scored on) — and
 # add a matching ENGINE_VERSION_LOG entry (test-enforced).
-BACKTEST_ENGINE_VERSION = 4
+BACKTEST_ENGINE_VERSION = 5
 
 # Append-only changelog: one entry per version, newest last. The unit test
 # asserts the newest entry matches BACKTEST_ENGINE_VERSION so a bump can never
@@ -91,6 +91,21 @@ ENGINE_VERSION_LOG: tuple[dict, ...] = (
             "liquidation, shared hedged exposure, exit-notional fee/slippage, "
             "mark-to-market portfolio return/drawdown, chronological purged WFA, "
             "disjoint optimizer holdout, and point-in-time appended-bar filtering."
+        ),
+    },
+    {
+        "version": 5,
+        "date": "2026-07-11",
+        "summary": (
+            "Metric-semantics re-baseline: bar-level CALENDAR Sharpe/Sortino from the "
+            "mark-to-market equity curve are now the primary sharpe/sortino (trade-based "
+            "EVENT values preserved as trade_sharpe/trade_sortino) — sparse-trading "
+            "strategies read a LOWER, cadence-comparable Sharpe; funding-aware Kelly "
+            "evidence (perp funding accrued inside the kernel walk so kelly sizing learns "
+            "funding-adjusted returns, applied exactly once); unified regime ATR-ratio "
+            "baseline (signal-walk aligned to the 30-bar baseline robustness + live use, "
+            "was 44-bar); and true fixed-DOLLAR notional (fixed-mode sizes off equity at "
+            "entry, so deployed notional stays ~fixed_size instead of scaling with equity)."
         ),
     },
 )

--- a/forven/regime.py
+++ b/forven/regime.py
@@ -88,6 +88,69 @@ def get_adx_bounds_for_family(strategy_type: str) -> tuple[float | None, float |
     return policy.get("adx_min"), policy.get("adx_max")
 
 
+# --- Shared regime ATR-ratio baseline --------------------------------------------
+# The volatility input to _classify is the ATR RATIO: recent ATR vs a lagged baseline
+# ATR. Historically THREE call sites computed it inline with drifting conventions —
+# the backtest signal-walk used a 44-bar baseline while the robustness validator and
+# THIS live detector used a 30-bar baseline (tr[-44:-14]). A bar could therefore
+# classify to a different regime in the backtest vs. live/robustness. These helpers are
+# the ONE definition all three now share (the 30-bar baseline the module docstring
+# always advertised); unifying the signal-walk to it is stats-affecting → engine v5.
+
+# Recent-ATR and baseline-ATR windows, and the lag between them (in bars).
+REGIME_ATR_PERIOD = 14
+REGIME_ATR_BASELINE_PERIOD = 30  # baseline window = tr[-44:-14] → 30 bars, lagged by 14
+
+
+def regime_true_range(high, low, close) -> "pd.Series":
+    """Wilder true range as a pandas Series (max of H-L, |H-prevClose|, |L-prevClose|).
+
+    Accepts pandas Series (aligned by index). No lookahead: TR at bar i uses close[i-1].
+    """
+    high = pd.Series(high)
+    low = pd.Series(low)
+    close = pd.Series(close)
+    prev_close = close.shift()
+    return pd.concat(
+        [(high - low), (high - prev_close).abs(), (low - prev_close).abs()],
+        axis=1,
+    ).max(axis=1)
+
+
+def regime_atr_ratio_series(high, low, close) -> "pd.Series":
+    """Per-bar ATR ratio = mean(TR over last 14) / mean(TR over the 30 bars ending 14
+    bars ago), for regime classification. Vectorized over the whole frame.
+
+    Taking ``.iloc[-1]`` of this on a trailing window reproduces the scalar computation
+    ``mean(tr[-14:]) / mean(tr[-44:-14])`` exactly (when the window spans > 44 bars), so
+    the signal-walk (which reads every bar) and the window-based sites (robustness, live)
+    share ONE baseline. NaN (warmup) is left as NaN — callers substitute 1.0 as before.
+    """
+    tr = regime_true_range(high, low, close)
+    atr_current = tr.rolling(REGIME_ATR_PERIOD).mean()
+    atr_baseline = tr.rolling(REGIME_ATR_BASELINE_PERIOD).mean().shift(REGIME_ATR_PERIOD)
+    return atr_current / atr_baseline.clip(lower=1e-9)
+
+
+def regime_atr_ratio_at(high, low, close, *, default: float = 1.0) -> float:
+    """Scalar ATR ratio at the LAST bar of the given series (the window-based sites).
+
+    Returns ``default`` when the ratio is NaN (warmup) or non-finite, matching the
+    ``else 1.0`` fallbacks the inline sites used.
+    """
+    series = regime_atr_ratio_series(high, low, close)
+    if len(series) == 0:
+        return float(default)
+    value = series.iloc[-1]
+    try:
+        value = float(value)
+    except (TypeError, ValueError):
+        return float(default)
+    if value != value or value in (float("inf"), float("-inf")):  # NaN / inf guard
+        return float(default)
+    return value
+
+
 REGIME_PARAM_OVERLAYS = {
     TREND_UP: {
         "rsi_momentum": {"rsi_entry": 40, "rsi_exit": 60, "adx_min": 0},
@@ -330,15 +393,9 @@ def detect_regime(asset: str, bars: int = 300) -> RegimeState:
         else:
             ema_alignment = "mixed"
 
-        # ATR ratio (current 14-bar ATR vs 30-bar average ATR)
-        tr = pd.concat([
-            high - low,
-            (high - close.shift()).abs(),
-            (low - close.shift()).abs(),
-        ], axis=1).max(axis=1)
-        atr_current = float(tr.iloc[-14:].mean())
-        atr_avg = float(tr.iloc[-44:-14].mean()) if len(tr) > 44 else atr_current
-        atr_ratio = atr_current / atr_avg if atr_avg > 0 else 1.0
+        # ATR ratio (current 14-bar ATR vs 30-bar average ATR) — shared baseline so a
+        # bar classifies identically here, in the backtest signal-walk, and in robustness.
+        atr_ratio = regime_atr_ratio_at(high, low, close, default=1.0)
 
         # Classification logic
         regime, confidence = _classify(adx_val, ema_alignment, atr_ratio, rsi_val)

--- a/forven/strategies/backtest.py
+++ b/forven/strategies/backtest.py
@@ -61,7 +61,16 @@ import pandas as pd
 from forven.db import create_strategy_container, get_db, init_db, next_container_id
 
 
-from forven.regime import HIGH_VOL, RANGE_BOUND, TREND_DOWN, TREND_UP, _classify, resolve_regime_gate
+from forven.regime import (
+    HIGH_VOL,
+    RANGE_BOUND,
+    TREND_DOWN,
+    TREND_UP,
+    _classify,
+    regime_atr_ratio_at,
+    regime_atr_ratio_series,
+    resolve_regime_gate,
+)
 
 
 from forven.scanner import (
@@ -368,11 +377,14 @@ def _isolated_backtest_worker(
             trade_mode=trade_mode,
             execution_controls=execution_controls, initial_capital=initial_capital,
             asset=asset, resolved_timeframe=resolved_timeframe,
+            include_funding=include_funding,
         )
     except Exception as e:
         return {"error": f"Indicator execution failed during in-sample: {_describe_signal_walk_error(e)}"}
 
     if include_funding:
+        # Kernel-path trades were already funded in-walk (funding-aware kelly) and are
+        # skipped here; legacy/slow-path trades are funded now — single application either way.
         is_trades, _ = _apply_funding_to_trades(is_trades, is_df, leverage, resolved_timeframe)
 
     is_equity_curve = _build_equity_curve_from_trades(is_trades, is_df, initial_capital)
@@ -392,6 +404,7 @@ def _isolated_backtest_worker(
                 trade_mode=trade_mode,
                 execution_controls=execution_controls, initial_capital=initial_capital,
                 asset=asset, resolved_timeframe=resolved_timeframe,
+                include_funding=include_funding,
             ),
             oos_start_timestamp,
         )
@@ -401,6 +414,7 @@ def _isolated_backtest_worker(
     if include_funding:
         # entry_bar indexes into oos_context_df (the warmup-padded slice the walk
         # ran on), not oos_df, so funding must be looked up against that frame.
+        # Kernel-funded trades are skipped inside _apply_funding_to_trades (single application).
         oos_trades, _ = _apply_funding_to_trades(oos_trades, oos_context_df, leverage, resolved_timeframe)
 
     oos_equity_curve = _build_equity_curve_from_trades(
@@ -525,6 +539,7 @@ def _isolated_walk_forward_worker(
                 trade_mode=trade_mode,
                 execution_controls=execution_controls, initial_capital=initial_capital,
                 asset=asset, resolved_timeframe=resolved_timeframe,
+                include_funding=include_funding,
             )
             if include_funding:
                 is_trades, _ = _apply_funding_to_trades(
@@ -553,6 +568,7 @@ def _isolated_walk_forward_worker(
                     trade_mode=trade_mode,
                     execution_controls=execution_controls, initial_capital=initial_capital,
                     asset=asset, resolved_timeframe=resolved_timeframe,
+                    include_funding=include_funding,
                 ),
                 oos_boundary,
             )
@@ -5924,16 +5940,11 @@ def _precompute_regimes(df: pd.DataFrame) -> pd.Series:
     h, low_p, c = df["high"], df["low"], df["close"]
 
 
-    tr = pd.concat([(h - low_p), (h - c.shift()).abs(), (low_p - c.shift()).abs()], axis=1).max(axis=1)
-
-
-    atr_current = tr.rolling(14).mean()
-
-
-    atr_avg = tr.rolling(44).mean().shift(14)
-
-
-    atr_ratio = (atr_current / atr_avg.clip(lower=1e-9)).fillna(1.0)
+    # v5: shared regime ATR-ratio baseline (14-bar recent vs 30-bar lagged) so a bar
+    # classifies to the SAME regime here, in robustness, and in the live detector. The
+    # signal-walk previously used a 44-bar baseline (the odd one out) — see
+    # forven.regime.regime_atr_ratio_series.
+    atr_ratio = regime_atr_ratio_series(h, low_p, c).fillna(1.0)
 
 
 
@@ -6499,6 +6510,30 @@ def _hours_per_bar(timeframe: str) -> float:
     return 1.0
 
 
+def _build_funding_context(
+    df: "pd.DataFrame",
+    leverage: float,
+    timeframe: str | None,
+) -> "_kernel.FundingContext | None":
+    """Build the per-bar funding series the kernel accrues in-walk (funding-aware kelly).
+
+    Returns None when the frame carries no ``funding_rate`` column, so the kernel stays
+    price-only and the caller's post-walk :func:`_apply_funding_to_trades` still marks the
+    result funding-incomplete (unchanged behaviour). When present, the ``rates`` array is
+    the raw per-bar funding rate (NaN preserved so a missing bar surfaces as
+    funding-incomplete, exactly like the post-walk pass's window.isna() check).
+
+    Sign/scale are applied inside the kernel's ``_accrue_funding_gross`` to mirror
+    :func:`_apply_funding_to_trades` bit-for-bit (verified by
+    tests/test_funding_kelly_single_application).
+    """
+    if df is None or "funding_rate" not in getattr(df, "columns", []):
+        return None
+    rates = df["funding_rate"].to_numpy(dtype=float)  # NaN preserved for incomplete bars
+    hours = _hours_per_bar(str(timeframe or "1h"))
+    return _kernel.FundingContext(rates=rates, hours_per_bar=float(hours))
+
+
 def _apply_funding_to_trades(
     trades: list[dict],
     df: "pd.DataFrame",
@@ -6535,6 +6570,13 @@ def _apply_funding_to_trades(
     lev = max(float(leverage), 0.0)
     all_complete = True
     for t in trades:
+        # SINGLE-APPLICATION INVARIANT: a trade the kernel already funded in-walk carries
+        # ``_funding_from_kernel``. Never re-apply funding to it — just honor its stamped
+        # completeness so the aggregate all_complete flag stays correct.
+        if t.get("_funding_from_kernel"):
+            if not bool(t.get("funding_complete", True)):
+                all_complete = False
+            continue
         entry_bar = max(int(t.get("entry_bar", 0)), 0)
         bars_held = max(int(t.get("bars_held", 0)), 0)
         if bars_held <= 0:
@@ -7461,10 +7503,18 @@ def run_strategy_execution(
     strategy_type: str | None = None,
     symbol: str | None = None,
     timeframe: str | None = None,
+    include_funding: bool = False,
 ) -> "_kernel.KernelResult | None":
     """The ONE signals→regime-mask→kernel pipeline, shared by the backtest's
     vectorized walk and the live/paper scanner so paper reproduces the backtest by
     SHARING this code rather than re-implementing it.
+
+    ``include_funding`` (backtest opt-in; default False): when True and the frame carries
+    a ``funding_rate`` column, the kernel accrues perp funding INSIDE the walk (so kelly
+    evidence is funding-aware and each trade's PnL carries funding), and every kernel trade
+    is stamped so the post-walk :func:`_apply_funding_to_trades` skips it — funding is
+    applied exactly once. The scanner leaves it False and applies funding post-walk on the
+    returned trades as before, so its behaviour is unchanged.
 
     Resolves the strategy's vectorized signals (``generate_signals``), applies the
     regime gate, resolves the execution profile (or the default 1% fraction sizing),
@@ -7565,11 +7615,16 @@ def run_strategy_execution(
     intrabar_resolver = None
     if symbol and timeframe and str(timeframe) != "1m" and _intrabar_resolution_enabled():
         intrabar_resolver = _build_intrabar_resolver(symbol, str(timeframe), d.index)
+    # Fund the kernel walk in-line (backtest opt-in) so kelly sizing sees funding-adjusted
+    # returns instead of price-only ones (which biased high-funding strategies to size UP).
+    # Built from THIS frame (d) so the per-bar array aligns positionally with the walk; the
+    # scanner passes include_funding=False and keeps its post-walk funding pass.
+    funding_context = _build_funding_context(d, leverage, timeframe) if include_funding else None
     return _kernel.simulate(
         d, signals, warmup, leverage,
         regimes=regime_series, round_trip_drag=drag, trade_mode=trade_mode,
         allowed_modes=_allowed_modes_for(trade_mode), ec=ec, initial_capital=initial_capital,
-        intrabar_resolver=intrabar_resolver,
+        intrabar_resolver=intrabar_resolver, funding=funding_context,
     )
 
 
@@ -9948,6 +10003,12 @@ def _compute_basic_metrics(
             "sortino": 0,
 
 
+            "trade_sharpe": 0,
+
+
+            "trade_sortino": 0,
+
+
             "max_drawdown_pct": 0,
 
 
@@ -10051,10 +10112,15 @@ def _compute_basic_metrics(
         bars_per_year = _BARS_PER_YEAR.get(timeframe, 8760)
 
 
+    # --- Trade-based (EVENT) Sharpe/Sortino ----------------------------------------
+    # mean/std of PER-TRADE pnls, annualized by sqrt(trades_per_year). Preserved as
+    # trade_sharpe/trade_sortino (some diagnostics/DSR want the event series). When an
+    # equity curve is available the bar-level CALENDAR Sharpe below supersedes these as
+    # the primary `sharpe`/`sortino`; otherwise the event value stays `sharpe`.
     mean_return = 0.0
 
 
-    sharpe = 0.0
+    trade_sharpe = 0.0
 
 
     if len(pnls) > 1:
@@ -10072,10 +10138,10 @@ def _compute_basic_metrics(
         if std_return > _RATIO_EPSILON:
 
 
-            sharpe = (mean_return / std_return) * np.sqrt(trades_per_year)
+            trade_sharpe = (mean_return / std_return) * np.sqrt(trades_per_year)
 
 
-    sharpe = _clamp_ratio(sharpe)
+    trade_sharpe = _clamp_ratio(trade_sharpe)
 
 
     # Sharpe is annualized via sqrt(trades_per_year); on a short window with
@@ -10088,10 +10154,10 @@ def _compute_basic_metrics(
 
 
 
-    # Sortino ratio (only penalizes downside deviation)
+    # Sortino ratio (only penalizes downside deviation) — trade-based (EVENT) form.
 
 
-    sortino = 0.0
+    trade_sortino = 0.0
 
 
     if len(pnls) > 1:
@@ -10111,10 +10177,42 @@ def _compute_basic_metrics(
         if downside_std > _RATIO_EPSILON:
 
 
-            sortino = (mean_return / downside_std) * np.sqrt(trades_per_year)
+            trade_sortino = (mean_return / downside_std) * np.sqrt(trades_per_year)
 
 
-    sortino = _clamp_ratio(sortino)
+    trade_sortino = _clamp_ratio(trade_sortino)
+
+
+    # --- Bar-level (CALENDAR) Sharpe/Sortino from the MTM equity curve --------------
+    # v5: when an equity curve is available, compute Sharpe/Sortino from per-BAR returns
+    # of consecutive curve equity points, annualized by sqrt(bars_per_year). This is a
+    # calendar Sharpe: FLAT bars (no open position, equity unchanged → return 0) are part
+    # of the return series by design, so a sparse-trading strategy's bar-Sharpe is
+    # typically LOWER than its event Sharpe (the flat bars dilute the mean and shrink the
+    # std). It is comparable across trade cadences, unlike the event Sharpe. The
+    # trade-based values are preserved as trade_sharpe/trade_sortino below.
+    bar_sharpe: float | None = None
+    bar_sortino: float | None = None
+    if ledger_points and len(ledger_points) > 2:
+        eq = np.array([max(float(p.get("equity") or 0.0), 0.0) for p in ledger_points], dtype=float)
+        prev = eq[:-1]
+        # Per-bar simple return; guard bars where prior equity is ~0 (ruin) → 0 return so
+        # a wiped-out curve doesn't inject spurious ±inf into the series.
+        bar_returns = np.where(prev > _RATIO_EPSILON, (eq[1:] - prev) / np.where(prev > 0.0, prev, 1.0), 0.0)
+        if bar_returns.size >= 2:
+            bmean = float(np.mean(bar_returns))
+            bstd = float(np.std(bar_returns))
+            ann = float(np.sqrt(bars_per_year))
+            # Division-by-zero guard for an all-flat (or single-value) curve.
+            bar_sharpe = _clamp_ratio((bmean / bstd) * ann) if bstd > _RATIO_EPSILON else 0.0
+            downside_b = np.minimum(bar_returns, 0.0)
+            bdown = float(np.sqrt(np.sum(downside_b ** 2) / bar_returns.size))
+            bar_sortino = _clamp_ratio((bmean / bdown) * ann) if bdown > _RATIO_EPSILON else 0.0
+
+    # Primary metrics: bar-level calendar values when a curve exists, else the trade-based
+    # (event) values (legacy fallback path — nothing breaks for metric-only callers).
+    sharpe = bar_sharpe if bar_sharpe is not None else trade_sharpe
+    sortino = bar_sortino if bar_sortino is not None else trade_sortino
 
 
 
@@ -10188,6 +10286,15 @@ def _compute_basic_metrics(
 
 
         "sortino": round(float(sortino), 3),
+
+
+        # Trade-based (event) Sharpe/Sortino preserved for diagnostics/DSR — equals
+        # `sharpe`/`sortino` on the legacy no-curve path, differs when the bar-level
+        # calendar value is primary. See the bar-level block above.
+        "trade_sharpe": round(float(trade_sharpe), 3),
+
+
+        "trade_sortino": round(float(trade_sortino), 3),
 
 
         "max_drawdown_pct": round(float(max_drawdown), 5),
@@ -10474,37 +10581,10 @@ def _detect_entry_regime(window) -> str:
 
 
 
-        tr = np.maximum.reduce([
-
-
-            (high - low).to_numpy(),
-
-
-            (high - close.shift()).abs().to_numpy(),
-
-
-            (low - close.shift()).abs().to_numpy(),
-
-
-        ])
-
-
-        atr_current = float(np.nanmean(tr[-14:]))
-
-
-        if len(tr) > 44:
-
-
-            atr_avg = float(np.nanmean(tr[-44:-14]))
-
-
-        else:
-
-
-            atr_avg = atr_current
-
-
-        atr_ratio = atr_current / atr_avg if atr_avg > 0 else 1.0
+        # v5: shared regime ATR-ratio baseline (14-bar recent vs 30-bar lagged) so a bar
+        # classifies identically here, in the signal-walk, and in the live detector.
+        # See forven.regime.regime_atr_ratio_at.
+        atr_ratio = regime_atr_ratio_at(high, low, close, default=1.0)
 
 
 
@@ -11373,10 +11453,17 @@ def _run_signal_walk(checker, df, params: dict, warmup: int, leverage: float,
 
                      asset: str | None = None,
 
-                     resolved_timeframe: str | None = None) -> list[dict]:
+                     resolved_timeframe: str | None = None,
+
+                     include_funding: bool = False) -> list[dict]:
 
 
     """Run signal checker across a dataframe window and collect trades.
+
+    ``include_funding`` (backtest opt-in): when True, the kernel path accrues perp funding
+    IN-WALK (funding-aware kelly evidence) and stamps each trade so the caller's post-walk
+    ``_apply_funding_to_trades`` skips it. The legacy/slow paths don't fund in-walk, so the
+    post-walk pass still funds their trades. The scanner never sets this.
 
 
 
@@ -11408,6 +11495,7 @@ def _run_signal_walk(checker, df, params: dict, warmup: int, leverage: float,
             trade_mode=trade_mode, execution_controls=execution_controls,
             initial_capital=initial_capital, strategy_type=strategy_type,
             symbol=asset, timeframe=resolved_timeframe,
+            include_funding=include_funding,
         )
     except RuntimeError as exc:
         if _VECTORIZED_PATH_UNAVAILABLE not in str(exc):
@@ -11418,6 +11506,9 @@ def _run_signal_walk(checker, df, params: dict, warmup: int, leverage: float,
             _kernel_result, df, leverage=leverage,
             round_trip_drag=_kernel.round_trip_drag(fee_bps, slippage_bps, leverage),
             trade_mode=trade_mode,
+            # Same funding context the walk ran with (None when include_funding is off or
+            # the frame has no funding_rate), so the end-of-data close funds consistently.
+            funding=_kernel_result.funding,
         )
 
 

--- a/forven/strategies/execution_kernel.py
+++ b/forven/strategies/execution_kernel.py
@@ -31,11 +31,27 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+import numpy as np
 import pandas as pd
 
 from forven.regime import RANGE_BOUND
 from forven.strategies import sizing as _sizing
 from forven.strategies.base import DirectionalSignals  # noqa: F401  (re-exported for callers)
+
+
+@dataclass(frozen=True)
+class FundingContext:
+    """Per-bar perp funding series threaded into :func:`simulate` (opt-in).
+
+    ``rates`` is a numpy array aligned 1:1 with the simulated frame's bars (the merged
+    ``funding_rate`` column; NaN where a bar had no rate). ``hours_per_bar`` scales the
+    per-bar rate to the bar's holding interval (funding accrues hourly). Supplied only by
+    the backtest funding path; the scanner and every parity test leave it None so the
+    kernel stays byte-identically price-only and funding is owned by the post-walk pass.
+    """
+
+    rates: "np.ndarray"
+    hours_per_bar: float
 
 
 def _trade_direction_sign(direction: str) -> float:
@@ -164,6 +180,47 @@ class KernelResult:
     pending_entries: dict[str, dict] = field(default_factory=dict)
     pending_exits: dict[str, dict] = field(default_factory=dict)
     ec: dict | None = None
+    # The funding context :func:`simulate` ran with (None = price-only). Exposed so the
+    # backtest's force-close applies funding to the end-of-data trade with the same
+    # series/alignment the walk used, keeping the single-application invariant intact.
+    funding: "FundingContext | None" = None
+
+
+def _accrue_funding_gross(
+    funding: "FundingContext | None",
+    direction: str,
+    entry_bar: int,
+    exit_idx: int,
+    leverage: float,
+) -> tuple[float | None, bool]:
+    """Pre-size, leveraged funding return for a position held over [entry_bar, exit_idx).
+
+    Returns ``(funding_gross, complete)`` where ``funding_gross`` is the equity-fraction
+    funding term at UNIT size (positive = credit received, negative = paid) and
+    ``complete`` is False if any held bar lacked a funding rate. Returns ``(None, ...)``
+    when no funding context is supplied (the default — kernel stays price-only, and the
+    post-walk :func:`backtest._apply_funding_to_trades` owns funding as before).
+
+    Sign/scale mirror ``_apply_funding_to_trades`` EXACTLY except it stops before the
+    ``* size_fraction`` step (that is applied by the caller), so the two never diverge:
+    ``funding_pnl = -sign * Σfunding_rate * hours * leverage`` (pre-size).
+    """
+    if funding is None:
+        return None, True
+    rates = funding.rates
+    n = len(rates)
+    lo = max(int(entry_bar), 0)
+    hi = min(int(exit_idx), n)
+    if hi <= lo:
+        # Zero-bar hold accrues no funding — trivially complete (mirrors the
+        # bars_held<=0 branch in _apply_funding_to_trades).
+        return 0.0, True
+    window = rates[lo:hi]
+    complete = not bool(np.isnan(window).any())
+    funding_sum = float(np.nansum(window))
+    sign = _trade_direction_sign(direction)
+    funding_gross = -sign * funding_sum * funding.hours_per_bar * max(float(leverage), 0.0)
+    return funding_gross, complete
 
 
 def finalize(
@@ -180,11 +237,19 @@ def finalize(
     leverage: float,
     trade_mode: str,
     open_at_end: bool = False,
+    funding: "FundingContext | None" = None,
 ) -> None:
     """Append one realized trade (and its pre-size gross to the kelly evidence list).
 
     Shared by :func:`simulate`'s in-loop exits and the backtest's end-of-data
     force-close so the math is defined exactly once.
+
+    When ``funding`` is supplied (opt-in; default None), the position's perp funding is
+    accrued INSIDE the walk: the pre-size funding return is folded into ``gross`` (so the
+    kelly evidence series ``closed_gross`` is funding-aware — the whole point) and the
+    size-scaled funding into ``pnl_pct`` (so the kernel's own trade PnL is funding-aware
+    too). The trade is stamped ``_funding_from_kernel`` so the post-walk
+    ``_apply_funding_to_trades`` SKIPS it — funding is applied exactly once.
     """
     entry_price = float(at["entry_price"])
     if entry_price <= 0:
@@ -192,8 +257,17 @@ def finalize(
     sign = _trade_direction_sign(direction)
     drag = _trade_drag(round_trip_drag, entry_price, float(exit_price))
     gross = ((exit_price - entry_price) / entry_price) * sign * leverage - drag
-    closed_gross.append(gross)  # pre-size, for kelly evidence
     size_fraction = float(at.get("size_fraction", 1.0))
+
+    funding_gross, funding_complete = _accrue_funding_gross(
+        funding, direction, int(at["entry_bar"]), int(exit_idx), leverage
+    )
+    if funding_gross is not None:
+        # Fold funding into the pre-size gross BEFORE the kelly-evidence append so
+        # Kelly learns from the funding-adjusted return (fixes the high-funding
+        # size-up bias); the trade's net pnl then carries the size-scaled leg.
+        gross = gross + funding_gross
+    closed_gross.append(gross)  # pre-size, for kelly evidence (funding-aware when supplied)
     pnl_pct = gross * size_fraction
     trade = {
         "entry_bar": int(at["entry_bar"]),
@@ -214,6 +288,13 @@ def finalize(
         "cost_drag_pct": round(float(drag * size_fraction), 8),
         "exit_reason": exit_reason,
     }
+    if funding_gross is not None:
+        # Kernel-applied funding: stamp the same fields _apply_funding_to_trades would,
+        # and mark it so that post-walk pass skips this trade (single-application invariant).
+        trade["funding_cost_pct"] = round(float(funding_gross * size_fraction), 6)
+        trade["funding_applied"] = True
+        trade["funding_complete"] = bool(funding_complete)
+        trade["_funding_from_kernel"] = True
     if open_at_end:
         trade["open_at_end"] = True
     if at.get("regime") is not None:
@@ -234,6 +315,7 @@ def simulate(
     ec: dict,
     initial_capital: float,
     intrabar_resolver=None,
+    funding: "FundingContext | None" = None,
 ) -> KernelResult:
     """Walk the bars and produce closed trades + still-open positions (no force-close).
 
@@ -249,6 +331,11 @@ def simulate(
     returns ``"stop"`` / ``"tp"`` / ``None`` (None = stay pessimistic). It is
     consulted ONLY in the both-touched case, so single-touch bars are
     byte-identical with the resolver on or off.
+
+    ``funding`` (optional): a :class:`FundingContext` of the per-bar funding series.
+    When supplied, each trade's funding is accrued at finalize (folded into the kelly
+    evidence AND the trade's net PnL) and the post-walk pass skips it — see
+    :func:`finalize`. Default None ⇒ price-only kernel (byte-identical to pre-v5).
     """
     opens = df["open"].astype(float).values
     highs = df["high"].astype(float).values
@@ -262,6 +349,12 @@ def simulate(
     lev = max(float(leverage), 1e-9)
     maintenance_margin_ratio = 0.005
 
+    # Running realized equity, compounded from each closed trade's net pnl_pct. Only
+    # ``fixed``-mode sizing reads it (true fixed-DOLLAR notional: the target dollar amount
+    # divided by the account value AT ENTRY, so a growing account deploys a shrinking
+    # fraction). Other modes ignore current_equity, so this is inert for them.
+    realized_equity = [max(float(initial_capital), 0.0)]
+
     def _entry_stop_dist_pct(entry_idx: int, entry_price: float) -> float | None:
         atr_value = (
             float(atr_vals[entry_idx])
@@ -274,7 +367,20 @@ def simulate(
         return _sizing.size_fraction(
             ec, stop_dist_pct, leverage=lev,
             initial_capital=initial_capital, closed_gross=closed_gross,
+            current_equity=realized_equity[0],
         )
+
+    def _finalize(at, direction, exit_price, exit_idx, exit_time, exit_reason, *, open_at_end=False):
+        """Finalize a trade AND advance the running equity by its net return, so a
+        later fixed-mode entry sizes off the up-to-date account value."""
+        before = len(trades)
+        finalize(
+            trades, closed_gross, at, direction, exit_price, exit_idx, exit_time, exit_reason,
+            round_trip_drag=round_trip_drag, leverage=leverage, trade_mode=trade_mode,
+            open_at_end=open_at_end, funding=funding,
+        )
+        if len(trades) > before:
+            realized_equity[0] = max(0.0, realized_equity[0] * (1.0 + float(trades[-1]["pnl_pct"])))
 
     for idx in range(max(int(warmup), 0) + 1, len(df)):
         signal_idx = idx - 1
@@ -371,8 +477,7 @@ def simulate(
                     exit_price, exit_reason = (tp, "take_profit")
 
             if exit_price is not None:
-                finalize(trades, closed_gross, at, direction, exit_price, idx, current_time, exit_reason,
-                         round_trip_drag=round_trip_drag, leverage=leverage, trade_mode=trade_mode)
+                _finalize(at, direction, exit_price, idx, current_time, exit_reason)
                 active_trades[direction] = None
             elif at.get("trail_pct"):
                 # Still open — ratchet the trailing peak with THIS bar for the next bar.
@@ -476,10 +581,7 @@ def simulate(
                 exit_price, exit_reason = float(target_price), "take_profit"
 
             if exit_price is not None:
-                finalize(
-                    trades, closed_gross, at, direction, exit_price, idx, current_time, exit_reason,
-                    round_trip_drag=round_trip_drag, leverage=leverage, trade_mode=trade_mode,
-                )
+                _finalize(at, direction, exit_price, idx, current_time, exit_reason)
                 active_trades[direction] = None
             elif at.get("trail_pct"):
                 at["extreme"] = max(fill_price, bar_high) if direction == "long" else min(fill_price, bar_low)
@@ -533,7 +635,7 @@ def simulate(
     open_positions = {direction: at for direction, at in active_trades.items() if at is not None}
     return KernelResult(
         closed_trades=trades, open_positions=open_positions, closed_gross=closed_gross,
-        pending_entries=pending_entries, pending_exits=pending_exits, ec=ec,
+        pending_entries=pending_entries, pending_exits=pending_exits, ec=ec, funding=funding,
     )
 
 
@@ -544,10 +646,15 @@ def force_close(
     leverage: float,
     round_trip_drag: float,
     trade_mode: str,
+    funding: "FundingContext | None" = None,
 ) -> list[dict]:
     """Append a synthetic close at the final bar's close for every still-open position
     (the backtest's end-of-data accounting). Mutates and returns ``res.closed_trades``.
-    The scanner does NOT call this — it leaves the position live."""
+    The scanner does NOT call this — it leaves the position live.
+
+    ``funding`` mirrors :func:`simulate`: when supplied, the end-of-data close accrues
+    its funding inside the kernel and is stamped so the post-walk pass skips it. Default
+    None keeps the price-only convention (the scanner never calls this)."""
     trades = res.closed_trades
     final_idx = len(df) - 1
     final_close = float(df["close"].iloc[final_idx]) if len(df) else 0.0
@@ -557,6 +664,7 @@ def force_close(
             continue
         finalize(
             trades, res.closed_gross, at, direction, final_close, final_idx, final_time, "signal",
-            round_trip_drag=round_trip_drag, leverage=leverage, trade_mode=trade_mode, open_at_end=True,
+            round_trip_drag=round_trip_drag, leverage=leverage, trade_mode=trade_mode,
+            open_at_end=True, funding=funding,
         )
     return trades

--- a/forven/strategies/sizing.py
+++ b/forven/strategies/sizing.py
@@ -260,6 +260,7 @@ def size_fraction(
     leverage: float,
     initial_capital: float,
     closed_gross: list[float] | None = None,
+    current_equity: float | None = None,
 ) -> float:
     """Fraction of equity to deploy on a trade, per the sizing mode.
 
@@ -267,6 +268,14 @@ def size_fraction(
     full/fixed/kelly; for fraction/atr it returns ``risk_per_trade /
     (stop_dist_pct * leverage)`` clamped to [0, 1] (so a stop-out loses
     ~risk_per_trade of equity, leverage-invariant).
+
+    ``current_equity`` is the account value AT ENTRY. ``fixed`` mode divides the
+    target dollar notional by it (true fixed-dollar: the deployed notional stays
+    ~``fixed_size`` dollars regardless of account growth). It defaults to
+    ``initial_capital`` when the caller cannot supply a running equity (e.g. a
+    stateless mirror), which reproduces the pre-v5 fixed-FRACTION behaviour for
+    that one call — callers that track equity (the kernel walk) pass it so the
+    notional is genuinely fixed.
     """
     mode = ec["sizing_mode"]
     if mode == "full":
@@ -274,7 +283,12 @@ def size_fraction(
     if mode == "fixed":
         if not ec.get("fixed_size"):
             return 1.0
-        return clamp01(ec["fixed_size"] / max(float(initial_capital), 1e-9))
+        # True fixed-dollar notional: size the target dollar amount against the
+        # account value AT ENTRY, not the static initial capital, so a growing
+        # account keeps deploying ~fixed_size dollars (a SHRINKING fraction) rather
+        # than a fixed fraction whose dollar notional balloons with equity.
+        equity_base = current_equity if (current_equity is not None and current_equity > 0) else initial_capital
+        return clamp01(ec["fixed_size"] / max(float(equity_base), 1e-9))
     if mode == "kelly":
         return clamp01(ec["kelly_multiplier"] * kelly_fraction(closed_gross or [], ec["kelly_lookback"]))
     # fraction / atr → risk-based: lose ~risk_per_trade of equity at the stop.

--- a/tests/test_backtest_metrics_math.py
+++ b/tests/test_backtest_metrics_math.py
@@ -6,11 +6,22 @@ import pytest
 
 import pandas as pd
 
+import numpy as np
+
 from forven.strategies.backtest import (
+    _BARS_PER_YEAR,
     _build_equity_curve_from_trades,
     _compute_basic_metrics,
     compute_metrics,
 )
+
+
+def _curve(equities):
+    """Minimal MTM ledger from a list of per-bar equity values."""
+    return [
+        {"equity": float(e), "drawdown_equity": float(e), "initial_equity": float(equities[0])}
+        for e in equities
+    ]
 
 
 def test_compute_basic_metrics_uses_compounded_equity_curve():
@@ -137,6 +148,99 @@ def test_mark_to_market_curve_captures_intratrade_drawdown():
     assert curve[2]["equity"] == pytest.approx(5_000.0)
     assert float(metrics["total_return_pct"]) == pytest.approx(0.10)
     assert float(metrics["max_drawdown_pct"]) == pytest.approx(0.50)
+
+
+def _bar_sharpe_expected(returns, timeframe):
+    """Mirror the production bar-level Sharpe (mean/std * sqrt(bpy), clamped to ±10)."""
+    r = np.asarray(returns, dtype=float)
+    bpy = _BARS_PER_YEAR[timeframe]
+    raw = (r.mean() / r.std()) * np.sqrt(bpy) if r.std() > 1e-6 else 0.0
+    return float(np.clip(raw, -10.0, 10.0))
+
+
+def test_bar_level_sharpe_is_primary_when_curve_present_and_includes_flat_bars():
+    """v5: with an equity curve, `sharpe`/`sortino` are the bar-level CALENDAR values —
+    computed from consecutive-point returns (flat bars INCLUDED), annualized by
+    sqrt(bars_per_year). Trade-based (event) values are preserved as trade_*."""
+    # Equity path chosen so bar returns have a deliberate FLAT bar and enough dispersion
+    # that the annualized Sharpe stays UNCLAMPED (well within ±10) on the weekly frame.
+    # bar returns: [+0.02, 0.0(flat), -0.01, +0.03, -0.005]
+    e0 = 10_000.0
+    r = [0.02, 0.0, -0.01, 0.03, -0.005]
+    equities = [e0]
+    for x in r:
+        equities.append(equities[-1] * (1.0 + x))
+    curve = _curve(equities)
+    trades = [
+        {"pnl_pct": 0.02, "bars_held": 1},
+        {"pnl_pct": -0.01, "bars_held": 1},
+        {"pnl_pct": 0.03, "bars_held": 1},
+        {"pnl_pct": -0.005, "bars_held": 1},
+    ]
+    m = _compute_basic_metrics(trades, total_bars=len(curve), timeframe="1w", equity_curve=curve)
+
+    # Reconstruct the exact per-bar simple returns from the curve (what the engine uses).
+    eq = np.array(equities)
+    bar_returns = (eq[1:] - eq[:-1]) / eq[:-1]
+    expected = _bar_sharpe_expected(bar_returns, "1w")
+    assert -10.0 < expected < 10.0, "test frame must keep the bar-Sharpe unclamped"
+    assert float(m["sharpe"]) == pytest.approx(round(expected, 3), abs=2e-3)
+
+    # Trade-based (event) value is preserved and computed by the OLD formula (differs).
+    event = _compute_basic_metrics(trades, total_bars=len(curve), timeframe="1w")  # no curve
+    assert float(m["trade_sharpe"]) == pytest.approx(float(event["sharpe"]), abs=1e-6)
+
+
+def test_bar_level_sharpe_lower_than_event_for_sparse_trading():
+    """The scale-shift note: a sparse-trading strategy's bar-Sharpe is LOWER than its
+    event Sharpe because the flat bars dilute the mean and enter the volatility. Compared
+    at the RAW (pre-clamp) mean/std ratios so the demonstration doesn't hide under the
+    ±10 clamp that heavy annualization would otherwise impose on both."""
+    # A mostly-flat curve with a handful of moves of MIXED sign (real dispersion).
+    r = [0.0, 0.0, 0.02, 0.0, -0.01, 0.0, 0.0, 0.03, 0.0, 0.0]
+    equities = [10_000.0]
+    for x in r:
+        equities.append(equities[-1] * (1.0 + x))
+    curve = _curve(equities)
+    # The "event" series = the non-flat moves the strategy actually took.
+    event_pnls = np.array([x for x in r if x != 0.0])
+    bar_returns = np.array(r)  # calendar series, flat bars included
+
+    # Raw (un-annualized, un-clamped) Sharpe ratios: bar dilutes the mean toward zero.
+    event_ratio = event_pnls.mean() / event_pnls.std()
+    bar_ratio = bar_returns.mean() / bar_returns.std()
+    assert 0.0 < bar_ratio < event_ratio, "flat bars must lower the calendar Sharpe ratio"
+
+    # And the engine's `sharpe` is the bar-level one (primary) while trade_sharpe is event.
+    m = _compute_basic_metrics(
+        [{"pnl_pct": float(x), "bars_held": 1} for x in event_pnls],
+        total_bars=len(curve), timeframe="1w", equity_curve=curve,
+    )
+    assert float(m["sharpe"]) != float(m["trade_sharpe"])
+
+
+def test_all_flat_curve_sharpe_is_zero_not_nan():
+    """Division-by-zero guard: a curve that never moves (all-flat) yields sharpe 0."""
+    curve = _curve([10_000.0, 10_000.0, 10_000.0, 10_000.0])
+    m = _compute_basic_metrics(
+        [{"pnl_pct": 0.0, "bars_held": 1}], total_bars=len(curve), timeframe="1h", equity_curve=curve
+    )
+    assert float(m["sharpe"]) == 0.0
+    assert float(m["sortino"]) == 0.0
+
+
+def test_no_curve_keeps_event_sharpe_as_primary():
+    """Legacy fallback: with NO equity curve, `sharpe` stays the trade-based value and
+    equals trade_sharpe (nothing breaks for metric-only callers)."""
+    trades = [
+        {"pnl_pct": 0.05, "bars_held": 3},
+        {"pnl_pct": -0.02, "bars_held": 2},
+        {"pnl_pct": 0.03, "bars_held": 4},
+    ]
+    m = _compute_basic_metrics(trades, total_bars=8760, timeframe="1h")  # no equity_curve
+    assert float(m["sharpe"]) == float(m["trade_sharpe"])
+    assert float(m["sortino"]) == float(m["trade_sortino"])
+    assert m["sharpe"] != 0.0  # dispersion present → non-trivial
 
 
 def test_simultaneous_hedged_exits_are_additive_not_sequentially_compounded():

--- a/tests/test_funding_kelly_single_application.py
+++ b/tests/test_funding_kelly_single_application.py
@@ -1,0 +1,178 @@
+"""v5 funding-aware Kelly evidence + the single-application invariant.
+
+Before v5 the kernel's kelly evidence (``closed_gross``) was PRICE-ONLY: funding was
+applied post-walk (``_apply_funding_to_trades``) after the walk had already sized every
+trade, so kelly sizing learned funding-free returns and biased high-funding strategies to
+size UP. v5 accrues funding INSIDE the kernel walk when a ``FundingContext`` is supplied,
+folding it into ``closed_gross`` (so kelly is funding-aware) and the trade's ``pnl_pct``.
+
+The CRITICAL correctness hazard is double-application. These tests prove funding is
+applied EXACTLY ONCE: the kernel-in-walk result equals the price-only-kernel + post-walk
+result trade-for-trade, and the post-walk pass SKIPS kernel-funded trades.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from forven.strategies import backtest as bt
+from forven.strategies import execution_kernel as ek
+from forven.strategies.base import DirectionalSignals
+from forven.strategies.sizing import normalize_execution_controls
+
+
+def _frame_with_funding(n: int = 12, funding_rate: float = 0.001) -> pd.DataFrame:
+    """A flat-ish uptrending frame with a constant per-bar funding_rate column."""
+    idx = pd.date_range("2025-01-01", periods=n, freq="1h", tz="UTC")
+    close = np.linspace(100.0, 111.0, n)
+    df = pd.DataFrame(
+        {
+            "open": close,
+            "high": close * 1.001,
+            "low": close * 0.999,
+            "close": close,
+            "volume": 1_000.0,
+            "funding_rate": float(funding_rate),
+        },
+        index=idx,
+    )
+    return df
+
+
+def _one_long_signal(df: pd.DataFrame, entry_i: int, exit_i: int) -> DirectionalSignals:
+    n = len(df)
+    le = pd.Series(False, index=df.index)
+    lx = pd.Series(False, index=df.index)
+    le.iloc[entry_i] = True   # fills at entry_i+1 open
+    lx.iloc[exit_i] = True     # exit signal at exit_i → fills exit_i+1 open
+    false = pd.Series(False, index=df.index)
+    return DirectionalSignals(le, lx, false.copy(), false.copy())
+
+
+LEV = 2.0
+HOURS = 1.0  # 1h bars
+
+
+def _sim(df, signals, ec, funding, trade_mode="long_only"):
+    allowed = ("short",) if trade_mode == "short_only" else ("long",)
+    return ek.simulate(
+        df, signals, warmup=1, leverage=LEV, regimes=None, round_trip_drag=0.0,
+        trade_mode=trade_mode, allowed_modes=allowed, ec=ec, initial_capital=10_000.0,
+        funding=funding,
+    )
+
+
+def test_kernel_funding_matches_post_walk_exactly_single_application():
+    """The kernel-in-walk funded trade PnL == price-only-kernel PnL + post-walk funding,
+    to the last decimal. Proves the two funding paths compute the identical value AND
+    that applying both would double-count (hence the skip guard)."""
+    df = _frame_with_funding()
+    signals = _one_long_signal(df, entry_i=2, exit_i=6)
+    ec = normalize_execution_controls({"sizing_mode": "full", "stop_loss_pct": 50.0})
+    assert ec is not None
+
+    # (A) price-only kernel, THEN post-walk funding (the pre-v5 path).
+    res_a = _sim(df, signals, ec, funding=None)
+    trades_a = ek.force_close(res_a, df, leverage=LEV, round_trip_drag=0.0, trade_mode="long_only")
+    assert trades_a and not trades_a[0].get("_funding_from_kernel")
+    bt._apply_funding_to_trades(trades_a, df, LEV, "1h")
+
+    # (B) funding-aware kernel (v5), no post-walk needed.
+    fctx = bt._build_funding_context(df, LEV, "1h")
+    assert fctx is not None
+    res_b = _sim(df, signals, ec, funding=fctx)
+    trades_b = ek.force_close(res_b, df, leverage=LEV, round_trip_drag=0.0, trade_mode="long_only",
+                              funding=fctx)
+    assert trades_b and trades_b[0].get("_funding_from_kernel") is True
+
+    assert len(trades_a) == len(trades_b) == 1
+    # Identical net PnL → funding applied once, same magnitude, in both paths.
+    assert trades_b[0]["pnl_pct"] == trades_a[0]["pnl_pct"]
+    assert trades_b[0]["funding_cost_pct"] == trades_a[0]["funding_cost_pct"]
+
+
+def test_post_walk_pass_skips_kernel_funded_trades_no_double_count():
+    """Running _apply_funding_to_trades on already-kernel-funded trades must be a NO-OP
+    for pnl (single-application invariant) — the exact call the backtest worker makes."""
+    df = _frame_with_funding()
+    signals = _one_long_signal(df, entry_i=2, exit_i=6)
+    ec = normalize_execution_controls({"sizing_mode": "full", "stop_loss_pct": 50.0})
+    fctx = bt._build_funding_context(df, LEV, "1h")
+
+    res = _sim(df, signals, ec, funding=fctx)
+    trades = ek.force_close(res, df, leverage=LEV, round_trip_drag=0.0, trade_mode="long_only",
+                            funding=fctx)
+    pnl_before = trades[0]["pnl_pct"]
+
+    # The worker still calls this afterward; it must SKIP the kernel-funded trade.
+    bt._apply_funding_to_trades(trades, df, LEV, "1h")
+    assert trades[0]["pnl_pct"] == pnl_before, "funding was double-applied"
+
+
+def test_closed_gross_is_funding_aware_hand_computed():
+    """closed_gross (the kelly evidence) must carry the PRE-SIZE funding term.
+
+    Long, leverage 2, held bars [3,4,5,6) = 4 funding intervals at rate 0.001/bar,
+    hours=1. Pre-size funding = -sign * Σrate * hours * lev = -1 * (4*0.001) * 1 * 2 =
+    -0.008 (a long PAYS positive funding). closed_gross = price_gross + (-0.008)."""
+    df = _frame_with_funding(funding_rate=0.001)
+    signals = _one_long_signal(df, entry_i=2, exit_i=6)  # entry fills bar 3, exit fills bar 7
+    ec = normalize_execution_controls({"sizing_mode": "full", "stop_loss_pct": 50.0})
+
+    # Price-only reference gross (funding=None).
+    res_price = _sim(df, signals, ec, funding=None)
+    ek.force_close(res_price, df, leverage=LEV, round_trip_drag=0.0, trade_mode="long_only")
+    gross_price = res_price.closed_gross[0]
+
+    # Funding-aware gross.
+    fctx = bt._build_funding_context(df, LEV, "1h")
+    res_fund = _sim(df, signals, ec, funding=fctx)
+    ek.force_close(res_fund, df, leverage=LEV, round_trip_drag=0.0, trade_mode="long_only", funding=fctx)
+    gross_fund = res_fund.closed_gross[0]
+
+    # The trade entered at bar 3 and exited at bar 7 (exit signal on bar 6 → fill bar 7);
+    # funding accrues over [entry_bar, exit_idx). Derive the expected pre-size funding from
+    # the actual trade's entry_bar/bars_held so the window matches the kernel exactly.
+    tr = res_fund.closed_trades[0]
+    held = tr["bars_held"]
+    expected_funding_gross = -1.0 * (held * 0.001) * HOURS * LEV
+    assert (gross_fund - gross_price) == pytest.approx(expected_funding_gross, abs=1e-12)
+    # Funding-aware gross is LOWER (long pays funding) → kelly sizes DOWN vs price-only.
+    assert gross_fund < gross_price
+
+
+def test_short_receives_funding_credit_sign_convention():
+    """A short RECEIVES positive funding: its funding term is POSITIVE (credit), so its
+    kelly evidence and pnl are HIGHER than price-only — the opposite of the long."""
+    df = _frame_with_funding(funding_rate=0.001)
+    n = len(df)
+    se = pd.Series(False, index=df.index)
+    sx = pd.Series(False, index=df.index)
+    se.iloc[2] = True
+    sx.iloc[6] = True
+    false = pd.Series(False, index=df.index)
+    signals = DirectionalSignals(false.copy(), false.copy(), se, sx)
+    ec = normalize_execution_controls({"sizing_mode": "full", "stop_loss_pct": 50.0})
+
+    res_price = _sim(df, signals, ec, funding=None, trade_mode="short_only")
+    ek.force_close(res_price, df, leverage=LEV, round_trip_drag=0.0, trade_mode="short_only")
+    fctx = bt._build_funding_context(df, LEV, "1h")
+    res_fund = _sim(df, signals, ec, funding=fctx, trade_mode="short_only")
+    ek.force_close(res_fund, df, leverage=LEV, round_trip_drag=0.0, trade_mode="short_only", funding=fctx)
+
+    # Short's funding is a credit → funded gross ABOVE the price-only gross.
+    assert res_fund.closed_gross[0] > res_price.closed_gross[0]
+
+
+def test_no_funding_column_leaves_kernel_price_only():
+    """When the frame has no funding_rate column, _build_funding_context returns None →
+    the kernel is byte-identical to the price-only path (funding owned post-walk)."""
+    df = _frame_with_funding().drop(columns=["funding_rate"])
+    assert bt._build_funding_context(df, LEV, "1h") is None
+    signals = _one_long_signal(df, entry_i=2, exit_i=6)
+    ec = normalize_execution_controls({"sizing_mode": "full", "stop_loss_pct": 50.0})
+    res = _sim(df, signals, ec, funding=None)
+    trades = ek.force_close(res, df, leverage=LEV, round_trip_drag=0.0, trade_mode="long_only")
+    assert trades and "_funding_from_kernel" not in trades[0]

--- a/tests/test_regime_atr_unification.py
+++ b/tests/test_regime_atr_unification.py
@@ -1,0 +1,91 @@
+"""v5 regime ATR-ratio unification.
+
+The ATR ratio that feeds ``regime._classify`` used to be computed inline at three sites
+with drifting conventions: the backtest signal-walk (``_precompute_regimes``) used a
+44-bar baseline while robustness (``_detect_entry_regime``) and the live detector used a
+30-bar baseline (``tr[-44:-14]``). So a bar could classify to a different regime in the
+backtest vs. live/robustness. v5 routes ALL three through
+``forven.regime.regime_atr_ratio_*`` so the baseline is identical everywhere.
+
+These tests lock the equivalence: the vectorized signal-walk ratio at bar i equals the
+window-based scalar at the same bar, and the two backtest regime paths agree bar-for-bar.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from forven import regime
+from forven.strategies import backtest as bt
+
+
+def _synth_frame(n: int = 400, seed: int = 11) -> pd.DataFrame:
+    """A volatile random walk so ATR ratios span calm and spiky regimes."""
+    rng = np.random.default_rng(seed)
+    steps = rng.normal(0.0004, 0.02, size=n).cumsum()
+    close = 100.0 * np.exp(steps)
+    spread = np.abs(rng.normal(0.0, 0.02, size=n)) + 0.003
+    high = close * (1.0 + spread)
+    low = close * (1.0 - spread)
+    openp = np.empty(n)
+    openp[0] = close[0]
+    openp[1:] = close[:-1]
+    high = np.maximum.reduce([high, openp, close])
+    low = np.minimum.reduce([low, openp, close])
+    idx = pd.date_range("2024-01-01", periods=n, freq="1h", tz="UTC")
+    return pd.DataFrame(
+        {"open": openp, "high": high, "low": low, "close": close, "volume": 1_000.0},
+        index=idx,
+    )
+
+
+def test_vectorized_ratio_matches_window_scalar_at_each_bar():
+    """regime_atr_ratio_series(...).iloc[i] == regime_atr_ratio_at(window ending at i)."""
+    df = _synth_frame()
+    series = regime.regime_atr_ratio_series(df["high"], df["low"], df["close"])
+    # Check several bars deep enough to have a full baseline window.
+    for i in (60, 120, 250, 399):
+        window = df.iloc[: i + 1]
+        scalar = regime.regime_atr_ratio_at(window["high"], window["low"], window["close"])
+        vec = series.iloc[i]
+        if np.isnan(vec):
+            # warmup NaN → scalar substitutes the default; skip the pointwise compare
+            continue
+        assert scalar == pytest.approx(float(vec), rel=1e-9, abs=1e-9)
+
+
+def test_scalar_helper_reproduces_legacy_30bar_window_math():
+    """The unified scalar equals the LEGACY robustness inline math (tr[-14:] mean /
+    tr[-44:-14] mean) — proving we unified onto the 30-bar baseline, not something new."""
+    df = _synth_frame().iloc[:120]
+    high, low, close = df["high"], df["low"], df["close"]
+    tr = pd.concat(
+        [(high - low), (high - close.shift()).abs(), (low - close.shift()).abs()], axis=1
+    ).max(axis=1).to_numpy()
+    atr_current = float(np.nanmean(tr[-14:]))
+    atr_avg = float(np.nanmean(tr[-44:-14]))
+    legacy_ratio = atr_current / atr_avg
+    unified = regime.regime_atr_ratio_at(high, low, close)
+    assert unified == pytest.approx(legacy_ratio, rel=1e-9)
+
+
+def test_both_backtest_regime_paths_agree_bar_for_bar():
+    """The signal-walk stamping (_precompute_regimes) and the robustness entry-regime
+    detector (_detect_entry_regime) must classify each bar to the SAME regime now that
+    they share the ATR baseline (ADX/EMA/RSI were already identical inputs)."""
+    df = _synth_frame(n=420)
+    walk_regimes = bt._precompute_regimes(df)
+
+    mismatches = []
+    # _detect_entry_regime needs >=210 bars of context; compare where both are defined.
+    for i in range(230, len(df)):
+        window = df.iloc[: i + 1]
+        entry_regime = bt._detect_entry_regime(window)
+        walk_regime = walk_regimes.iloc[i]
+        if entry_regime != walk_regime:
+            mismatches.append((i, walk_regime, entry_regime))
+
+    # Allow zero mismatches — same inputs, same classifier, same ATR baseline.
+    assert not mismatches, f"{len(mismatches)} bars classified differently, e.g. {mismatches[:5]}"

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -58,6 +58,30 @@ def test_size_fraction_fixed_is_ratio_of_initial_capital():
     assert sizing.size_fraction(_ec(sizing_mode="fixed", fixed_size=None), None, leverage=1.0, initial_capital=10000) == 1.0
 
 
+def test_fixed_mode_is_true_fixed_dollar_off_current_equity():
+    """v5: `fixed` mode targets a fixed DOLLAR notional — the fraction = fixed_size /
+    equity AT ENTRY, so a grown account deploys a SHRINKING fraction (constant dollars),
+    not a constant fraction whose notional balloons with equity."""
+    ec = _ec(sizing_mode="fixed", fixed_size=5000)
+    # At initial capital the fraction is 0.5 (5000/10000) — unchanged from before.
+    assert sizing.size_fraction(ec, None, leverage=1.0, initial_capital=10000, current_equity=10000) == pytest.approx(0.5)
+    # After the account doubles to 20000, the SAME $5000 target is a 0.25 fraction …
+    assert sizing.size_fraction(ec, None, leverage=1.0, initial_capital=10000, current_equity=20000) == pytest.approx(0.25)
+    # … so the deployed notional stays ~$5000 (0.25 * 20000), not $10000 (0.5 * 20000).
+    grown_fraction = sizing.size_fraction(ec, None, leverage=1.0, initial_capital=10000, current_equity=20000)
+    assert grown_fraction * 20000 == pytest.approx(5000)
+    # A shrunk account deploys a LARGER fraction, clamped to 1.0 when the target exceeds equity.
+    assert sizing.size_fraction(ec, None, leverage=1.0, initial_capital=10000, current_equity=4000) == pytest.approx(1.0)
+
+
+def test_fixed_mode_defaults_to_initial_capital_without_current_equity():
+    """Back-compat: a caller that cannot supply current_equity (current_equity=None)
+    reproduces the pre-v5 fixed-FRACTION behaviour for that one call."""
+    ec = _ec(sizing_mode="fixed", fixed_size=5000)
+    assert sizing.size_fraction(ec, None, leverage=1.0, initial_capital=10000) == pytest.approx(0.5)
+    assert sizing.size_fraction(ec, None, leverage=1.0, initial_capital=10000, current_equity=None) == pytest.approx(0.5)
+
+
 def test_size_fraction_fraction_risk_over_stop():
     sf = sizing.size_fraction(_ec(sizing_mode="fraction", risk_per_trade=0.02), 0.03, leverage=1.0, initial_capital=10000)
     assert sf == pytest.approx(0.02 / 0.03)


### PR DESCRIPTION
Ships the four remaining engine-v4-audit items that change backtest METRIC SEMANTICS, behind a `BACKTEST_ENGINE_VERSION` 4→5 bump. The bump auto-restamps prior verdicts as stale, re-queues validation, and revives strategies the old engine archived — the operator recalibrates gate thresholds after the rebaseline (no thresholds were changed here).

**Touched only:** `forven/strategies/backtest.py`, `forven/strategies/execution_kernel.py`, `forven/strategies/sizing.py`, `forven/regime.py`, `forven/engine_provenance.py`, and tests. No gauntlet/routers/policy/dataeng/frontend.

---

## Task 1 — Bar-level (calendar) Sharpe/Sortino from the MTM curve
`_compute_basic_metrics` now computes Sharpe/Sortino from per-BAR returns of consecutive equity-curve points (`mean/std * sqrt(bars_per_year)`, Sortino with downside RMS about 0), reusing the existing timeframe/asset-aware `bars_per_year`. These become the primary `sharpe`/`sortino` **when an equity curve is available**; the trade-based EVENT values are preserved as `trade_sharpe`/`trade_sortino`. On the legacy no-curve path the event value stays `sharpe` (nothing breaks for metric-only callers). Flat bars (no open position → 0 return) are part of the calendar series by design; all-flat curves are guarded against division-by-zero (→ 0).

**Sharpe scale-shift note (for post-rebaseline recalibration):** a bar-level calendar Sharpe of a *sparse-trading* strategy is typically **LOWER** than its event Sharpe — the flat bars both dilute the mean and enter the volatility denominator, whereas the event Sharpe only sees the (few, tight) per-trade points. It is, in exchange, comparable across trade cadences (a 1/day and a 1/week strategy are now on the same footing). Expect gate-relevant Sharpe numbers to drop for low-frequency strategies; recalibrate any Sharpe-based thresholds accordingly.

## Task 2 — Funding-aware Kelly evidence (single-application invariant)
Before v5, funding was applied post-walk (`_apply_funding_to_trades`) after the kernel had already sized every trade, so the kernel's kelly evidence (`closed_gross`) was price-only and biased high-funding strategies to size **up**. The kernel now accrues each position's funding **inside the walk** when a `FundingContext` is supplied: the pre-size funding term is folded into `closed_gross` (kelly is now funding-aware) and the size-scaled funding into the trade's `pnl_pct`. This is **opt-in** — the scanner and every parity test leave `funding=None`, so the kernel stays byte-identically price-only for them; only the backtest worker (`include_funding=True`) opts in.

**Single-application proof (the critical hazard):** the pre-size funding term computed in the kernel (`-sign * Σfunding_rate * hours * leverage`) mirrors `_apply_funding_to_trades` bit-for-bit *except* the `* size_fraction` step (applied by the caller), over the identical bar window `[entry_bar, exit_idx)`. Each kernel-funded trade is stamped `_funding_from_kernel`, and `_apply_funding_to_trades` now **skips** those trades (honoring only their stamped completeness for the aggregate flag). `tests/test_funding_kelly_single_application.py` proves it: a price-only kernel + post-walk funding produces trade-for-trade IDENTICAL `pnl_pct`/`funding_cost_pct` to the in-walk-funded kernel, and re-running the post-walk pass over kernel-funded trades is a no-op. Sign conventions verified empirically (long pays positive funding → gross LOWER; short receives → gross HIGHER). Legacy/slow paths (non-kernel) are unstamped and still funded post-walk exactly as before.

## Task 3 — Regime-ATR unification
Investigation confirmed the two backtest regime sites **differed**: the signal-walk (`_precompute_regimes`) used a 44-bar ATR baseline while robustness (`_detect_entry_regime`) and the live detector used a 30-bar baseline (`tr[-44:-14]`), so a bar could classify to a different regime across contexts. Extracted ONE shared helper — `forven.regime.regime_atr_ratio_series` (vectorized) / `regime_atr_ratio_at` (scalar) — on the **30-bar baseline** the `regime.py` module docstring always advertised (the signal-walk's 44-bar was the outlier). All three sites (signal-walk, robustness, live `detect_regime`) now route through it. Locked by `tests/test_regime_atr_unification.py`: the vectorized ratio equals the window scalar at each bar, the scalar reproduces the legacy 30-bar inline math, and the two backtest regime paths agree **bar-for-bar** over a synthetic frame spanning TREND/RANGE/HIGH_VOL. (Aligning the signal-walk to 30-bar is the stats-affecting change → the v5 bump.)

## Task 4 — True fixed-dollar notional
`sizing.size_fraction` `fixed` mode divided `fixed_size` by static `initial_capital` — a fixed FRACTION, so deployed notional ballooned with equity. It now divides by `current_equity` at entry (clamped to [0,1]), so the deployed notional stays ~`fixed_size` dollars as the account grows (a shrinking fraction). The kernel now tracks a running realized equity (compounded from each closed trade's net `pnl_pct`) and threads it as `current_equity`; `force_close` is terminal so it doesn't advance it. Leverage semantics unchanged (fixed_size stays the margin-side notional target). Back-compat: when no `current_equity` is supplied (stateless mirror callers), it falls back to `initial_capital` (pre-v5 behaviour for that one call), so `sizing.size_fraction` unit tests are unaffected.

**Fixed-notional migration note:** existing `fixed`-mode strategies whose account grew during a backtest will now show a **smaller** position fraction (and smaller returns) on late trades than before — this is the corrected "Fixed notional" behaviour (constant dollars, not constant fraction). A shrunk account deploys a larger fraction, clamped to 1.0.

## Task 5 — Version bump
`BACKTEST_ENGINE_VERSION` 4→5 with an `ENGINE_VERSION_LOG` entry dated 2026-07-11 summarizing all four changes. `tests/test_engine_provenance.py` (newest-log-matches-version) stays green.

---

## Tests
New: `tests/test_funding_kelly_single_application.py` (funding-aware kelly + single-application invariant + sign conventions), `tests/test_regime_atr_unification.py` (ATR-baseline equivalence + bar-for-bar path agreement), plus bar-Sharpe cases in `tests/test_backtest_metrics_math.py` and fixed-dollar cases in `tests/test_sizing.py`.

Ran green: `test_backtest_metrics_math`, `test_execution_parity`, `test_engine_provenance`, `test_per_bar_kernel_adapter`, `test_sizing`, `test_robustness_math_regression`, `test_backtesting_type_inference`, `test_backtest_funding_cost`, `test_deflated_sharpe`, `test_combine_is_oos_metrics`, `test_metrics_integrity`, plus the two new files — 167+ passing. `ruff check forven tests` clean. One pre-existing/environmental failure in `test_backtest_chart_context.py` (remote-OHLCV fetch, fails identically on base) is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CBHuQy6taZsvWNwsKig2N
