### PR TITLE
fix(data): route bootstrap catch-up tasks to demand-driven coverage

### DIFF
--- a/forven/api_domains/data.py
+++ b/forven/api_domains/data.py
@@ -1351,6 +1351,15 @@ def post_data_engine_backfill_plan() -> dict:
 _CATCHUP_STALL_COOLDOWN_SECS = 6 * 3600.0
 _catchup_stalled: dict[tuple[str, str], float] = {}
 
+# History window (calendar days) requested when BOOTSTRAPPING a brand-new
+# (symbol, timeframe) that has no catalog row yet. Matches the generation
+# universe's own seed default (coverage.backfill_universe / the global
+# DEFAULT_BACKTEST_DURATION_DAYS = 730), so a freshly-activated symbol lands with
+# the same ~2 years of history the quick-screen/backtest windows expect — a
+# thinner window would manufacture the "too-few-trades" rejections that the
+# demand-driven coverage machinery exists to prevent.
+_BOOTSTRAP_HISTORY_DAYS = 730
+
 
 def execute_data_engine_catchup(
     max_tasks: int = 10, *, cap: int = 50, deadline_seconds: float | None = None
@@ -1360,9 +1369,13 @@ def execute_data_engine_catchup(
 
     Pure (raises plain exceptions, never ``HTTPException``) so both the HTTP
     endpoint and the scheduled ``forven-data-engine-catchup`` auto-drain job can
-    call it. Uses ``backfill_ohlcv_gaps`` (reports bars_added + a no_recent_data
-    flag) so a series that genuinely can't advance is counted as ``failed`` rather
-    than silently reported as a green success.
+    call it. Gap-fill tasks (``stale`` / ``gaps``) use ``backfill_ohlcv_gaps``
+    (reports bars_added + a no_recent_data flag) so a series that genuinely can't
+    advance is counted as ``failed`` rather than silently reported as a green
+    success. ``bootstrap`` tasks — an active (symbol, timeframe) with no catalog
+    row — instead route to the demand-driven coverage machinery
+    (``ensure_coverage``), which backfill_ohlcv_gaps can't serve (it only extends
+    an EXISTING series, so a brand-new symbol is a 0-bar no-op there).
 
     ``deadline_seconds`` is a wall-clock budget: the batch stops gracefully once
     it is exceeded (returning partial progress; the next run continues the drain).
@@ -1432,7 +1445,7 @@ def execute_data_engine_catchup(
 
     from forven.data import backfill_ohlcv_gaps
 
-    executed = rows_added = failed = 0
+    executed = rows_added = failed = bootstrapped = 0
     deadline_hit = False
     results: list[dict] = []
     for t in batch:
@@ -1448,7 +1461,33 @@ def execute_data_engine_catchup(
             )
             break
         executed += 1
+        # A bootstrap task targets a brand-new (symbol, timeframe) with NO catalog
+        # row. backfill_ohlcv_gaps only EXTENDS an existing series — on a symbol
+        # with no stored bars it is a harmless 0-bar no-op, so history never
+        # actually lands. Route those to the demand-driven coverage machinery
+        # (ensure_coverage), which was built exactly to make a pair exist with
+        # enough history via an async submit_ingestion download.
+        is_bootstrap = str(getattr(t, "reason", "stale") or "") == "bootstrap"
         try:
+            if is_bootstrap:
+                added, kicked_off = _execute_bootstrap_task(t)
+                rows_added += added
+                if kicked_off:
+                    bootstrapped += 1
+                # A bootstrap is never a "stall": ensure_coverage degrades to
+                # "ready" (source exhausted / autobackfill disabled) rather than
+                # failing, so it must not enter the stall cooldown.
+                _catchup_stalled.pop((t.symbol, t.timeframe), None)
+                results.append(
+                    {
+                        "symbol": t.symbol,
+                        "timeframe": t.timeframe,
+                        "rows_added": added,
+                        "bootstrap": True,
+                        "backfilling": kicked_off,
+                    }
+                )
+                continue
             res = backfill_ohlcv_gaps(t.symbol, t.timeframe)
             added = int(res.get("bars_added") or 0)
             rows_added += added
@@ -1464,6 +1503,8 @@ def execute_data_engine_catchup(
                 {"symbol": t.symbol, "timeframe": t.timeframe, "rows_added": added, "stalled": stalled}
             )
         except Exception as exc:
+            # Per-task isolation: one unfetchable bootstrap / backfill must not
+            # abort the rest of the plan (mirror the existing gap-fill handling).
             failed += 1
             _catchup_stalled[(t.symbol, t.timeframe)] = time.monotonic()
             results.append({"symbol": t.symbol, "timeframe": t.timeframe, "error": str(exc)[:200]})
@@ -1471,14 +1512,20 @@ def execute_data_engine_catchup(
     try:
         from forven.data import _log_data_action
 
+        # Bootstraps kick off ASYNC downloads (submit_ingestion runs on the data
+        # thread pool), so their bars usually land on a LATER run — surfacing the
+        # bootstrap count keeps "+Y bars" honest instead of hiding an in-flight
+        # fetch as a silent 0-bar success.
+        bootstrap_note = f", {bootstrapped} bootstrapped" if bootstrapped else ""
         _log_data_action(
             "backfill",
             f"Executed Data Engine backfill plan: {executed} task(s), +{rows_added:,} bars, "
-            f"{failed} failed",
+            f"{failed} failed{bootstrap_note}",
             level="warning" if failed else "info",
             executed=executed,
             failed=failed,
             rows_added=rows_added,
+            bootstrapped=bootstrapped,
         )
     except Exception:
         pass
@@ -1489,9 +1536,46 @@ def execute_data_engine_catchup(
         "executed": executed,
         "rows_added": rows_added,
         "failed": failed,
+        "bootstrapped": bootstrapped,
         "deadline_hit": deadline_hit,
         "results": results[:50],
     }
+
+
+def _execute_bootstrap_task(task) -> tuple[int, bool]:
+    """Bootstrap a brand-new (symbol, timeframe) via the demand-driven coverage
+    machinery. Returns ``(bars_added, kicked_off)`` where ``bars_added`` is any
+    history that already landed for this series by the time we look (0 while an
+    async download is still in flight) and ``kicked_off`` is True when a fresh
+    async backfill was submitted / an in-flight one reused.
+
+    ensure_coverage is non-blocking: it submits the download onto the data thread
+    pool and returns immediately. So the honest bar count for THIS run is whatever
+    the run store already reports for the submitted ingestion (usually 0 — the
+    bars land on a later catch-up run, by which point the now-catalogued series
+    drains as an ordinary gap-fill task and its bars are counted there).
+    """
+    from forven.dataeng.coverage import ensure_coverage
+
+    source = str(getattr(task, "source", "") or "binance") or "binance"
+    res = ensure_coverage(
+        task.symbol, task.timeframe, _BOOTSTRAP_HISTORY_DAYS, exchange=source
+    )
+    kicked_off = str(res.get("status") or "") == "backfilling"
+
+    # Fold in any bars that already landed for the submitted ingestion. Pending /
+    # running downloads report 0 (nothing has landed yet) — honest, not a stall.
+    added = 0
+    run_id = res.get("run_id")
+    if run_id:
+        try:
+            from forven.data import get_ingestion_run
+
+            run = get_ingestion_run(str(run_id)) or {}
+            added = int(run.get("bars_new") or 0)
+        except Exception:
+            added = 0
+    return added, kicked_off
 
 
 def post_execute_data_engine_backfill(max_tasks: int = 10) -> dict:

--- a/tests/test_data_engine_catchup.py
+++ b/tests/test_data_engine_catchup.py
@@ -11,7 +11,7 @@ from forven.dataeng.settings import (
 )
 
 
-def _task(symbol: str, timeframe: str, stream: str = "candles"):
+def _task(symbol: str, timeframe: str, stream: str = "candles", reason: str = "stale"):
     return SimpleNamespace(
         source="binance",
         market="futures",
@@ -21,6 +21,7 @@ def _task(symbol: str, timeframe: str, stream: str = "candles"):
         start_ts=0,
         end_ts=0,
         permanent=False,
+        reason=reason,
     )
 
 
@@ -264,3 +265,200 @@ def test_catchup_deadline_stops_batch_gracefully(monkeypatch):
     out2 = data_domain.execute_data_engine_catchup(max_tasks=5)
     assert out2["executed"] == 5
     assert out2["deadline_hit"] is False
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap-reason routing: an active (symbol, timeframe) with NO catalog row
+# emits reason="bootstrap" (PR #71 planner side). backfill_ohlcv_gaps only
+# EXTENDS an existing series, so a brand-new symbol is a 0-bar no-op there; the
+# executor must instead route bootstrap tasks to the demand-driven coverage
+# machinery (ensure_coverage), account for them honestly, and isolate failures.
+# ---------------------------------------------------------------------------
+
+
+def _patch_bootstrap(monkeypatch, ensure_coverage, *, ingestion_runs=None):
+    """Route through ensure_coverage/get_ingestion_run without touching the network.
+
+    ``ensure_coverage`` is patched at its definition site (forven.dataeng.coverage)
+    so the executor's local import picks up the stub. ``get_ingestion_run`` returns
+    a stored bars_new so the accounting-folds-landed-bars path is exercised.
+
+    The unrelated ``ensure_universe_coverage`` pre-stage (which the executor also
+    runs, and which itself fans out over ensure_coverage) is stubbed to a no-op so
+    the assertions see ONLY the per-task bootstrap routing under test.
+    """
+    monkeypatch.setattr("forven.dataeng.coverage.ensure_coverage", ensure_coverage)
+    monkeypatch.setattr("forven.dataeng.coverage.ensure_universe_coverage", lambda *a, **k: [])
+    runs = ingestion_runs or {}
+    monkeypatch.setattr("forven.data.get_ingestion_run", lambda rid: runs.get(str(rid)))
+
+
+def test_bootstrap_task_routes_to_ensure_coverage_not_gap_fill(monkeypatch):
+    """A bootstrap task must NOT hit backfill_ohlcv_gaps (a 0-bar no-op on a
+    symbol with no stored bars) — it routes to ensure_coverage instead."""
+    tasks = [_task("NEW-USDT", "1h", reason="bootstrap")]
+
+    gap_calls: list = []
+
+    def fake_backfill(symbol, timeframe, **kwargs):  # must never be called
+        gap_calls.append((symbol, timeframe))
+        return {"bars_added": 0, "no_recent_data": False}
+
+    ec_calls: list = []
+
+    def fake_ensure(symbol, timeframe, required_days, *, exchange="binance"):
+        ec_calls.append((symbol, timeframe, required_days, exchange))
+        return {"status": "backfilling", "run_id": "run-boot", "symbol": symbol}
+
+    _patch_executor(monkeypatch, tasks, fake_backfill)
+    _patch_bootstrap(monkeypatch, fake_ensure)
+
+    result = data_domain.execute_data_engine_catchup(max_tasks=10)
+
+    assert gap_calls == []  # gap-fill path never used for a bootstrap
+    assert len(ec_calls) == 1
+    sym, tf, days, exch = ec_calls[0]
+    assert (sym, tf, exch) == ("NEW-USDT", "1h", "binance")
+    assert days == data_domain._BOOTSTRAP_HISTORY_DAYS == 730  # 2y seed window
+    assert result["executed"] == 1
+    assert result["bootstrapped"] == 1
+    assert result["failed"] == 0
+
+
+def test_bootstrap_folds_landed_bars_into_rows_added(monkeypatch):
+    """When the submitted ingestion has already landed N bars, the run reports N
+    (the current no-op path reported 0)."""
+    tasks = [_task("NEW-USDT", "1h", reason="bootstrap")]
+
+    def fake_ensure(symbol, timeframe, required_days, *, exchange="binance"):
+        return {"status": "backfilling", "run_id": "run-42", "symbol": symbol}
+
+    _patch_executor(monkeypatch, tasks, lambda s, t, **k: {"bars_added": 0})
+    _patch_bootstrap(
+        monkeypatch, fake_ensure, ingestion_runs={"run-42": {"bars_new": 17}}
+    )
+
+    result = data_domain.execute_data_engine_catchup(max_tasks=10)
+    assert result["rows_added"] == 17  # landed bars reported, not a silent 0
+    assert result["bootstrapped"] == 1
+
+
+def test_bootstrap_in_flight_reports_zero_bars_but_counts_bootstrapped(monkeypatch):
+    """An async download still in flight (bars_new==0) is honestly reported as 0
+    bars but is NOT a stall — it counts as a kicked-off bootstrap, not a failure."""
+    tasks = [_task("NEW-USDT", "1h", reason="bootstrap")]
+
+    def fake_ensure(symbol, timeframe, required_days, *, exchange="binance"):
+        return {"status": "backfilling", "run_id": "run-pending", "symbol": symbol}
+
+    _patch_executor(monkeypatch, tasks, lambda s, t, **k: {"bars_added": 0})
+    _patch_bootstrap(
+        monkeypatch, fake_ensure, ingestion_runs={"run-pending": {"bars_new": 0}}
+    )
+
+    result = data_domain.execute_data_engine_catchup(max_tasks=10)
+    assert result["rows_added"] == 0
+    assert result["bootstrapped"] == 1
+    assert result["failed"] == 0
+    # A bootstrap never enters the stall cooldown (ensure_coverage degrades to
+    # "ready", it does not "fail" like a delisted gap-fill series).
+    assert ("NEW-USDT", "1h") not in data_domain._catchup_stalled
+
+
+def test_bootstrap_ready_source_exhausted_is_not_a_stall(monkeypatch):
+    """ensure_coverage returning "ready" (source has no more history / autobackfill
+    disabled) is executed-but-0, never counted as failed."""
+    tasks = [_task("NEW-USDT", "1h", reason="bootstrap")]
+
+    def fake_ensure(symbol, timeframe, required_days, *, exchange="binance"):
+        return {"status": "ready", "coverage_days": 0.0, "symbol": symbol}
+
+    _patch_executor(monkeypatch, tasks, lambda s, t, **k: {"bars_added": 0})
+    _patch_bootstrap(monkeypatch, fake_ensure)
+
+    result = data_domain.execute_data_engine_catchup(max_tasks=10)
+    assert result["executed"] == 1
+    assert result["bootstrapped"] == 0  # nothing kicked off
+    assert result["rows_added"] == 0
+    assert result["failed"] == 0
+
+
+def test_failing_bootstrap_does_not_abort_the_rest_of_the_plan(monkeypatch):
+    """A raising ensure_coverage (unfetchable symbol) is isolated: it counts as
+    one failure and the remaining tasks still execute."""
+    tasks = [
+        _task("BAD-USDT", "1h", reason="bootstrap"),
+        _task("GOOD-USDT", "1h", reason="bootstrap"),
+        _task("STALE-USDT", "1h"),  # ordinary gap-fill still runs after
+    ]
+
+    gap_calls: list = []
+
+    def fake_backfill(symbol, timeframe, **kwargs):
+        gap_calls.append(symbol)
+        return {"bars_added": 4, "no_recent_data": False}
+
+    def fake_ensure(symbol, timeframe, required_days, *, exchange="binance"):
+        if symbol == "BAD-USDT":
+            raise RuntimeError("exchange unavailable")
+        return {"status": "backfilling", "run_id": "run-good", "symbol": symbol}
+
+    _patch_executor(monkeypatch, tasks, fake_backfill)
+    _patch_bootstrap(
+        monkeypatch, fake_ensure, ingestion_runs={"run-good": {"bars_new": 9}}
+    )
+
+    result = data_domain.execute_data_engine_catchup(max_tasks=10)
+    assert result["executed"] == 3  # all three attempted despite the raise
+    assert result["failed"] == 1  # only BAD-USDT
+    assert result["bootstrapped"] == 1  # GOOD-USDT kicked off
+    assert result["rows_added"] == 13  # 9 (bootstrap) + 4 (gap-fill)
+    assert gap_calls == ["STALE-USDT"]  # gap-fill path reached after the failure
+
+
+def test_bootstrap_count_surfaces_in_activity_log(monkeypatch):
+    """The activity-log line reports the bootstrap count so an async fetch isn't
+    hidden as a silent 0-bar success."""
+    tasks = [_task("NEW-USDT", "1h", reason="bootstrap")]
+
+    def fake_ensure(symbol, timeframe, required_days, *, exchange="binance"):
+        return {"status": "backfilling", "run_id": "run-boot", "symbol": symbol}
+
+    logged: list = []
+
+    def fake_log(action, message, **kwargs):
+        logged.append((message, kwargs))
+
+    _patch_executor(monkeypatch, tasks, lambda s, t, **k: {"bars_added": 0})
+    _patch_bootstrap(monkeypatch, fake_ensure)
+    monkeypatch.setattr("forven.data._log_data_action", fake_log)
+
+    data_domain.execute_data_engine_catchup(max_tasks=10)
+
+    assert len(logged) == 1
+    message, kwargs = logged[0]
+    assert "1 bootstrapped" in message
+    assert kwargs.get("bootstrapped") == 1
+
+
+def test_non_bootstrap_tasks_are_unaffected(monkeypatch):
+    """Regression: stale/gaps tasks still flow through backfill_ohlcv_gaps and
+    never invoke ensure_coverage."""
+    tasks = [_task("BTC-USDT", "1h"), _task("ETH-USDT", "4h", reason="gaps")]
+
+    calls: list = []
+
+    def fake_backfill(symbol, timeframe, **kwargs):
+        calls.append(symbol)
+        return {"bars_added": 6, "no_recent_data": False}
+
+    def fake_ensure(*a, **k):  # must never be called
+        raise AssertionError("ensure_coverage called for a non-bootstrap task")
+
+    _patch_executor(monkeypatch, tasks, fake_backfill)
+    _patch_bootstrap(monkeypatch, fake_ensure)
+
+    result = data_domain.execute_data_engine_catchup(max_tasks=10)
+    assert calls == ["BTC-USDT", "ETH-USDT"]
+    assert result["rows_added"] == 12
+    assert result["bootstrapped"] == 0


### PR DESCRIPTION
## Context

PR #71 added a symbol-inventory pre-stage to the catch-up planner (`forven/dataeng/catchup.py`): active `(symbol, timeframe)` pairs with **no catalog row** now emit `reason="bootstrap"` tasks, appended after gap-fill tasks. But the executor (`execute_data_engine_catchup` in `forven/api_domains/data.py`) routed **all** candle tasks to `backfill_ohlcv_gaps`, which only **extends an existing series**. On a brand-new symbol with no stored bars that's a harmless 0-bar no-op — so a bootstrap task's history never actually landed (the limitation PR #71 documented).

## The fix — routing

Branch the executor loop on `reason == "bootstrap"` and route those tasks to `ensure_coverage` (`forven/dataeng/coverage.py`) — the demand-driven coverage machinery built exactly to "make this pair exist with enough history" via an async `submit_ingestion` download. Non-bootstrap (`stale` / `gaps`) tasks keep flowing through `backfill_ohlcv_gaps` unchanged. The `reason` is read with `getattr(t, "reason", "stale")` so any task shape without the field defaults to the gap-fill path.

## The window choice — 730 days

Bootstraps request **730 calendar days** of history (`_BOOTSTRAP_HISTORY_DAYS`). Not invented: it mirrors what the pipeline already uses to seed the generation universe — `coverage.backfill_universe` / `ensure_universe_coverage` default to `730`, and `DEFAULT_BACKTEST_DURATION_DAYS = 730`. A freshly-activated symbol therefore lands with the same ~2 years the quick-screen / backtest windows expect; a thinner window would manufacture the "too-few-trades" rejections the coverage machinery exists to prevent.

## Accounting — made honest

`ensure_coverage` is **non-blocking**: it submits the download onto the data thread pool and returns immediately, so a bootstrap's bars usually land on a **later** run (by which point the now-catalogued series drains as an ordinary gap-fill task and its bars are counted there). The executor now:

- Folds any **already-landed** bars for the submitted ingestion (read from the run store via `get_ingestion_run`) into `rows_added` — a bootstrap that fetched N reports N; an in-flight download honestly reports 0.
- Reports a distinct **`bootstrapped`** count in the return dict and in the activity-log line (`Executed Data Engine backfill plan: X task(s), +Y bars, Z failed, N bootstrapped`), so an async fetch is visibly surfaced instead of hidden as a silent 0-bar success (the old no-op path).
- Never counts a bootstrap as a **stall**: `ensure_coverage` degrades to `"ready"` (source exhausted / autobackfill disabled) rather than failing, so it does not enter the stall-deprioritization cooldown.

## Failure isolation

One unfetchable bootstrap (raising `ensure_coverage`) counts as a single `failed` and the rest of the plan continues — mirroring the existing per-task `try/except` around `backfill_ohlcv_gaps`.

## Tests (all mocked — no live network)

Added to `tests/test_data_engine_catchup.py`, following the PR #71 fixture conventions:
- Bootstrap routes to `ensure_coverage` (not gap-fill), with the 730-day window and the task's source as `exchange`.
- Landed bars fold into `rows_added`; in-flight download reports 0 bars but counts `bootstrapped`; source-exhausted `"ready"` is executed-but-0, never `failed`.
- A raising bootstrap is isolated — remaining bootstrap + gap-fill tasks still execute.
- Activity-log line surfaces the bootstrap count.
- Regression: non-bootstrap tasks never invoke `ensure_coverage`.

The unrelated `ensure_universe_coverage` pre-stage (which also fans out over `ensure_coverage`) is stubbed to a no-op in the bootstrap tests so assertions see only the per-task routing under test.

## Test results

- `tests/test_data_coverage.py`, `tests/test_data_engine_p2_hardening.py`, `tests/test_data_manager.py`, `tests/test_dataeng_foundation.py`, `tests/test_data_engine_catchup.py` (+ new tests), `tests/test_data_activity_log.py`, `tests/test_dataeng_coverage.py`, `tests/test_gap_detection.py`: **all pass** (158 + 10).
- `ruff check forven tests`: clean.

## Scope

Touched only `forven/api_domains/data.py` and `tests/test_data_engine_catchup.py`. `catchup.py` needed no change (the `reason` field already ships on the task) and `coverage.py` needed no change (`ensure_coverage` already accepts the params required to route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CBHuQy6taZsvWNwsKig2N