### PR TITLE
Harden live execution and operational safety

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,12 @@ jobs:
             tests/test_pipeline_hardening.py::test_evaluate_promotion_accepts_persisted_validation_artifacts_for_paper \
             tests/test_pipeline_hardening.py::test_evaluate_promotion_blocks_failed_required_verdict_tests_for_paper
 
+      - name: Run async runtime regression tests
+        run: |
+          python -m pytest -q \
+            tests/test_daemon_price_freshness.py \
+            tests/test_loop_starvation_fixes.py
+
       # Data-engine regression gate — locks in the 2026-07 data hardening + edge-data
       # expansion (tail-append storage, perp canonicalization, causality shifts,
       # quality gates, fingerprints, symbol registry, basis/IV streams, kernel

--- a/forven/api_domains/paper_control.py
+++ b/forven/api_domains/paper_control.py
@@ -552,6 +552,7 @@ def open_manual_position(
     leverage: float = 1.0,
     stop_loss_price=None,
     take_profit_price=None,
+    idempotency_key: str | None = None,
 ) -> dict:
     """Open a brand-new position by hand (paper: local; live: real market order)."""
     session = _resolve_session(session_id)
@@ -581,6 +582,7 @@ def open_manual_position(
             session_id, strategy_id, asset, norm_dir,
             size=size, risk_pct=risk_pct, leverage=lev,
             stop_loss_price=sl, take_profit_price=tp,
+            idempotency_key=idempotency_key,
         )
         return _refresh(session_id)
 
@@ -632,7 +634,7 @@ def open_manual_position(
 
 def _live_open(
     session_id, strategy_id, asset, direction, *, size, risk_pct, leverage,
-    stop_loss_price, take_profit_price,
+    stop_loss_price, take_profit_price, idempotency_key=None,
 ) -> None:
     """Open a real Hyperliquid position (gated), persist it, and register the slot."""
     risk_fraction = None
@@ -696,11 +698,17 @@ def _live_open(
         raise HTTPException(status_code=409, detail=f"Trading halted — {_halt_reason}")
 
     side = "buy" if direction == "long" else "sell"
+    normalized_idempotency_key = str(idempotency_key or "").strip()[:160] or None
     try:
         result = market_order(
             asset, side, float(resolved_size),
             stop_loss_price=stop_loss_price, take_profit_price=take_profit_price,
             testnet=testnet, vault_address=vault,
+            idempotency_key=(
+                f"manual-open:{normalized_idempotency_key}"
+                if normalized_idempotency_key
+                else None
+            ),
         )
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(status_code=502, detail=f"Exchange open failed: {exc}") from exc
@@ -719,6 +727,8 @@ def _live_open(
         "entry_exchange_order_id": str(entry_oid) if entry_oid is not None else None,
         "exchange_order_id": str(entry_oid) if entry_oid is not None else None,
     }
+    if normalized_idempotency_key:
+        signal_data["manual_open_idempotency_key"] = normalized_idempotency_key
     if stop_loss_price:
         signal_data["stop_loss_price"] = float(stop_loss_price)
         signal_data["stop_loss_source"] = "manual"

--- a/forven/backups.py
+++ b/forven/backups.py
@@ -1,0 +1,99 @@
+"""Managed SQLite backup creation for destructive operator workflows."""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+
+from filelock import FileLock
+
+from forven.config import FORVEN_HOME
+from forven.db import backup_db
+
+log = logging.getLogger("forven.backups")
+
+DEFAULT_DB_BACKUP_RETENTION = 3
+_BACKUP_LOCK = threading.Lock()
+_SAFE_REASON_RE = re.compile(r"[^a-z0-9_-]+")
+
+
+def _retention_limit(value: int | None = None) -> int:
+    if value is not None:
+        return max(1, int(value))
+    raw = str(os.environ.get("FORVEN_DB_BACKUP_RETENTION") or "").strip()
+    try:
+        return max(1, int(raw)) if raw else DEFAULT_DB_BACKUP_RETENTION
+    except ValueError:
+        return DEFAULT_DB_BACKUP_RETENTION
+
+
+def _safe_reason(reason: str) -> str:
+    normalized = _SAFE_REASON_RE.sub("-", str(reason or "manual").strip().lower()).strip("-_")
+    return normalized or "manual"
+
+
+def _backup_timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+
+
+def _prune_managed_backups(backup_dir: Path, *, retain: int) -> list[Path]:
+    """Delete only backups created by this module, keeping the newest N."""
+    root = backup_dir.resolve()
+    candidates = sorted(
+        (path for path in backup_dir.glob("forven-*.db") if path.is_file()),
+        key=lambda path: (path.stat().st_mtime_ns, path.name),
+        reverse=True,
+    )
+    removed: list[Path] = []
+    for path in candidates[retain:]:
+        resolved = path.resolve()
+        if resolved.parent != root:
+            continue
+        try:
+            resolved.unlink()
+            removed.append(resolved)
+        except OSError as exc:
+            log.warning("Could not prune managed database backup %s: %s", resolved, exc)
+    return removed
+
+
+def create_managed_db_backup(
+    reason: str,
+    *,
+    backup_root: str | Path | None = None,
+    retain: int | None = None,
+) -> Path:
+    """Create a consistent database snapshot and enforce managed retention.
+
+    Snapshots live under ``FORVEN_HOME/backups/database`` by default. Retention
+    applies only to the ``forven-*.db`` files created here; legacy ``.bak`` files
+    and operator-selected recovery directories are never touched.
+    """
+    backup_dir = Path(backup_root) if backup_root is not None else FORVEN_HOME / "backups" / "database"
+    backup_dir = backup_dir.expanduser().resolve()
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    target = backup_dir / f"forven-{_safe_reason(reason)}-{_backup_timestamp()}.db"
+
+    process_lock = FileLock(str(backup_dir / ".database-backup.lock"), timeout=60)
+    with _BACKUP_LOCK, process_lock:
+        try:
+            created = backup_db(target)
+        except Exception:
+            try:
+                if target.exists():
+                    target.unlink()
+            except OSError:
+                pass
+            raise
+        _prune_managed_backups(backup_dir, retain=_retention_limit(retain))
+    return created
+
+
+__all__ = [
+    "DEFAULT_DB_BACKUP_RETENTION",
+    "create_managed_db_backup",
+]

--- a/forven/exchange/risk.py
+++ b/forven/exchange/risk.py
@@ -2254,6 +2254,73 @@ def _persist_trade_protection_metadata(conn, trade_id: str, protection: dict[str
     )
 
 
+def _finalize_matched_open_trade(conn, trade: dict, position: dict) -> dict | None:
+    """Commit exchange-authoritative entry fields for one matched OPEN trade.
+
+    This closes the post-fill crash/write-failure gap: protection reconciliation
+    previously matched the real position but left a stale requested size and entry
+    price in SQLite indefinitely.
+    """
+    trade_id = str(trade.get("id") or "").strip()
+    entry_price = _coerce_positive_float(position.get("entry_price"))
+    position_size = _coerce_positive_float(position.get("size"))
+    if not trade_id or entry_price is None or position_size is None:
+        return None
+
+    signal_data = parse_trade_signal_data(trade.get("signal_data"))
+    previous_state = str(signal_data.get("entry_finalization_state") or "").strip() or None
+    previous_entry = _coerce_positive_float(trade.get("fill_entry_price"))
+    previous_size = _coerce_positive_float(trade.get("size"))
+    needs_finalization = bool(
+        signal_data.get("pending_open_reconcile")
+        or signal_data.get("fill_persistence_failed")
+        or previous_state in {"order_pending", "reconcile_required"}
+        or previous_entry is None
+        or previous_size is None
+        or abs(previous_entry - entry_price) > max(1e-9, entry_price * 1e-9)
+        or abs(previous_size - position_size) > max(1e-9, position_size * 1e-9)
+    )
+    if not needs_finalization:
+        return None
+
+    finalized_at = get_now().isoformat()
+    for stale_key in (
+        "pending_open_reconcile",
+        "pending_open_reconcile_at",
+        "open_execution_failure_reason",
+        "fill_persistence_failed",
+    ):
+        signal_data.pop(stale_key, None)
+    signal_data["filled_size"] = float(position_size)
+    signal_data["entry_finalization_state"] = "finalized_reconciled"
+    signal_data["entry_finalized_at"] = finalized_at
+    signal_data["entry_reconciled_at"] = finalized_at
+
+    conn.execute(
+        "UPDATE trades SET entry_price = ?, fill_entry_price = ?, size = ?, signal_data = ? "
+        "WHERE id = ? AND status = 'OPEN'",
+        (
+            float(entry_price),
+            float(entry_price),
+            float(position_size),
+            json.dumps(signal_data),
+            trade_id,
+        ),
+    )
+    conn.execute(
+        "UPDATE portfolio_positions SET entry_price = ? WHERE trade_id = ?",
+        (float(entry_price), trade_id),
+    )
+    return {
+        "type": "entry_finalized",
+        "trade_id": trade_id,
+        "asset": str(position.get("asset") or trade.get("asset") or "").strip().upper(),
+        "previous_state": previous_state,
+        "entry_price": float(entry_price),
+        "filled_size": float(position_size),
+    }
+
+
 def _repair_position_protection(
     position: dict,
     *,
@@ -2644,6 +2711,8 @@ def _insert_recovered_trade(
         signal_data["data_source"] = "local"
     signal_data["execution_venue"] = "hyperliquid"
     signal_data["execution_mode"] = "recovered"
+    signal_data["entry_finalization_state"] = "finalized_recovered"
+    signal_data["entry_finalized_at"] = get_now().isoformat()
 
     conn.execute(
         """
@@ -3059,6 +3128,14 @@ def reconcile_exchange_positions(
                         }
                     )
                 matched_open_trade = _first_item(local_trades) if len(local_trades) == 1 else None
+                if matched_open_trade:
+                    finalized_action = _finalize_matched_open_trade(conn, matched_open_trade, position)
+                    if finalized_action:
+                        resolved_actions.append(finalized_action)
+                        matched_open_trade = dict(matched_open_trade)
+                        matched_open_trade["entry_price"] = finalized_action["entry_price"]
+                        matched_open_trade["fill_entry_price"] = finalized_action["entry_price"]
+                        matched_open_trade["size"] = finalized_action["filled_size"]
                 _repair_kwargs = {"account_address": account_address} if account_address else {}
                 protection, open_orders = _repair_position_protection(
                     position,

--- a/forven/routers/paper.py
+++ b/forven/routers/paper.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Header
 
 from forven import api_core as core
 from forven.api_domains import paper as paper_domain
@@ -121,7 +121,11 @@ def partial_close_paper_position(session_id: str, body: core.PaperPartialCloseBo
 
 
 @router.post("/api/paper/sessions/{session_id}/open-position")
-def open_paper_position(session_id: str, body: core.PaperOpenPositionBody):
+def open_paper_position(
+    session_id: str,
+    body: core.PaperOpenPositionBody,
+    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+):
     return paper_control_domain.open_manual_position(
         session_id,
         direction=body.direction,
@@ -130,6 +134,7 @@ def open_paper_position(session_id: str, body: core.PaperOpenPositionBody):
         leverage=body.leverage,
         stop_loss_price=body.stop_loss_price,
         take_profit_price=body.take_profit_price,
+        idempotency_key=idempotency_key,
     )
 
 

--- a/forven/scanner.py
+++ b/forven/scanner.py
@@ -79,6 +79,7 @@ _ENTRY_SIGNAL_STATE_KEY = "scanner_entry_signal_state"
 _ASSET_ENTRY_STATE_KEY = "scanner_asset_entry_state"
 _CERTIFIED_PAPER_FAMILIES = set(EXECUTION_CERTIFIED_FAMILIES)
 _LAST_STRATEGY_LOAD_DIAGNOSTICS: dict[str, dict] = {}
+_CONFIRMED_FILL_PERSISTENCE_ERROR = "confirmed exchange fill awaiting local persistence reconciliation"
 # DATA-3: cover the FULL canonical timeframe set (data.TIMEFRAME_MS). The bar-width
 # lookups for closed-bar trimming and the stale-feed gate do `.get(tf, 3600)`; an
 # incomplete table silently used a 1h width for any unlisted timeframe (e.g. a 2h bar
@@ -3144,16 +3145,16 @@ def _signed_slippage_bps(signal_price: float, fill_price: float, side: str) -> f
     return ((signal_price - fill_price) / signal_price) * 1e4
 
 
-def _update_trade_signal_data(trade_id: str, updates: dict) -> None:
+def _update_trade_signal_data(trade_id: str, updates: dict) -> bool:
     """Merge auxiliary signal metadata into an existing trade row."""
     if not trade_id or not isinstance(updates, dict) or not updates:
-        return
+        return False
 
     try:
         with get_db() as conn:
             row = conn.execute("SELECT signal_data FROM trades WHERE id = ?", (trade_id,)).fetchone()
             if not row:
-                return
+                return False
 
             raw = row["signal_data"]
             if isinstance(raw, str):
@@ -3171,11 +3172,13 @@ def _update_trade_signal_data(trade_id: str, updates: dict) -> None:
                 "UPDATE trades SET signal_data = ? WHERE id = ?",
                 (json.dumps(signal_data), str(trade_id)),
             )
-    except Exception:
-        return
+        return True
+    except Exception as exc:
+        log.error("Could not persist signal metadata for trade %s: %s", trade_id, exc)
+        return False
 
 
-def _update_trade_fill(trade_id: str, fill_price: float, fill_kind: str, signal_price: float | None = None, exchange_order_id: str | None = None, filled_size: float | None = None, mark_price: float | None = None) -> None:
+def _update_trade_fill(trade_id: str, fill_price: float, fill_kind: str, signal_price: float | None = None, exchange_order_id: str | None = None, filled_size: float | None = None, mark_price: float | None = None) -> bool:
     """Update a trade row with fill details from direct execution.
 
     `filled_size` is the size the exchange actually filled (an IOC entry can
@@ -3198,7 +3201,7 @@ def _update_trade_fill(trade_id: str, fill_price: float, fill_kind: str, signal_
                 (trade_id,),
             ).fetchone()
             if not row:
-                return
+                return False
 
             direction = (row["direction"] or "long").lower()
             signal_data_raw = row["signal_data"]
@@ -3237,6 +3240,9 @@ def _update_trade_fill(trade_id: str, fill_price: float, fill_kind: str, signal_
                 signal_data.pop("pending_open_reconcile", None)
                 signal_data.pop("pending_open_reconcile_at", None)
                 signal_data.pop("open_execution_failure_reason", None)
+                signal_data.pop("fill_persistence_failed", None)
+                signal_data["entry_finalization_state"] = "finalized_direct"
+                signal_data["entry_finalized_at"] = get_now().isoformat()
                 ref_price = signal_price if signal_price not in (None, 0) else row["signal_entry_price"]
                 if signal_price not in (None, 0):
                     updates.append("signal_entry_price = ?")
@@ -3264,15 +3270,103 @@ def _update_trade_fill(trade_id: str, fill_price: float, fill_kind: str, signal_
                         updates.append("exit_lag_bps = COALESCE(?, exit_lag_bps)")
                         values.append(_signed_slippage_bps(float(ref_price), float(mark_price), side))
             else:
-                return
+                return False
 
             updates.append("signal_data = ?")
             values.append(json.dumps(signal_data))
             values.append(str(trade_id))
             values_sql = ", ".join(updates)
             conn.execute(f"UPDATE trades SET {values_sql} WHERE id = ?", values)
-    except Exception:
-        return
+        return True
+    except Exception as exc:
+        log.error("Could not persist %s fill for trade %s: %s", fill_kind, trade_id, exc)
+        return False
+
+
+def _persist_live_entry_fill(
+    trade_id: str,
+    fill_price: float,
+    *,
+    signal_price: float | None,
+    exchange_order_id: str | None,
+    filled_size: float | None,
+    mark_price: float | None,
+    attempts: int = 3,
+) -> bool:
+    """Persist a confirmed live entry fill with a short, bounded retry window."""
+    attempt_count = max(1, int(attempts))
+    for attempt in range(1, attempt_count + 1):
+        if _update_trade_fill(
+            trade_id,
+            fill_price,
+            "entry",
+            signal_price=signal_price,
+            exchange_order_id=exchange_order_id,
+            filled_size=filled_size,
+            mark_price=mark_price,
+        ):
+            return True
+        if attempt < attempt_count:
+            time.sleep(0.05 * attempt)
+    return False
+
+
+def _emit_live_execution_critical(
+    event_type: str,
+    *,
+    trade_id: str,
+    title: str,
+    summary: str,
+    body: str,
+    dedupe_prefix: str,
+) -> None:
+    """Best-effort critical operator notification for post-fill safety faults."""
+    try:
+        from forven.notifications import emit_notification
+
+        emit_notification(
+            event_type,
+            severity="critical",
+            source="scanner",
+            title=title,
+            summary=summary,
+            body=body,
+            dedupe_key=f"{dedupe_prefix}:{trade_id}",
+        )
+    except Exception as exc:
+        log.error("Could not emit critical %s notification for trade %s: %s", event_type, trade_id, exc)
+
+
+def _pause_after_live_fill_persistence_failure(
+    *, trade_id: str, asset: str, direction: str, error: str
+) -> None:
+    """Block further opens after an exchange fill cannot be committed locally."""
+    try:
+        from forven.system_pause import set_system_paused
+
+        set_system_paused(True, paused_at=get_now().isoformat())
+    except Exception as exc:
+        log.critical("Could not persist system pause after fill-write failure for %s: %s", trade_id, exc)
+
+    log.critical(
+        "%s %s entry filled at the exchange but local persistence failed for trade=%s; "
+        "new opens are paused pending reconciliation: %s",
+        asset,
+        direction,
+        trade_id,
+        error,
+    )
+    _emit_live_execution_critical(
+        "trade_fill_persistence_failed",
+        trade_id=trade_id,
+        title=f"Live fill persistence failed ({asset})",
+        summary=(
+            f"{asset} {direction} filled at the exchange but could not be committed locally; "
+            "new opens were paused pending reconciliation."
+        ),
+        body=f"trade={trade_id}: {error}",
+        dedupe_prefix="fill_persistence_failed",
+    )
 
 
 def _fail_unfilled_open_trade(trade_id: str | None, reason: str | None) -> None:
@@ -3631,15 +3725,27 @@ def _execute_direct(
                     asset, direction, trade_id, size, filled_size_f,
                 )
             if fill is not None:
-                _update_trade_fill(
+                _fill_persisted = _persist_live_entry_fill(
                     trade_id,
                     fill,
-                    "entry",
                     signal_price=price,
                     exchange_order_id=exchange_order_id,
                     filled_size=filled_size_f,
                     mark_price=result.get("mid"),
                 )
+                if not _fill_persisted:
+                    order_meta["pending_open_reconcile"] = True
+                    order_meta["pending_open_reconcile_at"] = get_now().isoformat()
+                    order_meta["fill_persistence_failed"] = True
+                    order_meta["entry_finalization_state"] = "reconcile_required"
+                    result["fill_persistence_failed"] = True
+                    if not is_sim_active():
+                        _pause_after_live_fill_persistence_failure(
+                            trade_id=trade_id,
+                            asset=asset,
+                            direction=direction,
+                            error="entry fill write failed after 3 attempts",
+                        )
             if exchange_order_id is not None and "entry_exchange_order_id" not in order_meta:
                 order_meta["entry_exchange_order_id"] = exchange_order_id
             if order_meta:
@@ -3657,9 +3763,16 @@ def _execute_direct(
                 _prot_kwargs = {"testnet": testnet}
                 if vault_address:
                     _prot_kwargs["vault_address"] = vault_address
+                _protection_size = (
+                    filled_size_f
+                    if filled_size_f is not None and filled_size_f > 0
+                    else float(size)
+                )
                 if "stop" in _protective_failed and stop_loss is not None:
                     try:
-                        _ps = place_protective_stop(asset, direction, size, float(stop_loss), **_prot_kwargs)
+                        _ps = place_protective_stop(
+                            asset, direction, _protection_size, float(stop_loss), **_prot_kwargs
+                        )
                         if isinstance(_ps, dict) and not _ps.get("error") and _ps.get("stop_order_id"):
                             _update_trade_signal_data(trade_id, {
                                 "exchange_stop_order_id": str(_ps["stop_order_id"]),
@@ -3672,23 +3785,36 @@ def _execute_direct(
                                 "[%s] %s entry FILLED but stop leg rejected AND re-arm failed (trade=%s): %s — "
                                 "periodic reconcile will retry", strat_id, asset, trade_id, _err,
                             )
-                            try:
-                                from forven.notifications import emit_notification
-                                emit_notification(
-                                    "trade_protective_unarmed", severity="critical", source="scanner",
-                                    title=f"Live position temporarily UNPROTECTED ({asset})",
-                                    summary=f"{asset} {direction} entry filled but the protective stop could not be armed; reconcile will retry.",
-                                    body=f"trade={trade_id}: {_err}",
-                                    dedupe_key=f"protective_unarmed:{trade_id}",
-                                )
-                            except Exception:
-                                pass
+                            _emit_live_execution_critical(
+                                "trade_protective_unarmed",
+                                trade_id=trade_id,
+                                title=f"Live position temporarily UNPROTECTED ({asset})",
+                                summary=(
+                                    f"{asset} {direction} entry filled but the protective stop could not "
+                                    "be armed; reconcile will retry."
+                                ),
+                                body=f"trade={trade_id}: {_err}",
+                                dedupe_prefix="protective_unarmed",
+                            )
                     except Exception as _exc:
                         _update_trade_signal_data(trade_id, {"protective_stop_unarmed": True})
                         log.error("[%s] re-arm stop after rejected bracket leg raised for %s trade=%s: %s", strat_id, asset, trade_id, _exc)
+                        _emit_live_execution_critical(
+                            "trade_protective_unarmed",
+                            trade_id=trade_id,
+                            title=f"Live position temporarily UNPROTECTED ({asset})",
+                            summary=(
+                                f"{asset} {direction} entry filled but protective-stop re-arming raised; "
+                                "reconcile will retry."
+                            ),
+                            body=f"trade={trade_id}: {_exc}",
+                            dedupe_prefix="protective_unarmed",
+                        )
                 if "take_profit" in _protective_failed and take_profit is not None:
                     try:
-                        _tp = place_take_profit(asset, direction, size, float(take_profit), **_prot_kwargs)
+                        _tp = place_take_profit(
+                            asset, direction, _protection_size, float(take_profit), **_prot_kwargs
+                        )
                         if isinstance(_tp, dict) and not _tp.get("error") and _tp.get("take_profit_order_id"):
                             _update_trade_signal_data(trade_id, {
                                 "exchange_take_profit_order_id": str(_tp["take_profit_order_id"]),
@@ -4271,7 +4397,7 @@ def manage_positions(
             )
             return True, None
         try:
-            _execute_direct(
+            result = _execute_direct(
                 action="open",
                 trade_id=trade_id,
                 strat_id=strat_id,
@@ -4283,6 +4409,8 @@ def manage_positions(
                 take_profit=take_profit,
                 leverage=p.get("leverage", 1.0),
             )
+            if isinstance(result, dict) and result.get("fill_persistence_failed"):
+                return False, _CONFIRMED_FILL_PERSISTENCE_ERROR
             return True, None
         except Exception as e:
             log.error("Direct open failed for %s %s: %s", strat_id, trade_asset, e)
@@ -4972,6 +5100,7 @@ def manage_positions(
                 signal_data["data_source"] = "local"
             signal_data["execution_venue"] = "hyperliquid"
             signal_data["execution_mode"] = execution_type
+            signal_data["entry_finalization_state"] = "order_pending"
 
             resolved_leverage = float(p.get("leverage", 1.0) or 1.0)
             # Pass book only when direction books are active, so the books-off
@@ -5066,6 +5195,7 @@ def manage_positions(
                         "pending_open_reconcile": True,
                         "pending_open_reconcile_at": get_now().isoformat(),
                         "open_execution_failure_reason": open_error,
+                        "entry_finalization_state": "reconcile_required",
                     },
                 )
                 # M2: free the risk slot immediately so a failed open doesn't
@@ -5074,7 +5204,8 @@ def manage_positions(
                 # order actually filled); _rebuild_portfolio_positions skips
                 # re-adding this position while it's pending_open_reconcile
                 # without an exchange order id, so the release is durable.
-                release(str(trade_id))
+                if open_error != _CONFIRMED_FILL_PERSISTENCE_ERROR:
+                    release(str(trade_id))
                 log.warning(
                     "[%s] OPEN execution failed; keeping local trade %s open pending reconcile",
                     strat_id,

--- a/forven/scheduler.py
+++ b/forven/scheduler.py
@@ -2187,21 +2187,9 @@ async def run_job(job: dict) -> tuple[str, str | None]:
             await _run_sync_job(run_overnight_summary_job, lookback)
             return "ok", None
 
-        # Shell command execution
-        proc = await asyncio.create_subprocess_shell(
-            command,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=600)
-
-        if proc.returncode != 0:
-            error = stderr.decode()[:500]
-            log.error("Job %s failed: %s", job_name, error)
-            return "error", error
-
-        log.info("Job %s completed successfully", job_name)
-        return "ok", None
+        error = f"Unknown scheduler job kind: {kind or '<missing>'}"
+        log.error("Job %s rejected: %s", job_name, error)
+        return "error", error
 
     except asyncio.TimeoutError:
         log.error("Job %s timed out", job_name)

--- a/frontend/src/lib/api/assistant.ts
+++ b/frontend/src/lib/api/assistant.ts
@@ -1,4 +1,4 @@
-import { ACTIVE_API_BASE, API_BASE, fetchApi } from './core';
+import { fetchApi, fetchApiStream } from './core';
 import type { PageContext } from '$lib/stores/pageContext';
 
 export type AssistantThread = {
@@ -102,11 +102,6 @@ export async function setAssistantCostCap(capUsd: number): Promise<number> {
 	return r.cap_usd;
 }
 
-function resolveStreamBase(): string {
-	const base = (ACTIVE_API_BASE && ACTIVE_API_BASE.trim()) || API_BASE;
-	return base.endsWith('/') ? base.slice(0, -1) : base;
-}
-
 export async function streamAssistantSend(
 	threadId: string,
 	userText: string,
@@ -114,18 +109,16 @@ export async function streamAssistantSend(
 	onEvent: (event: AssistantStreamEvent) => void,
 	allowActions = true,
 ): Promise<void> {
-	const url = `${resolveStreamBase()}/assistant/threads/${encodeURIComponent(threadId)}/send`;
-	const r = await fetch(url, {
+	const r = await fetchApiStream(`/assistant/threads/${encodeURIComponent(threadId)}/send`, {
 		method: 'POST',
-		headers: { 'content-type': 'application/json' },
 		body: JSON.stringify({
 			user_text: userText,
 			page_context: pageContext ?? null,
 			allow_actions: allowActions,
 		}),
 	});
-	if (!r.ok || !r.body) {
-		throw new Error(`assistant send failed: ${r.status}`);
+	if (!r.body) {
+		throw new Error('assistant send failed: response stream missing');
 	}
 	const reader = r.body.getReader();
 	const decoder = new TextDecoder();

--- a/frontend/src/lib/api/core.ts
+++ b/frontend/src/lib/api/core.ts
@@ -303,6 +303,21 @@ export class ApiError extends Error {
 	}
 }
 
+export class ApiOutcomeUnknownError extends Error {
+	method: string;
+	endpoint: string;
+
+	constructor(method: string, endpoint: string) {
+		super(
+			`${method} ${endpoint} lost its network response. The operation may have completed; ` +
+				'check current state before trying again.',
+		);
+		this.name = 'ApiOutcomeUnknownError';
+		this.method = method;
+		this.endpoint = endpoint;
+	}
+}
+
 export function isNotFoundError(error: unknown): boolean {
 	if (error instanceof ApiError) return error.status === 404;
 	if (!(error instanceof Error)) return false;
@@ -362,6 +377,8 @@ function parseErrorPayload(raw: string): { detail: string; payload: unknown } {
 
 export async function fetchApi<T>(endpoint: string, options?: RequestInit & { timeoutMs?: number }): Promise<T> {
 	const { timeoutMs, ...restOptions } = (options ?? {}) as RequestInit & { timeoutMs?: number };
+	const method = String(restOptions.method ?? 'GET').toUpperCase();
+	const canRetryAcrossBases = ['GET', 'HEAD', 'OPTIONS'].includes(method);
 	const headers = new Headers(restOptions?.headers);
 	const authHeaders = buildAuthHeaders();
 	for (const [key, value] of Object.entries(authHeaders)) {
@@ -406,14 +423,16 @@ export async function fetchApi<T>(endpoint: string, options?: RequestInit & { ti
 			if (error instanceof ApiError) {
 				throw error;
 			}
-			if (isRetryableNetworkError(error)) {
-				if (!isLast) {
-					continue;
-				}
-			}
-			if (isLast) {
+			if (!isRetryableNetworkError(error)) {
 				throw error;
 			}
+			if (!canRetryAcrossBases) {
+				throw new ApiOutcomeUnknownError(method, endpoint);
+			}
+			if (!isLast) {
+				continue;
+			}
+			throw error;
 		}
 	}
 
@@ -421,6 +440,57 @@ export async function fetchApi<T>(endpoint: string, options?: RequestInit & { ti
 		throw lastError;
 	}
 	throw new Error('Request failed');
+}
+
+/**
+ * Open a streaming API response with the same base discovery and authentication
+ * as fetchApi. Streaming mutations deliberately use one resolved base: retrying
+ * after a lost response could duplicate the request while its outcome is unknown.
+ */
+export async function fetchApiStream(
+	endpoint: string,
+	options: RequestInit & { timeoutMs?: number },
+): Promise<Response> {
+	const { timeoutMs, ...restOptions } = options;
+	const method = String(restOptions.method ?? 'GET').toUpperCase();
+	const headers = new Headers(restOptions.headers);
+	for (const [key, value] of Object.entries(buildAuthHeaders())) {
+		if (value && !headers.has(key)) headers.set(key, value);
+	}
+	const isFormData = typeof FormData !== 'undefined' && restOptions.body instanceof FormData;
+	if (!isFormData && !headers.has('Content-Type')) {
+		headers.set('Content-Type', 'application/json');
+	}
+
+	await detectActiveApiBase();
+	const base = ACTIVE_API_BASE;
+	const requestPath = getRequestPath(base, endpoint);
+	const requestUrl = /^https?:\/\//.test(requestPath) ? requestPath : `${base}${requestPath}`;
+	let response: Response;
+	try {
+		response = await fetchWithLimit(requestUrl, {
+			...restOptions,
+			headers,
+			...(timeoutMs != null ? { timeoutMs } : {}),
+		});
+	} catch (error) {
+		if (isRetryableNetworkError(error) && !['GET', 'HEAD', 'OPTIONS'].includes(method)) {
+			throw new ApiOutcomeUnknownError(method, endpoint);
+		}
+		throw error;
+	}
+	if (!response.ok) {
+		const rawError = typeof response.text === 'function'
+			? await response.text().catch(() => '')
+			: '';
+		const parsed = parseErrorPayload(rawError);
+		throw new ApiError(
+			response.status,
+			parsed.detail || response.statusText || `HTTP ${response.status}`,
+			parsed.payload,
+		);
+	}
+	return response;
 }
 
 // Health check

--- a/frontend/src/lib/api/deepdive.ts
+++ b/frontend/src/lib/api/deepdive.ts
@@ -1,4 +1,4 @@
-import { ACTIVE_API_BASE, API_BASE, fetchApi } from './core';
+import { fetchApi, fetchApiStream } from './core';
 
 export type DeepdiveThread = {
 	id: string;
@@ -55,26 +55,17 @@ export async function listDeepdiveMessages(threadId: string): Promise<DeepdiveMe
 	return resp.messages;
 }
 
-function resolveStreamBase(): string {
-	// In test env ACTIVE_API_BASE is '/api'; in browser it's a discovered absolute URL.
-	// fetchApi uses ACTIVE_API_BASE for its requests; mirror that so SSE URLs match what tests expect.
-	const base = (ACTIVE_API_BASE && ACTIVE_API_BASE.trim()) || API_BASE;
-	return base.endsWith('/') ? base.slice(0, -1) : base;
-}
-
 export async function streamDeepdiveSend(
 	threadId: string,
 	userText: string,
 	onEvent: (event: DeepdiveStreamEvent) => void,
 ): Promise<void> {
-	const url = `${resolveStreamBase()}/deepdive/threads/${encodeURIComponent(threadId)}/send`;
-	const r = await fetch(url, {
+	const r = await fetchApiStream(`/deepdive/threads/${encodeURIComponent(threadId)}/send`, {
 		method: 'POST',
-		headers: { 'content-type': 'application/json' },
 		body: JSON.stringify({ user_text: userText }),
 	});
-	if (!r.ok || !r.body) {
-		throw new Error(`deepdive send failed: ${r.status}`);
+	if (!r.body) {
+		throw new Error('deepdive send failed: response stream missing');
 	}
 	const reader = r.body.getReader();
 	const decoder = new TextDecoder();

--- a/frontend/src/lib/api/paper.ts
+++ b/frontend/src/lib/api/paper.ts
@@ -1,5 +1,6 @@
 import type { OHLCVBar } from './data';
 import {
+	ApiOutcomeUnknownError,
 	fetchApi,
 } from './core';
 
@@ -25,6 +26,15 @@ export interface PaperPosition {
 	source?: string | null;
 	/** Direction book (Approach C sub-account) a live position routes to. */
 	book?: string | null;
+}
+
+const pendingManualOpenIntents = new Map<string, { fingerprint: string; key: string }>();
+
+function newIdempotencyKey(): string {
+	if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+		return crypto.randomUUID();
+	}
+	return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
 }
 
 export interface PaperNetPosition {
@@ -352,17 +362,35 @@ export async function openManualPaperPosition(
 	sessionId: string,
 	options: OpenManualPaperPositionOptions
 ): Promise<PaperTradingSession> {
-	return fetchApi(`/paper/sessions/${sessionId}/open-position`, {
-		method: 'POST',
-		body: JSON.stringify({
-			direction: options.direction,
-			size: options.size ?? null,
-			risk_pct: options.riskPct ?? null,
-			leverage: options.leverage ?? 1,
-			stop_loss_price: options.stopLossPrice ?? null,
-			take_profit_price: options.takeProfitPrice ?? null,
-		}),
-	});
+	const body = {
+		direction: options.direction,
+		size: options.size ?? null,
+		risk_pct: options.riskPct ?? null,
+		leverage: options.leverage ?? 1,
+		stop_loss_price: options.stopLossPrice ?? null,
+		take_profit_price: options.takeProfitPrice ?? null,
+	};
+	const fingerprint = JSON.stringify(body);
+	const existing = pendingManualOpenIntents.get(sessionId);
+	const intent = existing?.fingerprint === fingerprint
+		? existing
+		: { fingerprint, key: newIdempotencyKey() };
+	pendingManualOpenIntents.set(sessionId, intent);
+
+	try {
+		const result = await fetchApi<PaperTradingSession>(`/paper/sessions/${sessionId}/open-position`, {
+			method: 'POST',
+			headers: { 'Idempotency-Key': intent.key },
+			body: JSON.stringify(body),
+		});
+		pendingManualOpenIntents.delete(sessionId);
+		return result;
+	} catch (error) {
+		if (!(error instanceof ApiOutcomeUnknownError)) {
+			pendingManualOpenIntents.delete(sessionId);
+		}
+		throw error;
+	}
 }
 
 // Set/clear (price=null) the absolute stop-loss on the open position

--- a/frontend/src/lib/help/content.ts
+++ b/frontend/src/lib/help/content.ts
@@ -1004,17 +1004,17 @@ Crypto exchanges typically charge 0.1% (10 bps) per trade, meaning a round-trip 
 	initial_capital: {
 		id: 'initial_capital',
 		term: 'Initial Capital',
-		shortDescription: 'Base account size used by sizing and PnL calculations.',
+		shortDescription: 'Capital baseline for backtests, simulations, and legacy risk conversions.',
 		category: 'risk',
-		fullDescription: 'This value anchors position sizing and reported returns. Set it to realistic deployable capital, not an arbitrary number.',
+		fullDescription: 'This value anchors backtest and simulation sizing, reported returns, and legacy USD-to-percent risk conversions. It does not change the standardized per-strategy paper sandbox, which uses a fixed $10,000 benchmark.',
 		interpretations: [
 			{ range: '$1,000 - $100,000', label: 'Typical', color: 'green', description: 'Good starting range for paper/live validation.' },
 			{ range: '< $1,000', label: 'Small', color: 'yellow', description: 'Useful for testing, but sizing/noise can be distorted.' },
 			{ range: '> $100,000', label: 'Large', color: 'yellow', description: 'Use only if your real deployable capital is this high.' }
 		],
 		proTips: [
-			'Recommended: match this to real deployable capital within ±20%',
-			'Revisit this number before switching from paper to live'
+			'Recommended: match simulation capital to the scenario you are evaluating',
+			'Paper strategy comparisons stay normalized to the fixed $10,000 sandbox'
 		]
 	},
 	position_size_limit: {

--- a/frontend/src/lib/settings/manifest.ts
+++ b/frontend/src/lib/settings/manifest.ts
@@ -225,7 +225,7 @@ export const SETTINGS_MANIFEST: SettingsEntry[] = [
     subsection: 'trading-mode-capital',
     backendSection: 'initial-capital',
     backendPath: 'initial_capital',
-    description: 'Starting equity used to size positions and compute paper P&L.',
+    description: 'Capital baseline for backtests, simulations, and legacy risk-limit conversions; the per-strategy paper sandbox uses a fixed $10,000 benchmark.',
     usedBy: ['forven.api_core', 'forven.bot', 'forven.simulation'],
   },
 

--- a/frontend/src/tests/api.test.ts
+++ b/frontend/src/tests/api.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as api from '../lib/api';
-import { LONG_TIMEOUT_MS } from '../lib/api/core';
+import { ApiOutcomeUnknownError, fetchApi, LONG_TIMEOUT_MS } from '../lib/api/core';
 
 // Mock fetch globally
 const mockFetch = vi.fn();
@@ -859,6 +859,16 @@ describe('API Client', () => {
 	});
 
 	describe('Error Handling', () => {
+		it('does not retry a mutation after a network-level failure', async () => {
+			mockFetch.mockRejectedValue(new TypeError('Failed to fetch'));
+
+			await expect(fetchApi('/tasks', {
+				method: 'POST',
+				body: JSON.stringify({ name: 'one-shot' }),
+			})).rejects.toBeInstanceOf(ApiOutcomeUnknownError);
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+		});
+
 		it('should handle network errors', async () => {
 			mockFetch.mockRejectedValue(new Error('Network error'));
 

--- a/frontend/src/tests/assistantApi.test.ts
+++ b/frontend/src/tests/assistantApi.test.ts
@@ -15,6 +15,7 @@ global.fetch = mockFetch;
 describe('assistant api client', () => {
 	beforeEach(() => {
 		mockFetch.mockReset();
+		window.localStorage.clear();
 	});
 	afterEach(() => {
 		vi.clearAllMocks();
@@ -65,6 +66,8 @@ describe('assistant api client', () => {
 	});
 
 	it('streamAssistantSend parses SSE incl. action_proposed and sends context', async () => {
+		window.localStorage.setItem('forven_api_key', 'assistant-api-key');
+		window.localStorage.setItem('forven_operator_key', 'assistant-operator-key');
 		const encoder = new TextEncoder();
 		const chunks = [
 			encoder.encode('data: {"type":"user_persisted"}\n\n'),
@@ -89,6 +92,9 @@ describe('assistant api client', () => {
 		const [url, init] = mockFetch.mock.calls[0];
 		expect(String(url)).toContain('/api/assistant/threads/as_1/send');
 		const body = JSON.parse(String((init as RequestInit).body));
+		const headers = (init as RequestInit).headers as Headers;
+		expect(headers.get('X-API-Key')).toBe('assistant-api-key');
+		expect(headers.get('X-Operator-Key')).toBe('assistant-operator-key');
 		expect(body.user_text).toBe('promote S1');
 		expect(body.allow_actions).toBe(true);
 		expect(body.page_context).toEqual({ route: '/lab', page_kind: 'lab' });

--- a/frontend/src/tests/deepdiveApi.test.ts
+++ b/frontend/src/tests/deepdiveApi.test.ts
@@ -17,6 +17,7 @@ global.fetch = mockFetch;
 describe('deepdive api client', () => {
 	beforeEach(() => {
 		mockFetch.mockReset();
+		window.localStorage.clear();
 	});
 	afterEach(() => {
 		vi.clearAllMocks();
@@ -68,6 +69,8 @@ describe('deepdive api client', () => {
 	});
 
 	it('streamDeepdiveSend parses SSE chunks and invokes callback per event', async () => {
+		window.localStorage.setItem('forven_api_key', 'deepdive-api-key');
+		window.localStorage.setItem('forven_operator_key', 'deepdive-operator-key');
 		// Build a fake stream that emits two SSE blocks across two reader chunks
 		const encoder = new TextEncoder();
 		const chunks = [
@@ -97,6 +100,9 @@ describe('deepdive api client', () => {
 		const [url, init] = mockFetch.mock.calls[0];
 		expect(String(url)).toContain('/api/deepdive/threads/dd_1/send');
 		expect((init as RequestInit).method).toBe('POST');
+		const headers = (init as RequestInit).headers as Headers;
+		expect(headers.get('X-API-Key')).toBe('deepdive-api-key');
+		expect(headers.get('X-Operator-Key')).toBe('deepdive-operator-key');
 		expect(JSON.parse(String((init as RequestInit).body))).toEqual({ user_text: 'hi' });
 	});
 

--- a/frontend/src/tests/paperApiCompatibility.test.ts
+++ b/frontend/src/tests/paperApiCompatibility.test.ts
@@ -64,6 +64,27 @@ describe('paper compatibility API client', () => {
 		expect(methods.every((method) => method === 'POST')).toBe(true);
 	});
 
+	it('reuses the manual-open idempotency key after an ambiguous response', async () => {
+		const sessionId = 'compat:strategy:S00002';
+		const options = { direction: 'long' as const, size: 1, stopLossPrice: 95 };
+		mockFetch
+			.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+			.mockResolvedValueOnce({
+				ok: true,
+				json: () => Promise.resolve({ id: sessionId }),
+			});
+
+		await expect(openManualPaperPosition(sessionId, options)).rejects.toThrow(
+			'operation may have completed',
+		);
+		await openManualPaperPosition(sessionId, options);
+
+		const firstHeaders = (mockFetch.mock.calls[0][1] as RequestInit).headers as Headers;
+		const secondHeaders = (mockFetch.mock.calls[1][1] as RequestInit).headers as Headers;
+		expect(firstHeaders.get('Idempotency-Key')).toBeTruthy();
+		expect(secondHeaders.get('Idempotency-Key')).toBe(firstHeaders.get('Idempotency-Key'));
+	});
+
 	it('rejects unsupported replay controls before fetch', async () => {
 		await expect(replayStep('compat:strategy:S00001')).rejects.toThrow('not supported');
 		await expect(replaySeek('compat:strategy:S00001', 4)).rejects.toThrow('not supported');

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
 
 [project.optional-dependencies]
 discord = ["discord.py>=2.3"]
+test = ["pytest>=8.0", "pytest-asyncio>=1.3,<2"]
 
 [project.scripts]
 forven = "forven.cli:cli"

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -20,6 +20,7 @@ psutil>=5.9
 pyarrow>=16.0.0
 PyJWT>=2.8
 pytest>=8.0
+pytest-asyncio>=1.3,<2
 python-multipart>=0.0.9
 PyYAML>=6.0
 requests>=2.31

--- a/scripts/assign_execution_profiles.py
+++ b/scripts/assign_execution_profiles.py
@@ -32,9 +32,7 @@ from __future__ import annotations
 
 import argparse
 import json
-import shutil
 import sys
-import time
 
 
 def _load_paper_strategies(only: str | None) -> list[dict]:
@@ -88,12 +86,9 @@ def optimize_one(strat: dict, *, objective: str, max_risk: float, max_dd: float,
 
 
 def _backup_db() -> str:
-    import forven.config as cfg
+    from forven.backups import create_managed_db_backup
 
-    db_path = str(cfg.FORVEN_DB)
-    backup = f"{db_path}.bak-{int(time.time())}"
-    shutil.copy2(db_path, backup)
-    return backup
+    return str(create_managed_db_backup("assign-execution-profiles"))
 
 
 def _write_profile(strategy_id: str, profile: dict) -> None:

--- a/scripts/recover_cross_asset_rehomed_strategies.py
+++ b/scripts/recover_cross_asset_rehomed_strategies.py
@@ -28,9 +28,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import shutil
 import sys
-import time
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -99,7 +97,6 @@ def main() -> int:
     ap.add_argument("--limit", type=int, default=0, help="cap how many to recover (0 = no cap)")
     args = ap.parse_args()
 
-    from forven.config import FORVEN_DB
     from forven.db import get_db
 
     only = {s.strip() for s in args.ids.split(",") if s.strip()}
@@ -144,8 +141,9 @@ def main() -> int:
         print("\nNothing to recover.")
         return 0
 
-    backup = f"{FORVEN_DB}.bak.recover.{int(time.time())}"
-    shutil.copy2(FORVEN_DB, backup)
+    from forven.backups import create_managed_db_backup
+
+    backup = create_managed_db_backup("recover-cross-asset-rehomed-strategies")
     print(f"\nDB backed up to {backup}")
 
     from forven.brain import transition_stage

--- a/scripts/reset_paper_trades.py
+++ b/scripts/reset_paper_trades.py
@@ -21,10 +21,7 @@ doesn't open a fresh trade mid-reset.
 from __future__ import annotations
 
 import argparse
-import shutil  # noqa: F401  (retained for callers/compat; backup now uses the sqlite3 backup API)
-import sqlite3
 import sys
-import time
 
 PAPER_TYPES = ("paper", "paper_challenger", "simulation")
 
@@ -61,7 +58,6 @@ def main(argv=None) -> int:
     args = ap.parse_args(argv)
 
     from forven.db import get_db
-    import forven.config as cfg
 
     types = list(PAPER_TYPES) + (["live"] if args.include_live else [])
 
@@ -78,22 +74,9 @@ def main(argv=None) -> int:
         print("\nDRY RUN — nothing deleted. Re-run with --apply to back up + delete.")
         return 0
 
-    db_path = str(cfg.FORVEN_DB)
-    backup = f"{db_path}.bak-{int(time.time())}"
-    # Online backup via SQLite's backup API — correct for a LIVE/WAL DB held open by the
-    # running daemon. A plain file copy (shutil.copy2) fails with PermissionError on the
-    # locked file (and would capture a torn WAL state mid-write); the backup API copies a
-    # consistent snapshot cooperatively while the daemon keeps running.
-    _src = sqlite3.connect(db_path)
-    try:
-        _dst = sqlite3.connect(backup)
-        try:
-            with _dst:
-                _src.backup(_dst)
-        finally:
-            _dst.close()
-    finally:
-        _src.close()
+    from forven.backups import create_managed_db_backup
+
+    backup = create_managed_db_backup("reset-paper-trades")
     print(f"\nBacked up DB -> {backup}")
 
     # Stamp the paper-book reset so the kernel's recording window restarts HERE — BEFORE any

--- a/tests/test_live_entry_finalization.py
+++ b/tests/test_live_entry_finalization.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+
+def test_live_entry_fill_persistence_retries_until_success(monkeypatch):
+    import forven.scanner as scanner
+
+    outcomes = iter([False, False, True])
+    calls: list[dict] = []
+    sleeps: list[float] = []
+
+    def fake_update(*args, **kwargs):
+        calls.append({"args": args, "kwargs": kwargs})
+        return next(outcomes)
+
+    monkeypatch.setattr(scanner, "_update_trade_fill", fake_update)
+    monkeypatch.setattr(scanner.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    persisted = scanner._persist_live_entry_fill(
+        "T-LIVE-1",
+        101.25,
+        signal_price=100.0,
+        exchange_order_id="OID-1",
+        filled_size=0.4,
+        mark_price=101.0,
+    )
+
+    assert persisted is True
+    assert len(calls) == 3
+    assert sleeps == [0.05, 0.1]
+    assert calls[-1]["args"] == ("T-LIVE-1", 101.25, "entry")
+    assert calls[-1]["kwargs"]["filled_size"] == 0.4
+
+
+def test_live_entry_fill_persistence_failure_pauses_new_opens(monkeypatch):
+    import forven.exchange.hyperliquid as hyperliquid
+    import forven.exchange.risk as risk
+    import forven.scanner as scanner
+    import forven.sim.clock as clock
+
+    pauses: list[dict] = []
+
+    monkeypatch.setattr(scanner, "_resolve_hyperliquid_testnet", lambda: True)
+    monkeypatch.setattr(scanner, "_resolve_trade_vault_address", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(scanner, "_persist_live_entry_fill", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(
+        scanner,
+        "_pause_after_live_fill_persistence_failure",
+        lambda **kwargs: pauses.append(kwargs),
+    )
+    monkeypatch.setattr(scanner, "_update_trade_signal_data", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(scanner, "log_activity", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(clock, "is_sim_active", lambda: False)
+    monkeypatch.setattr(risk, "is_trading_allowed", lambda: (True, "ok"))
+    monkeypatch.setattr(hyperliquid, "set_leverage", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(
+        hyperliquid,
+        "market_order",
+        lambda **_kwargs: {
+            "entry_price": 101.25,
+            "filled_size": 0.4,
+            "entry_order_id": "OID-1",
+        },
+    )
+
+    result = scanner._execute_direct(
+        action="open",
+        trade_id="T-LIVE-1",
+        strat_id="S-LIVE",
+        asset="SOL",
+        direction="long",
+        size=0.5,
+        price=100.0,
+        stop_loss=95.0,
+    )
+
+    assert result["fill_persistence_failed"] is True
+    assert pauses == [{
+        "trade_id": "T-LIVE-1",
+        "asset": "SOL",
+        "direction": "long",
+        "error": "entry fill write failed after 3 attempts",
+    }]
+
+
+def test_fill_persistence_fault_engages_canonical_pause_and_critical_alert(monkeypatch):
+    import forven.notifications as notifications
+    import forven.scanner as scanner
+    import forven.system_pause as system_pause
+
+    pauses: list[tuple[bool, str | None]] = []
+    alerts: list[dict] = []
+    monkeypatch.setattr(
+        system_pause,
+        "set_system_paused",
+        lambda paused, *, paused_at=None: pauses.append((paused, paused_at)) or {},
+    )
+    monkeypatch.setattr(
+        notifications,
+        "emit_notification",
+        lambda event_type, **kwargs: alerts.append({"event_type": event_type, **kwargs}),
+    )
+
+    scanner._pause_after_live_fill_persistence_failure(
+        trade_id="T-LIVE-1",
+        asset="SOL",
+        direction="long",
+        error="database locked",
+    )
+
+    assert pauses and pauses[0][0] is True
+    assert pauses[0][1]
+    assert alerts[0]["event_type"] == "trade_fill_persistence_failed"
+    assert alerts[0]["severity"] == "critical"
+
+
+def test_rejected_stop_rearm_uses_filled_size_and_alerts_on_exception(monkeypatch):
+    import forven.exchange.hyperliquid as hyperliquid
+    import forven.exchange.risk as risk
+    import forven.notifications as notifications
+    import forven.scanner as scanner
+    import forven.sim.clock as clock
+
+    stop_sizes: list[float] = []
+    alerts: list[dict] = []
+
+    monkeypatch.setattr(scanner, "_resolve_hyperliquid_testnet", lambda: True)
+    monkeypatch.setattr(scanner, "_resolve_trade_vault_address", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(scanner, "_persist_live_entry_fill", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(scanner, "_update_trade_signal_data", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(scanner, "log_activity", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(clock, "is_sim_active", lambda: False)
+    monkeypatch.setattr(risk, "is_trading_allowed", lambda: (True, "ok"))
+    monkeypatch.setattr(hyperliquid, "set_leverage", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(
+        hyperliquid,
+        "market_order",
+        lambda **_kwargs: {
+            "entry_price": 101.25,
+            "filled_size": 0.4,
+            "entry_order_id": "OID-1",
+            "protective_leg_failed": ["stop"],
+        },
+    )
+
+    def raise_rearm(_asset, _direction, size, _stop_loss, **_kwargs):
+        stop_sizes.append(size)
+        raise RuntimeError("venue rejected re-arm")
+
+    monkeypatch.setattr(hyperliquid, "place_protective_stop", raise_rearm)
+    monkeypatch.setattr(notifications, "emit_notification", lambda event_type, **kwargs: alerts.append({"event_type": event_type, **kwargs}))
+
+    scanner._execute_direct(
+        action="open",
+        trade_id="T-LIVE-2",
+        strat_id="S-LIVE",
+        asset="SOL",
+        direction="long",
+        size=0.5,
+        price=100.0,
+        stop_loss=95.0,
+    )
+
+    assert stop_sizes == [0.4]
+    assert alerts[0]["event_type"] == "trade_protective_unarmed"
+    assert alerts[0]["severity"] == "critical"
+
+
+def test_reconcile_finalizes_matched_trade_from_exchange_truth(forven_db):
+    import json
+
+    from forven.db import get_db
+    from forven.exchange import risk
+
+    trade_id = "T-LIVE-RECONCILE"
+    with get_db() as conn:
+        conn.execute(
+            """
+            INSERT INTO trades
+            (id, strategy, strategy_id, asset, direction, entry_price, size, leverage,
+             status, execution_type, opened_at, signal_data)
+            VALUES (?, 'S-LIVE', 'S-LIVE', 'SOL', 'long', 100.0, 0.5, 1.0,
+                    'OPEN', 'live', datetime('now'), ?)
+            """,
+            (
+                trade_id,
+                json.dumps({
+                    "pending_open_reconcile": True,
+                    "fill_persistence_failed": True,
+                    "entry_finalization_state": "reconcile_required",
+                }),
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO portfolio_positions
+            (trade_id, asset, direction, strategy, strategy_id, risk_pct, entry_price,
+             correlation_group, opened_at, execution_type)
+            VALUES (?, 'SOL', 'long', 'S-LIVE', 'S-LIVE', 0.01, 100.0,
+                    'crypto_major', datetime('now'), 'live')
+            """,
+            (trade_id,),
+        )
+
+    with get_db() as conn:
+        trade = dict(conn.execute("SELECT * FROM trades WHERE id = ?", (trade_id,)).fetchone())
+        action = risk._finalize_matched_open_trade(
+            conn,
+            trade,
+            {"asset": "SOL", "direction": "long", "entry_price": 101.25, "size": 0.4},
+        )
+
+    with get_db() as conn:
+        row = dict(conn.execute(
+            "SELECT entry_price, fill_entry_price, size, signal_data FROM trades WHERE id = ?",
+            (trade_id,),
+        ).fetchone())
+        position = conn.execute(
+            "SELECT entry_price FROM portfolio_positions WHERE trade_id = ?",
+            (trade_id,),
+        ).fetchone()
+
+    signal_data = json.loads(row["signal_data"])
+    assert action and action["type"] == "entry_finalized"
+    assert row["entry_price"] == 101.25
+    assert row["fill_entry_price"] == 101.25
+    assert row["size"] == 0.4
+    assert position["entry_price"] == 101.25
+    assert signal_data["entry_finalization_state"] == "finalized_reconciled"
+    assert signal_data["filled_size"] == 0.4
+    assert "pending_open_reconcile" not in signal_data
+    assert "fill_persistence_failed" not in signal_data

--- a/tests/test_managed_backups.py
+++ b/tests/test_managed_backups.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_managed_backup_uses_online_primitive_and_prunes_only_managed_files(tmp_path, monkeypatch):
+    import forven.backups as backups
+
+    timestamps = iter([
+        "20260101T000001000000Z",
+        "20260101T000002000000Z",
+        "20260101T000003000000Z",
+        "20260101T000004000000Z",
+    ])
+    created: list[Path] = []
+
+    def fake_backup(destination):
+        target = Path(destination)
+        target.write_text("sqlite snapshot", encoding="utf-8")
+        created.append(target)
+        return target
+
+    monkeypatch.setattr(backups, "backup_db", fake_backup)
+    monkeypatch.setattr(backups, "_backup_timestamp", lambda: next(timestamps))
+    legacy = tmp_path / "forven.db.bak-legacy"
+    legacy.write_text("preserve", encoding="utf-8")
+
+    for _ in range(4):
+        backups.create_managed_db_backup("reset paper", backup_root=tmp_path, retain=2)
+
+    remaining = sorted(tmp_path.glob("forven-*.db"))
+    assert len(remaining) == 2
+    assert remaining == created[-2:]
+    assert legacy.read_text(encoding="utf-8") == "preserve"
+
+
+def test_managed_backup_removes_partial_target_when_backup_fails(tmp_path, monkeypatch):
+    import forven.backups as backups
+
+    def fail_backup(destination):
+        Path(destination).write_text("partial", encoding="utf-8")
+        raise RuntimeError("backup failed")
+
+    monkeypatch.setattr(backups, "backup_db", fail_backup)
+    monkeypatch.setattr(backups, "_backup_timestamp", lambda: "20260101T000001000000Z")
+
+    try:
+        backups.create_managed_db_backup("failure", backup_root=tmp_path)
+    except RuntimeError as exc:
+        assert str(exc) == "backup failed"
+    else:
+        raise AssertionError("backup failure should propagate")
+
+    assert list(tmp_path.glob("forven-*.db")) == []

--- a/tests/test_paper_control.py
+++ b/tests/test_paper_control.py
@@ -488,7 +488,10 @@ def test_live_open_places_market_order_and_registers(forven_db, monkeypatch):
     registered = {}
     monkeypatch.setattr(pc.risk_mod, "register", lambda *a, **k: registered.update({"called": True}))
 
+    placed = {}
+
     def _fake_market(asset, side, size, stop_loss_price=None, take_profit_price=None, testnet=True, **kw):
+        placed.update(kw)
         return {
             "entry_price": 100.5,
             "filled_size": size,
@@ -498,7 +501,13 @@ def test_live_open_places_market_order_and_registers(forven_db, monkeypatch):
 
     monkeypatch.setattr(hl, "market_order", _fake_market)
 
-    pc.open_manual_position(STRATEGY_ID, direction="long", size=2.0, stop_loss_price=90.0)
+    pc.open_manual_position(
+        STRATEGY_ID,
+        direction="long",
+        size=2.0,
+        stop_loss_price=90.0,
+        idempotency_key="intent-123",
+    )
 
     from forven.db import get_db
 
@@ -513,6 +522,8 @@ def test_live_open_places_market_order_and_registers(forven_db, monkeypatch):
     assert sd["entry_exchange_order_id"] == "OID-ENTRY-NEW"
     assert sd["exchange_stop_order_id"] == "OID-STOP"
     assert sd["stop_loss_price"] == 90.0
+    assert sd["manual_open_idempotency_key"] == "intent-123"
+    assert placed["idempotency_key"] == "manual-open:intent-123"
     assert registered.get("called") is True
 
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1349,6 +1349,65 @@ def test_manage_positions_marks_trade_pending_reconcile_when_open_execution_fail
     assert any("PENDING open ETH" in action for action in actions)
 
 
+def test_confirmed_fill_persistence_failure_keeps_risk_slot_reserved(monkeypatch):
+    signal_updates = {}
+    released = {"called": False}
+
+    monkeypatch.setattr(scanner_mod, "_get_open_trades", lambda _sid: [])
+    monkeypatch.setattr(scanner_mod, "can_open", lambda **_kwargs: (True, 0.01, "ok"))
+    monkeypatch.setattr(
+        scanner_mod,
+        "calculate_position_size",
+        lambda **_kwargs: (0.5, {"method": "atr"}),
+    )
+    monkeypatch.setattr(
+        scanner_mod,
+        "_open_trade_db",
+        lambda *_args, **_kwargs: "E-FILL-PERSIST-1",
+    )
+    monkeypatch.setattr(scanner_mod, "register", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(scanner_mod, "log_activity", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        scanner_mod,
+        "_execute_direct",
+        lambda **_kwargs: {"entry_price": 2001.0, "fill_persistence_failed": True},
+    )
+    monkeypatch.setattr(
+        scanner_mod,
+        "_update_trade_signal_data",
+        lambda trade_id, updates: signal_updates.update({"trade_id": trade_id, **updates}) or True,
+    )
+    monkeypatch.setattr(
+        scanner_mod,
+        "release",
+        lambda _trade_id: released.update({"called": True}),
+    )
+    monkeypatch.setattr(scanner_mod, "_paper_stage_local_execution_only_enabled", lambda: False)
+    monkeypatch.setattr(scanner_mod, "_paper_test_mode_enabled", lambda: False)
+    monkeypatch.setattr("forven.config.get_execution_mode", lambda: "paper")
+
+    actions = manage_positions(
+        "S-FILL-PERSIST",
+        {
+            "asset": "ETH",
+            "stage": "paper",
+            "params": {
+                "risk_pct": 0.01,
+                "leverage": 1.0,
+                "stop_loss_pct": 2.0,
+                "take_profit_pct": 4.0,
+            },
+        },
+        {"price": 2000.0, "entry_signal": True, "exit_signal": False},
+        account_equity=10_000.0,
+    )
+
+    assert released["called"] is False
+    assert signal_updates["entry_finalization_state"] == "reconcile_required"
+    assert signal_updates["open_execution_failure_reason"] == scanner_mod._CONFIRMED_FILL_PERSISTENCE_ERROR
+    assert any("PENDING open ETH" in action for action in actions)
+
+
 def test_scan_asset_group_stamps_last_bar_time(monkeypatch):
     df = _ohlcv_from_close([100.0, 101.0, 102.0])
     monkeypatch.setattr(scanner_mod, "fetch_candles", lambda *_args, **_kwargs: df)

--- a/tests/test_scheduler_background_jobs.py
+++ b/tests/test_scheduler_background_jobs.py
@@ -433,6 +433,20 @@ def test_gauntlet_step_loop_runs_via_tracked_sync_job(monkeypatch, forven_db):
     assert captured["kwargs"].get("max_workflows") == 7
 
 
+def test_run_job_rejects_unknown_kind_without_shell_execution(forven_db):
+    job = {
+        "id": "unknown-kind",
+        "name": "Unknown kind",
+        "command": "echo must-not-run",
+        "payload": json.dumps({"kind": "not_registered"}),
+    }
+
+    status, error = asyncio.run(scheduler.run_job(job))
+
+    assert status == "error"
+    assert error == "Unknown scheduler job kind: not_registered"
+
+
 def test_tick_skips_due_gauntlet_job_while_zombie_thread_alive(monkeypatch, forven_db):
     """A due gauntlet_step_loop tick must NOT be claimed (not even via the
     stale takeover in _try_mark_job_running) while a previous tick's worker


### PR DESCRIPTION
## Summary

- make live entry-fill persistence explicit, retry boundedly, pause new opens on unreconciled writes, and finalize matched trades from exchange-authoritative entry price and size
- re-arm rejected protective orders with actual filled size and emit critical alerts for both returned errors and raised exceptions
- prevent unsafe frontend mutation retries, surface ambiguous outcomes, authenticate assistant/deep-dive streams, and give manual live opens retry-stable venue idempotency
- fail closed for unknown scheduler job kinds
- consolidate destructive-script database snapshots onto locked SQLite online backups with bounded managed retention
- restore async runtime coverage in CI and correct initial-capital help text

## Root cause

Several safety paths were individually reasonable but did not form an end-to-end contract. A confirmed exchange fill could fail local persistence without a result visible to the caller, and reconciliation repaired protection without updating stale local entry fields. The frontend also retried mutation requests after network-level failures, which could resend an operation whose response was lost. Backup helpers existed but destructive scripts bypassed them and accumulated unbounded full database copies.

## Impact

Live fills now remain risk-accounted and reconciliation-owned until local state converges. Manual live-open retries reuse the same venue client order identity. Unknown scheduler payloads cannot fall through to shell execution. New managed database snapshots are consistent under WAL and retain only the newest configured count.

Paper strategies continue to be evaluated independently; this PR does not add cross-strategy paper correlation enforcement. It also does not introduce automatic flattening when a stop cannot be armed.

## Validation

- Ruff passed on all touched backend files
- 110 affected backend tests passed
- 191 surrounding live-risk, recovery, security, and idempotency tests passed
- 413 frontend unit tests passed
- Svelte/TypeScript check passed with 0 errors and 2 pre-existing warnings
- 10 async runtime tests passed with pytest-asyncio
- git diff integrity checks passed
