### PR TITLE
Harden live order finalization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,19 @@ jobs:
             tests/test_daemon_price_freshness.py \
             tests/test_loop_starvation_fixes.py
 
+      # Real-money execution integrity: ambiguous/partial IOC responses must
+      # never release local exposure or remove the last protective order.
+      - name: Run capital-integrity regression tests
+        run: |
+          python -m pytest -q \
+            tests/test_execution_results.py \
+            tests/test_paper_control.py \
+            tests/test_open_trades_exchange_verification.py \
+            tests/test_live_entry_finalization.py \
+            tests/test_kill_switch_close_integrity.py \
+            tests/test_mtier_hardening.py \
+            tests/test_engine_audit_phase1.py
+
       # Data-engine regression gate — locks in the 2026-07 data hardening + edge-data
       # expansion (tail-append storage, perp canonicalization, causality shifts,
       # quality gates, fingerprints, symbol registry, basis/IV streams, kernel

--- a/forven/api_domains/paper_control.py
+++ b/forven/api_domains/paper_control.py
@@ -38,6 +38,7 @@ from fastapi import HTTPException
 from forven.api_domains import paper as paper_domain
 from forven.api_domains import trading as trading_domain
 from forven.db import get_db, kv_get, next_container_id
+from forven.execution_results import parse_close_receipt
 from forven.exchange import books as books_mod
 from forven.exchange import risk as risk_mod
 from forven.sim.clock import get_now
@@ -359,14 +360,15 @@ def _live_close_trade(trade: dict, *, close_reason: str, note: str | None = None
         raise HTTPException(status_code=502, detail=str(result["error"]))
 
     order_id = result.get("order_id") or result.get("oid")
-    fill = _coerce_optional_float(result.get("exit_price")) or _coerce_optional_float(result.get("fill_price"))
+    receipt = parse_close_receipt(result, size)
+    fill = receipt.fill_price
     extra = {
         "source": "manual",
         "manually_closed_at": _iso_now(),
         "manual_close_note": note,
         "exit_exchange_order_id": str(order_id) if order_id is not None else None,
     }
-    if fill is not None:
+    if receipt.outcome == "filled" and fill is not None:
         closed = close_trade_record(
             str(trade["id"]),
             signal_exit_price=fill,
@@ -381,9 +383,31 @@ def _live_close_trade(trade: dict, *, close_reason: str, note: str | None = None
         _safe_release(str(trade["id"]))
         return
 
-    # No immediate fill — record the requested close and let the reconciler finalize
-    # once the exchange confirms flat (mirrors force_close_trade's deferred path).
+    if receipt.outcome == "partial":
+        with get_db() as conn:
+            conn.execute(
+                "UPDATE trades SET size = ? WHERE id = ? AND status = 'OPEN'",
+                (round(receipt.residual_size, 8), str(trade["id"])),
+            )
+        extra.update(
+            {
+                "partial_close": True,
+                "partial_close_filled": receipt.filled_size,
+                "partial_close_residual": receipt.residual_size,
+                "partial_close_at": _iso_now(),
+            }
+        )
+
+    # Partial, unfilled, or ambiguous response: keep the residual OPEN and let
+    # reconciliation confirm exchange-flat before releasing local risk state.
     pending_price = _coerce_optional_float(result.get("close_price")) or _coerce_optional_float(result.get("mid"))
+    extra.update(
+        {
+            "close_execution_outcome": receipt.outcome,
+            "close_filled_size": receipt.filled_size,
+            "close_residual_size": receipt.residual_size,
+        }
+    )
     pending = mark_trade_pending_close_reconcile(
         str(trade["id"]),
         signal_exit_price=pending_price,
@@ -433,8 +457,12 @@ def partial_close_paper_position(session_id: str, qty=None, pct=None) -> dict:
     if close_qty >= size:
         return close_paper_position(session_id, reason="manual_partial_close (full)")
 
+    booked_close_qty = close_qty
     if _trade_is_live(trade):
-        fill = _live_reduce(trade, close_qty)
+        live_fill = _live_reduce(trade, close_qty)
+        if live_fill is None:
+            return _refresh(session_id)
+        fill, booked_close_qty = live_fill
     else:
         fill = _fresh_manual_mark(session, trade)
 
@@ -447,7 +475,7 @@ def partial_close_paper_position(session_id: str, qty=None, pct=None) -> dict:
     direction = _normalize_trade_direction(trade.get("direction"))
     leverage = _coerce_optional_float(trade.get("leverage")) or 1.0
     signed = 1.0 if direction == "long" else -1.0
-    pnl_usd = (fill - entry) * close_qty * signed
+    pnl_usd = (fill - entry) * booked_close_qty * signed
     pnl_pct = ((fill - entry) / entry) * signed * leverage if entry > 0 else 0.0
 
     parent_id = str(trade["id"])
@@ -481,7 +509,7 @@ def partial_close_paper_position(session_id: str, qty=None, pct=None) -> dict:
                 entry,
                 fill,
                 fill,
-                round(close_qty, 8),
+                round(booked_close_qty, 8),
                 trade.get("risk_pct"),
                 leverage,
                 round(pnl_usd, 4),
@@ -494,6 +522,7 @@ def partial_close_paper_position(session_id: str, qty=None, pct=None) -> dict:
             ),
         )
 
+        residual_size = round(max(size - booked_close_qty, 0.0), 8)
         # Shrink the parent and append an audit entry. The parent's `source` is left
         # untouched: a partial close does not hand the residual to the operator (use
         # Pause for that) — the strategy keeps managing what's left. A live position's
@@ -505,7 +534,8 @@ def partial_close_paper_position(session_id: str, qty=None, pct=None) -> dict:
         audit.append(
             {
                 "child_id": child_id,
-                "qty": round(close_qty, 8),
+                "qty": round(booked_close_qty, 8),
+                "requested_qty": round(close_qty, 8),
                 "exit_price": fill,
                 "pnl_usd": round(pnl_usd, 4),
                 "at": closed_at,
@@ -514,14 +544,18 @@ def partial_close_paper_position(session_id: str, qty=None, pct=None) -> dict:
         parent_sd["partial_closes"] = audit
         conn.execute(
             "UPDATE trades SET size = ?, signal_data = ? WHERE id = ?",
-            (round(size - close_qty, 8), json.dumps(parent_sd), parent_id),
+            (residual_size, json.dumps(parent_sd), parent_id),
         )
 
     return _refresh(session_id)
 
 
-def _live_reduce(trade: dict, close_qty: float) -> float:
-    """Reduce a live position by ``close_qty`` with a reduce-only market order; return fill."""
+def _live_reduce(trade: dict, close_qty: float) -> tuple[float, float] | None:
+    """Reduce a live position and return confirmed ``(price, filled_size)``.
+
+    Ambiguous and unfilled responses are left for reconciliation so an operator
+    retry cannot double-book an exchange outcome that was never confirmed.
+    """
     asset = str(trade.get("asset") or "").strip().upper()
     direction = _normalize_trade_direction(trade.get("direction"))
     close_side = "sell" if direction == "long" else "buy"
@@ -535,10 +569,22 @@ def _live_reduce(trade: dict, close_qty: float) -> float:
         raise HTTPException(status_code=502, detail=f"Exchange partial close failed: {exc}") from exc
     if isinstance(result, dict) and result.get("error"):
         raise HTTPException(status_code=502, detail=str(result["error"]))
-    fill = _coerce_optional_float(result.get("exit_price")) or _coerce_optional_float(result.get("fill_price"))
-    if fill is None or fill <= 0:
-        raise HTTPException(status_code=502, detail="Partial close did not return a fill price; try again.")
-    return float(fill)
+    receipt = parse_close_receipt(result, close_qty)
+    if receipt.outcome in {"unknown", "unfilled"} or receipt.fill_price is None or not receipt.filled_size:
+        mark_trade_pending_close_reconcile(
+            str(trade["id"]),
+            signal_exit_price=_coerce_optional_float(result.get("mid")),
+            close_reason="manual_partial_close",
+            close_price_source="manual_partial_close_requested",
+            requested_at=_iso_now(),
+            extra_signal_data={
+                "close_execution_outcome": receipt.outcome,
+                "close_requested_size": close_qty,
+                "close_filled_size": receipt.filled_size,
+            },
+        )
+        return None
+    return float(receipt.fill_price), float(receipt.filled_size)
 
 
 # --------------------------------------------------------------------------- #
@@ -669,7 +715,7 @@ def _live_open(
         raise HTTPException(status_code=400, detail="A live position requires a protective stop_loss_price.")
 
     testnet = _live_testnet()
-    from forven.exchange.hyperliquid import get_account_value, market_order
+    from forven.exchange.hyperliquid import get_account_value, market_order, set_leverage
 
     resolved_size = _coerce_optional_float(size)
     if resolved_size is None or resolved_size <= 0:
@@ -697,6 +743,18 @@ def _live_open(
     if not _halt_ok:
         raise HTTPException(status_code=409, detail=f"Trading halted — {_halt_reason}")
 
+    try:
+        leverage_result = set_leverage(
+            asset, float(leverage), testnet=testnet, vault_address=vault
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=502, detail=f"Could not set exchange leverage: {exc}") from exc
+    if isinstance(leverage_result, dict) and leverage_result.get("error"):
+        raise HTTPException(
+            status_code=502,
+            detail=f"Could not set exchange leverage: {leverage_result.get('error')}",
+        )
+
     side = "buy" if direction == "long" else "sell"
     normalized_idempotency_key = str(idempotency_key or "").strip()[:160] or None
     try:
@@ -715,7 +773,13 @@ def _live_open(
     if isinstance(result, dict) and result.get("error"):
         raise HTTPException(status_code=502, detail=str(result["error"]))
 
-    fill = _coerce_optional_float(result.get("entry_price")) or _fresh_manual_mark(_resolve_session(session_id))
+    fill_unknown = bool(result.get("fill_price_unknown"))
+    reported_entry = _coerce_optional_float(result.get("entry_price"))
+    fill = (
+        _fresh_manual_mark(_resolve_session(session_id))
+        if fill_unknown
+        else reported_entry or _fresh_manual_mark(_resolve_session(session_id))
+    )
     filled_size = _coerce_optional_float(result.get("filled_size")) or float(resolved_size)
     entry_oid = result.get("entry_order_id") or result.get("order_id")
     stop_oid = result.get("stop_order_id")
@@ -727,6 +791,16 @@ def _live_open(
         "entry_exchange_order_id": str(entry_oid) if entry_oid is not None else None,
         "exchange_order_id": str(entry_oid) if entry_oid is not None else None,
     }
+    if fill_unknown:
+        signal_data.update(
+            {
+                "pending_open_reconcile": True,
+                "pending_open_reconcile_at": _iso_now(),
+                "entry_finalization_state": "reconcile_required",
+                "open_fill_unconfirmed_price": reported_entry,
+                "requested_size": float(resolved_size),
+            }
+        )
     if normalized_idempotency_key:
         signal_data["manual_open_idempotency_key"] = normalized_idempotency_key
     if stop_loss_price:
@@ -741,29 +815,57 @@ def _live_open(
         if tp_oid is not None:
             signal_data["exchange_take_profit_order_id"] = str(tp_oid)
 
-    trade_id = _open_trade_db_safe(
-        strategy_id=strategy_id, asset=asset, direction=direction, entry=fill,
-        size=float(filled_size), risk_pct=float(risk_fraction or 0.0),
-        leverage=leverage, signal_data=signal_data, execution_type="live", book=book,
-    )
     try:
-        from forven.scanner import _update_trade_fill
+        trade_id = _open_trade_db_safe(
+            strategy_id=strategy_id, asset=asset, direction=direction, entry=fill,
+            size=float(filled_size), risk_pct=float(risk_fraction or 0.0),
+            leverage=leverage, signal_data=signal_data, execution_type="live", book=book,
+        )
+    except HTTPException as exc:
+        _recover_unpersisted_manual_entry(
+            asset=asset,
+            direction=direction,
+            size=float(filled_size),
+            stop_loss_price=float(_parsed_stop),
+            entry_oid=entry_oid,
+            stop_oid=stop_oid,
+            testnet=testnet,
+            vault=vault,
+            reason=str(exc.detail),
+        )
+        raise
 
-        _update_trade_fill(
-            trade_id=trade_id, fill_price=fill, fill_kind="entry",
+    if not fill_unknown:
+        from forven.scanner import _pause_after_live_fill_persistence_failure, _persist_live_entry_fill
+
+        if not _persist_live_entry_fill(
+            trade_id=trade_id,
+            fill_price=fill,
             signal_price=fill,
             exchange_order_id=str(entry_oid) if entry_oid is not None else None,
             filled_size=filled_size,
-        )
-    except Exception:  # noqa: BLE001 - fill bookkeeping is best-effort; entry_price is already set
-        log.warning("manual live open %s: fill bookkeeping failed", trade_id, exc_info=True)
+            mark_price=None,
+        ):
+            _pause_after_live_fill_persistence_failure(
+                trade_id=trade_id,
+                asset=asset,
+                direction=direction,
+                error="manual live entry fill metadata could not be committed",
+            )
     try:
         risk_mod.register(
             trade_id, asset, direction, strategy_id, float(risk_fraction or 0.0),
             float(fill), execution_type="live", book=book,
         )
-    except Exception:  # noqa: BLE001
-        log.warning("manual live open %s: risk register failed", trade_id, exc_info=True)
+    except Exception as exc:  # noqa: BLE001
+        from forven.scanner import _pause_after_live_fill_persistence_failure
+
+        _pause_after_live_fill_persistence_failure(
+            trade_id=trade_id,
+            asset=asset,
+            direction=direction,
+            error=f"manual live risk registration failed: {exc}",
+        )
     # #4: a protective leg the exchange REJECTED on the bracket entry (entry filled, stop
     # bounced) must not be recorded as a normally-protected position. Re-arm it immediately
     # (and alert if the stop still can't be armed) — mirroring the scanner's open path.
@@ -777,6 +879,72 @@ def _live_open(
             testnet=testnet, vault=vault,
         )
     log.info("Manual LIVE open %s %s %s size=%s @ %s", trade_id, direction, asset, filled_size, fill)
+
+
+def _recover_unpersisted_manual_entry(
+    *,
+    asset: str,
+    direction: str,
+    size: float,
+    stop_loss_price: float,
+    entry_oid,
+    stop_oid,
+    testnet: bool,
+    vault: str | None,
+    reason: str,
+) -> None:
+    """Pause new opens and best-effort protect an entry missing local ownership."""
+    recovery_id = f"manual-unpersisted:{entry_oid or asset}"
+    stop_detail = f"existing stop order {stop_oid}" if stop_oid is not None else "stop status unknown"
+    if stop_oid is None:
+        try:
+            from forven.exchange.hyperliquid import place_protective_stop
+
+            kwargs: dict = {"testnet": testnet}
+            if vault:
+                kwargs["vault_address"] = vault
+            stop_result = place_protective_stop(
+                asset, direction, size, stop_loss_price, **kwargs
+            )
+            if isinstance(stop_result, dict) and not stop_result.get("error") and stop_result.get("stop_order_id"):
+                stop_detail = f"emergency stop order {stop_result['stop_order_id']} placed"
+            else:
+                stop_detail = f"emergency stop placement failed: {(stop_result or {}).get('error') if isinstance(stop_result, dict) else stop_result}"
+        except Exception as exc:  # noqa: BLE001
+            stop_detail = f"emergency stop placement raised: {exc}"
+
+    try:
+        from forven.system_pause import set_system_paused
+
+        set_system_paused(True, paused_at=_iso_now())
+    except Exception:  # noqa: BLE001
+        log.critical("Could not pause after unpersisted manual entry", exc_info=True)
+
+    log.critical(
+        "Manual live entry %s %s may have filled but local trade creation failed; "
+        "new opens paused. %s. reason=%s",
+        asset,
+        direction,
+        stop_detail,
+        reason,
+    )
+    try:
+        from forven.notifications import emit_notification
+
+        emit_notification(
+            "trade_fill_persistence_failed",
+            severity="critical",
+            source="manual",
+            title=f"Manual live entry requires recovery ({asset})",
+            summary=(
+                f"{asset} {direction} may have filled but no local trade row was created; "
+                "new opens were paused."
+            ),
+            body=f"entry_order={entry_oid}; {stop_detail}; reason={reason}",
+            dedupe_key=recovery_id,
+        )
+    except Exception:  # noqa: BLE001
+        log.error("Could not emit unpersisted manual-entry notification", exc_info=True)
 
 
 def _open_trade_db_safe(
@@ -833,8 +1001,11 @@ def _adjust_protective(session_id: str, session: dict, trade: dict, kind: str, p
 
     if parsed is None:
         # Clear the level (and cancel the resting exchange order, if live).
-        if live and existing_oid:
-            _cancel_live_order(trade.get("asset"), existing_oid, vault)
+        if live and existing_oid and not _cancel_live_order(trade.get("asset"), existing_oid, vault):
+            raise HTTPException(
+                status_code=502,
+                detail=f"Exchange {kind.replace('_', ' ')} cancellation failed; the existing order was kept locally.",
+            )
         _update_open_trade_signal_data(
             trade_id, {source_key: "manual", ts_key: _iso_now()}, removals=(price_key, oid_key)
         )
@@ -847,28 +1018,37 @@ def _adjust_protective(session_id: str, session: dict, trade: dict, kind: str, p
 
     updates = {price_key: float(parsed), source_key: "manual", ts_key: _iso_now()}
     if live:
-        # Replace the resting exchange order on the position's sub-account: cancel
-        # the old one, place the new.
-        if existing_oid:
-            _cancel_live_order(trade.get("asset"), existing_oid, vault)
+        # PLACE-BEFORE-CANCEL: a rejected replacement must leave the old resting
+        # protection intact.  If old-order cancellation fails, retain its id in
+        # signal_data so reconciliation can retire it later.
         new_oid = _place_live_protective(kind, trade, float(parsed), vault)
-        if new_oid is not None:
-            updates[oid_key] = str(new_oid)
-        else:
-            updates.pop(oid_key, None)
+        if new_oid is None:
+            raise HTTPException(status_code=502, detail=f"Exchange {kind.replace('_', ' ')} placement returned no order id.")
+        updates[oid_key] = str(new_oid)
+        if existing_oid and not _cancel_live_order(trade.get("asset"), existing_oid, vault):
+            pending_ids = sd.get("protective_cancel_pending_order_ids")
+            pending_ids = list(pending_ids) if isinstance(pending_ids, list) else []
+            if str(existing_oid) not in pending_ids:
+                pending_ids.append(str(existing_oid))
+            updates["protective_cancel_pending_order_ids"] = pending_ids
         if kind == "stop_loss":
             updates["exchange_stop_requested"] = True
     _update_open_trade_signal_data(trade_id, updates)
     return _refresh(session_id)
 
 
-def _cancel_live_order(asset, oid, vault_address: str | None = None) -> None:
+def _cancel_live_order(asset, oid, vault_address: str | None = None) -> bool:
     try:
         from forven.exchange.hyperliquid import cancel_order
 
-        cancel_order(str(asset).upper(), int(oid), testnet=_live_testnet(), vault_address=vault_address)
-    except Exception:  # noqa: BLE001 - a stale/already-filled order is fine to ignore
+        result = cancel_order(str(asset).upper(), int(oid), testnet=_live_testnet(), vault_address=vault_address)
+        if isinstance(result, dict) and result.get("error"):
+            log.warning("cancel_order(%s, %s) rejected during manual adjust: %s", asset, oid, result.get("error"))
+            return False
+        return True
+    except Exception:  # noqa: BLE001
         log.warning("cancel_order(%s, %s) failed during manual adjust", asset, oid, exc_info=True)
+        return False
 
 
 def _place_live_protective(kind: str, trade: dict, price: float, vault_address: str | None = None):

--- a/forven/api_domains/trading.py
+++ b/forven/api_domains/trading.py
@@ -16,6 +16,7 @@ from forven.db import (
 )
 from forven.exchange import hyperliquid as hl
 from forven.exchange.risk import release, sync_from_trades
+from forven.execution_results import parse_close_receipt
 from forven.trade_state import (
     close_trade_record,
     is_local_only_paper_trade,
@@ -1029,9 +1030,20 @@ def _force_close_exchange_backed_trade(trade_id: str, body) -> dict[str, object]
     except Exception as exc:
         return {"ok": False, "error": str(exc)}
 
-    exit_price = _coerce_optional_float(close_result.get("close_price"))
-    if exit_price is None:
-        exit_price = _coerce_optional_float(close_result.get("mid"))
+    receipt = parse_close_receipt(close_result, float(size))
+    if receipt.outcome != "filled" or receipt.fill_price is None:
+        return {
+            "ok": False,
+            "pending_close_reconcile": True,
+            "error": "Exchange close was not confirmed complete; protective orders were retained.",
+            "trade_id": trade_id,
+            "asset": asset,
+            "direction": direction,
+            "filled_size": receipt.filled_size,
+            "residual_size": receipt.residual_size,
+            "source": "exchange",
+        }
+    exit_price = receipt.fill_price
     close_order_id = close_result.get("order_id") or close_result.get("orderId") or close_result.get("oid")
     close_note = str(body.reason or "").strip() or None
 
@@ -1122,14 +1134,13 @@ def force_close_trade(trade_id: str, body):
 
     close_order_id = close_result.get("order_id") or close_result.get("orderId") or close_result.get("oid")
     close_note = str(body.reason or "").strip() or None
-    actual_exit_price = _coerce_optional_float(close_result.get("exit_price"))
-    if actual_exit_price is None:
-        actual_exit_price = _coerce_optional_float(close_result.get("fill_price"))
+    receipt = parse_close_receipt(close_result, size)
+    actual_exit_price = receipt.fill_price
     pending_close_price = _coerce_optional_float(close_result.get("close_price"))
     if pending_close_price is None:
         pending_close_price = _coerce_optional_float(close_result.get("mid"))
 
-    if actual_exit_price is not None:
+    if receipt.outcome == "filled" and actual_exit_price is not None:
         closed = close_trade_record(
             trade_id,
             signal_exit_price=actual_exit_price,
@@ -1173,6 +1184,13 @@ def force_close_trade(trade_id: str, body):
             "source": "sqlite",
         }
 
+    if receipt.outcome == "partial":
+        with get_db() as conn:
+            conn.execute(
+                "UPDATE trades SET size = ? WHERE id = ? AND status = 'OPEN'",
+                (round(receipt.residual_size, 8), trade_id),
+            )
+
     pending = mark_trade_pending_close_reconcile(
         trade_id,
         signal_exit_price=pending_close_price,
@@ -1183,6 +1201,9 @@ def force_close_trade(trade_id: str, body):
             "manual_close_note": close_note,
             "exit_exchange_order_id": str(close_order_id) if close_order_id is not None else None,
             "pending_close_requested_execution_price": pending_close_price,
+            "close_execution_outcome": receipt.outcome,
+            "close_filled_size": receipt.filled_size,
+            "close_residual_size": receipt.residual_size,
         },
     )
     if not pending or not pending.get("updated"):
@@ -1210,6 +1231,9 @@ def force_close_trade(trade_id: str, body):
         "direction": direction,
         "close_side": close_side,
         "pending_close_reconcile": True,
+        "close_execution_outcome": receipt.outcome,
+        "filled_size": receipt.filled_size,
+        "residual_size": receipt.residual_size,
         "requested_exit_price": round(float(pending_close_price), 8) if pending_close_price is not None else None,
         "closed_at": None,
         "source": "sqlite",

--- a/forven/exchange/hyperliquid.py
+++ b/forven/exchange/hyperliquid.py
@@ -1637,7 +1637,11 @@ def cancel_order(asset: str, oid: int, testnet: bool = True, vault_address: str 
 
     _assert_execution_allowed(testnet)
     exchange, info, address = _exchange_for_trading(testnet, vault_address=vault_address)
-    return _submit("order_cancel", hl_trade_breaker, exchange.cancel, asset.upper(), oid)
+    result = _submit("order_cancel", hl_trade_breaker, exchange.cancel, asset.upper(), oid)
+    nested_error = _first_status_error(result) if isinstance(result, dict) else None
+    if nested_error and not result.get("error"):
+        return {**result, "error": nested_error}
+    return result
 
 
 def place_protective_stop(

--- a/forven/exchange/risk.py
+++ b/forven/exchange/risk.py
@@ -1876,23 +1876,14 @@ def _extract_close_price(result: object) -> float | None:
 def _close_residual_size(result: object, fallback_requested: float) -> float:
     """M8: unfilled size left after a (no-error) close response.
 
-    Returns 0.0 when the fill size is unknown (don't over-escalate) or when only
-    dust remains. Used by the kill-switch to roll a partial fill into the next,
-    wider slippage tier instead of declaring a partial 'closed'.
+    An unknown fill size is the full requested residual.  Reduce-only retries
+    cannot reverse the position, while assuming an ambiguous response completed
+    can make the kill-switch close local state around real venue exposure.
     """
-    if not isinstance(result, dict):
-        return 0.0
-    filled = result.get("filled_size")
-    if filled is None:
-        return 0.0  # unknown fill -> assume complete (preserve prior behavior)
-    try:
-        req = result.get("requested_size")
-        req_f = float(req) if req is not None else float(fallback_requested)
-        residual = req_f - abs(float(filled))
-    except (TypeError, ValueError):
-        return 0.0
-    dust = max(1e-9, abs(req_f) * 1e-6)
-    return residual if residual > dust else 0.0
+    from forven.execution_results import parse_close_receipt
+
+    receipt = parse_close_receipt(result, fallback_requested)
+    return receipt.residual_size
 
 
 def _close_result_error(result: object) -> str | None:

--- a/forven/execution_results.py
+++ b/forven/execution_results.py
@@ -1,0 +1,67 @@
+"""Small, shared parsers for exchange execution results.
+
+Live callers must agree on what constitutes a confirmed fill.  In particular,
+an IOC response without ``filled_size`` is ambiguous: it must never be treated
+as a complete close merely because the response lacks a top-level error.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+CloseOutcome = Literal["filled", "partial", "unfilled", "unknown"]
+
+
+@dataclass(frozen=True)
+class CloseReceipt:
+    outcome: CloseOutcome
+    requested_size: float
+    filled_size: float | None
+    residual_size: float
+    fill_price: float | None
+
+
+def _positive_float(value: object) -> float | None:
+    try:
+        parsed = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def parse_close_receipt(result: object, requested_size: float) -> CloseReceipt:
+    """Classify a reduce-only close result using confirmed venue quantities.
+
+    ``close_price`` and ``mid`` are deliberately ignored as fill prices: they
+    are request-time prices, not proof that an IOC executed.
+    """
+    requested = max(float(requested_size or 0.0), 0.0)
+    if not isinstance(result, dict):
+        return CloseReceipt("unknown", requested, None, requested, None)
+
+    fill_price = _positive_float(result.get("exit_price")) or _positive_float(result.get("fill_price"))
+    raw_filled = result.get("filled_size")
+    if raw_filled is None:
+        return CloseReceipt("unknown", requested, None, requested, fill_price)
+
+    try:
+        filled = max(float(raw_filled), 0.0)
+    except (TypeError, ValueError):
+        return CloseReceipt("unknown", requested, None, requested, fill_price)
+
+    filled = min(filled, requested) if requested > 0 else filled
+    residual = max(requested - filled, 0.0)
+    dust = max(1e-9, requested * 1e-6)
+    if filled <= dust:
+        outcome: CloseOutcome = "unfilled"
+    elif residual > dust:
+        outcome = "partial"
+    else:
+        outcome = "filled"
+        residual = 0.0
+    return CloseReceipt(outcome, requested, filled, residual, fill_price)
+
+
+__all__ = ["CloseReceipt", "parse_close_receipt"]

--- a/tests/test_engine_audit_phase1.py
+++ b/tests/test_engine_audit_phase1.py
@@ -68,6 +68,22 @@ def test_place_take_profit_fails_closed_on_rejection(monkeypatch):
     assert "take_profit_order_id" not in res
 
 
+def test_cancel_order_surfaces_nested_exchange_rejection(monkeypatch):
+    pytest.importorskip("hyperliquid")
+    import forven.exchange.hyperliquid as hl
+
+    class _Ex:
+        def cancel(self, *a, **k):
+            return {
+                "status": "ok",
+                "response": {"data": {"statuses": [{"error": "order not found"}]}},
+            }
+
+    _patch_hl(monkeypatch, hl, _Ex())
+    result = hl.cancel_order("BTC", 123)
+    assert result["error"] == "order not found"
+
+
 def test_market_order_keeps_fill_when_stop_leg_rejected(monkeypatch):
     pytest.importorskip("hyperliquid")
     import forven.exchange.hyperliquid as hl

--- a/tests/test_execution_results.py
+++ b/tests/test_execution_results.py
@@ -1,0 +1,39 @@
+import pytest
+
+from forven.execution_results import parse_close_receipt
+
+
+def test_confirmed_full_close_requires_filled_size():
+    receipt = parse_close_receipt(
+        {"exit_price": 101.0, "filled_size": 1.0}, requested_size=1.0
+    )
+    assert receipt.outcome == "filled"
+    assert receipt.residual_size == 0.0
+    assert receipt.fill_price == 101.0
+
+
+def test_partial_close_preserves_residual():
+    receipt = parse_close_receipt(
+        {"exit_price": 101.0, "filled_size": 0.4}, requested_size=1.0
+    )
+    assert receipt.outcome == "partial"
+    assert receipt.filled_size == pytest.approx(0.4)
+    assert receipt.residual_size == pytest.approx(0.6)
+
+
+def test_missing_filled_size_is_unknown_not_complete():
+    receipt = parse_close_receipt(
+        {"close_price": 97.0, "mid": 100.0}, requested_size=1.0
+    )
+    assert receipt.outcome == "unknown"
+    assert receipt.filled_size is None
+    assert receipt.residual_size == 1.0
+    assert receipt.fill_price is None
+
+
+def test_zero_fill_is_unfilled():
+    receipt = parse_close_receipt(
+        {"exit_price": None, "filled_size": 0.0}, requested_size=1.0
+    )
+    assert receipt.outcome == "unfilled"
+    assert receipt.residual_size == 1.0

--- a/tests/test_mtier_hardening.py
+++ b/tests/test_mtier_hardening.py
@@ -311,7 +311,7 @@ class TestKillSwitchSlippageM8:
     def test_residual_helper(self):
         from forven.exchange.risk import _close_residual_size
         assert _close_residual_size({"requested_size": 1.0, "filled_size": 0.3}, 1.0) == pytest.approx(0.7)
-        assert _close_residual_size({"requested_size": 1.0, "filled_size": None}, 1.0) == 0.0
+        assert _close_residual_size({"requested_size": 1.0, "filled_size": None}, 1.0) == 1.0
         assert _close_residual_size({"requested_size": 1.0, "filled_size": 1.0}, 1.0) == 0.0
 
     def test_no_fill_ioc_detected_as_error_so_escalation_fires(self):

--- a/tests/test_open_trades_exchange_verification.py
+++ b/tests/test_open_trades_exchange_verification.py
@@ -334,7 +334,8 @@ def test_force_close_trade_closes_exchange_backed_position(forven_db, monkeypatc
     monkeypatch.setattr(
         "forven.exchange.hyperliquid.close_position",
         lambda asset, size, side, testnet=True: {
-            "close_price": 110.0,
+            "exit_price": 110.0,
+            "filled_size": size,
             "order_id": "close-123",
         },
     )
@@ -375,6 +376,63 @@ def test_force_close_trade_closes_exchange_backed_position(forven_db, monkeypatc
     assert result["cancelled_reduce_only_orders"] == 1
     assert cancelled == [("BTC", 101, True)]
     assert logged and "exchange-backed position" in logged[0][2]
+
+
+def test_force_close_exchange_backed_unknown_fill_keeps_protection(forven_db, monkeypatch):
+    cancelled: list[int] = []
+    monkeypatch.setattr(
+        trading_domain,
+        "_extract_exchange_open_positions",
+        lambda testnet=True: [_sample_exchange_position()],
+    )
+    monkeypatch.setattr(
+        "forven.exchange.hyperliquid.close_position",
+        lambda *a, **k: {"close_price": 49_000.0, "order_id": "OID-UNKNOWN"},
+    )
+    monkeypatch.setattr(
+        "forven.exchange.hyperliquid.cancel_order",
+        lambda asset, oid, testnet=True: cancelled.append(oid) or {"ok": True},
+    )
+
+    result = trading_domain.force_close_trade(
+        "hl:testnet:BTC:long", SimpleNamespace(reason="unknown IOC outcome")
+    )
+
+    assert result["ok"] is False
+    assert result["pending_close_reconcile"] is True
+    assert result["residual_size"] == 1.0
+    assert cancelled == []
+
+
+def test_force_close_local_partial_fill_keeps_residual_open(forven_db, monkeypatch):
+    with get_db() as conn:
+        conn.execute(
+            """
+            INSERT INTO trades
+            (id, strategy, strategy_id, asset, direction, entry_price,
+             signal_entry_price, fill_entry_price, size, risk_pct, leverage,
+             status, execution_type, source, signal_data, opened_at)
+            VALUES ('T-PARTIAL', 'S-PARTIAL', 'S-PARTIAL', 'BTC', 'long',
+                    100, 100, 100, 1, 0.01, 1, 'OPEN', 'live', 'manual', '{}', datetime('now'))
+            """
+        )
+    monkeypatch.setattr(trading_domain, "_resolve_exchange_testnet", lambda: True)
+    monkeypatch.setattr(
+        "forven.exchange.hyperliquid.close_position",
+        lambda *a, **k: {"exit_price": 105.0, "filled_size": 0.4, "order_id": "OID-PART"},
+    )
+
+    result = trading_domain.force_close_trade(
+        "T-PARTIAL", SimpleNamespace(reason="partial IOC")
+    )
+
+    assert result["pending_close_reconcile"] is True
+    assert result["close_execution_outcome"] == "partial"
+    assert result["residual_size"] == 0.6
+    with get_db() as conn:
+        row = conn.execute("SELECT status, size, signal_data FROM trades WHERE id = 'T-PARTIAL'").fetchone()
+    assert row["status"] == "OPEN"
+    assert row["size"] == 0.6
 
 
 def test_force_close_route_raises_on_failure(forven_db, monkeypatch):

--- a/tests/test_paper_control.py
+++ b/tests/test_paper_control.py
@@ -108,6 +108,11 @@ def _force_cached_mid_in_manual_fills(monkeypatch):
 
     monkeypatch.setattr(md, "fetch_binance_prices", _venue_unavailable)
     monkeypatch.setattr(md, "resolve_market_data_source", lambda: "binance")
+    # Live manual opens must configure venue leverage before entry. Individual
+    # tests override this when exercising the fail-closed branch.
+    import forven.exchange.hyperliquid as hl
+
+    monkeypatch.setattr(hl, "set_leverage", lambda *a, **k: {"status": "ok"})
 
 
 def _get_trade(trade_id: str) -> dict | None:
@@ -347,7 +352,7 @@ def test_live_close_places_order_and_clean_reason(forven_db, monkeypatch):
 
     def _fake_close(asset, size, side="sell", testnet=True, **kw):
         calls["close"] = (asset, size, side)
-        return {"exit_price": 110.0, "order_id": "OID-EXIT"}
+        return {"exit_price": 110.0, "filled_size": size, "order_id": "OID-EXIT"}
 
     monkeypatch.setattr(hl, "close_position", _fake_close)
     monkeypatch.setattr(pc, "_live_testnet", lambda: True)
@@ -361,6 +366,50 @@ def test_live_close_places_order_and_clean_reason(forven_db, monkeypatch):
     assert sd["close_reason"] == "manual_close"
     assert not any(t in sd["close_reason"].lower() for t in SYNTHETIC_REASON_TOKENS)
     assert sd["exit_exchange_order_id"] == "OID-EXIT"
+
+
+def test_live_close_partial_fill_keeps_residual_open(forven_db, monkeypatch):
+    import forven.exchange.hyperliquid as hl
+
+    _insert_paper_strategy()
+    _insert_live_trade("L-PARTIAL", direction="long", size=1.0, entry_price=100.0)
+    _set_mid("BTC", 105.0)
+    monkeypatch.setattr(
+        hl,
+        "close_position",
+        lambda *a, **k: {"exit_price": 105.0, "filled_size": 0.4, "order_id": "OID-PART"},
+    )
+
+    pc.close_paper_position(STRATEGY_ID)
+
+    trade = _get_trade("L-PARTIAL")
+    assert trade["status"] == "OPEN"
+    assert trade["size"] == pytest.approx(0.6)
+    sd = json.loads(trade["signal_data"])
+    assert sd["pending_close_reconcile"] is True
+    assert sd["close_execution_outcome"] == "partial"
+    assert sd["close_residual_size"] == pytest.approx(0.6)
+
+
+def test_live_partial_close_books_only_confirmed_size(forven_db, monkeypatch):
+    import forven.exchange.hyperliquid as hl
+    from forven.db import get_db
+
+    _insert_paper_strategy()
+    _insert_live_trade("L-REDUCE", direction="long", size=2.0, entry_price=100.0)
+    _set_mid("BTC", 105.0)
+    monkeypatch.setattr(
+        hl,
+        "close_position",
+        lambda *a, **k: {"exit_price": 105.0, "filled_size": 0.4, "order_id": "OID-REDUCE"},
+    )
+
+    pc.partial_close_paper_position(STRATEGY_ID, pct=50.0)
+
+    assert _get_trade("L-REDUCE")["size"] == pytest.approx(1.6)
+    with get_db() as conn:
+        child = conn.execute("SELECT * FROM trades WHERE signal_data LIKE '%partial_of%'").fetchone()
+    assert dict(child)["size"] == pytest.approx(0.4)
 
 
 def test_live_open_respects_gate(forven_db, monkeypatch):
@@ -527,6 +576,153 @@ def test_live_open_places_market_order_and_registers(forven_db, monkeypatch):
     assert registered.get("called") is True
 
 
+def test_live_open_sets_leverage_before_market_order(forven_db, monkeypatch):
+    import forven.exchange.hyperliquid as hl
+
+    _insert_paper_strategy()
+    _set_mid("BTC", 100.0)
+    monkeypatch.setattr(pc, "_session_is_live", lambda session: True)
+    monkeypatch.setattr(pc.risk_mod, "can_open", lambda *a, **k: (True, 0.01, "ok"))
+    monkeypatch.setattr(pc.risk_mod, "register", lambda *a, **k: None)
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        hl,
+        "set_leverage",
+        lambda asset, leverage, **kw: calls.append(f"leverage:{asset}:{leverage}") or {"status": "ok"},
+    )
+    monkeypatch.setattr(
+        hl,
+        "market_order",
+        lambda asset, side, size, **kw: calls.append("market")
+        or {"entry_price": 100.0, "filled_size": size, "entry_order_id": "OID-LEV"},
+    )
+
+    pc.open_manual_position(
+        STRATEGY_ID, direction="long", size=1.0, leverage=3.0, stop_loss_price=95.0
+    )
+
+    assert calls == ["leverage:BTC:3.0", "market"]
+
+
+def test_live_open_unknown_fill_stays_pending_reconcile(forven_db, monkeypatch):
+    import forven.exchange.hyperliquid as hl
+    from forven.db import get_db
+
+    _insert_paper_strategy()
+    _set_mid("BTC", 100.0)
+    monkeypatch.setattr(pc, "_session_is_live", lambda session: True)
+    monkeypatch.setattr(pc.risk_mod, "can_open", lambda *a, **k: (True, 0.01, "ok"))
+    monkeypatch.setattr(pc.risk_mod, "register", lambda *a, **k: None)
+    monkeypatch.setattr(
+        hl,
+        "market_order",
+        lambda *a, **k: {
+            "entry_price": 103.0,
+            "filled_size": 1.0,
+            "entry_order_id": "OID-UNKNOWN",
+            "fill_price_unknown": True,
+        },
+    )
+
+    pc.open_manual_position(STRATEGY_ID, direction="long", size=1.0, stop_loss_price=95.0)
+
+    with get_db() as conn:
+        row = conn.execute(
+            "SELECT * FROM trades WHERE strategy_id = ? AND status = 'OPEN'", (STRATEGY_ID,)
+        ).fetchone()
+    trade = dict(row)
+    sd = json.loads(trade["signal_data"])
+    assert trade["entry_price"] == pytest.approx(100.0)
+    assert sd["pending_open_reconcile"] is True
+    assert sd["entry_finalization_state"] == "reconcile_required"
+    assert sd["open_fill_unconfirmed_price"] == pytest.approx(103.0)
+
+
+def test_live_open_leverage_failure_blocks_market_order(forven_db, monkeypatch):
+    import forven.exchange.hyperliquid as hl
+    from fastapi import HTTPException
+
+    _insert_paper_strategy()
+    _set_mid("BTC", 100.0)
+    monkeypatch.setattr(pc, "_session_is_live", lambda session: True)
+    monkeypatch.setattr(pc.risk_mod, "can_open", lambda *a, **k: (True, 0.01, "ok"))
+    monkeypatch.setattr(hl, "set_leverage", lambda *a, **k: {"error": "venue rejected"})
+    placed: list[bool] = []
+    monkeypatch.setattr(hl, "market_order", lambda *a, **k: placed.append(True))
+
+    with pytest.raises(HTTPException, match="Could not set exchange leverage"):
+        pc.open_manual_position(STRATEGY_ID, direction="long", size=1.0, stop_loss_price=95.0)
+    assert placed == []
+
+
+def test_live_open_db_failure_enters_recovery_and_pauses_path(forven_db, monkeypatch):
+    import forven.exchange.hyperliquid as hl
+    from fastapi import HTTPException
+
+    _insert_paper_strategy()
+    _set_mid("BTC", 100.0)
+    monkeypatch.setattr(pc, "_session_is_live", lambda session: True)
+    monkeypatch.setattr(pc.risk_mod, "can_open", lambda *a, **k: (True, 0.01, "ok"))
+    monkeypatch.setattr(
+        hl,
+        "market_order",
+        lambda *a, **k: {
+            "entry_price": 100.0,
+            "filled_size": 0.4,
+            "entry_order_id": "OID-ORPHAN",
+            "stop_order_id": "OID-PROTECTED",
+        },
+    )
+    monkeypatch.setattr(
+        pc,
+        "_open_trade_db_safe",
+        lambda **kw: (_ for _ in ()).throw(HTTPException(status_code=502, detail="db locked")),
+    )
+    recovery: dict = {}
+    monkeypatch.setattr(pc, "_recover_unpersisted_manual_entry", lambda **kw: recovery.update(kw))
+
+    with pytest.raises(HTTPException, match="db locked"):
+        pc.open_manual_position(STRATEGY_ID, direction="long", size=1.0, stop_loss_price=95.0)
+
+    assert recovery["entry_oid"] == "OID-ORPHAN"
+    assert recovery["stop_oid"] == "OID-PROTECTED"
+    assert recovery["size"] == pytest.approx(0.4)
+
+
+def test_unpersisted_manual_entry_pauses_and_emits_critical(forven_db, monkeypatch):
+    import forven.exchange.hyperliquid as hl
+    import forven.notifications as notifications
+    import forven.system_pause as system_pause
+
+    paused: list[bool] = []
+    emitted: dict = {}
+    monkeypatch.setattr(hl, "place_protective_stop", lambda *a, **k: {"error": "no position"})
+    monkeypatch.setattr(
+        system_pause, "set_system_paused", lambda value, **kw: paused.append(value) or {}
+    )
+    monkeypatch.setattr(
+        notifications, "emit_notification", lambda event_type, **kw: emitted.update(event_type=event_type, **kw)
+    )
+
+    pc._recover_unpersisted_manual_entry(
+        asset="BTC",
+        direction="long",
+        size=0.4,
+        stop_loss_price=95.0,
+        entry_oid="OID-ORPHAN",
+        stop_oid=None,
+        testnet=True,
+        vault=None,
+        reason="db locked",
+    )
+
+    assert paused == [True]
+    assert emitted["event_type"] == "trade_fill_persistence_failed"
+    assert emitted["severity"] == "critical"
+    assert emitted["dedupe_key"] == "manual-unpersisted:OID-ORPHAN"
+
+
 def test_live_adjust_stop_places_protective_stop(forven_db, monkeypatch):
     import forven.exchange.hyperliquid as hl
 
@@ -549,6 +745,57 @@ def test_live_adjust_stop_places_protective_stop(forven_db, monkeypatch):
     sd = json.loads(_get_trade("L200")["signal_data"])
     assert sd["stop_loss_price"] == 95.0
     assert sd["exchange_stop_order_id"] == "OID-STOP-2"
+
+
+def test_manual_stop_replace_places_before_cancel(forven_db, monkeypatch):
+    _insert_paper_strategy()
+    _insert_live_trade("L-STOP", direction="long", size=1.0, entry_price=100.0)
+    _set_mid("BTC", 100.0)
+    pc._update_open_trade_signal_data(
+        "L-STOP", {"exchange_stop_order_id": "OLD-STOP", "stop_loss_price": 94.0}
+    )
+    calls: list[str] = []
+    monkeypatch.setattr(
+        pc,
+        "_place_live_protective",
+        lambda *a, **k: calls.append("place") or "NEW-STOP",
+    )
+    monkeypatch.setattr(
+        pc,
+        "_cancel_live_order",
+        lambda *a, **k: calls.append("cancel") or True,
+    )
+
+    pc.adjust_stop_loss(STRATEGY_ID, price=95.0)
+
+    assert calls == ["place", "cancel"]
+    assert json.loads(_get_trade("L-STOP")["signal_data"])["exchange_stop_order_id"] == "NEW-STOP"
+
+
+def test_manual_stop_replace_failure_keeps_old_stop(forven_db, monkeypatch):
+    from fastapi import HTTPException
+
+    _insert_paper_strategy()
+    _insert_live_trade("L-STOP-FAIL", direction="long", size=1.0, entry_price=100.0)
+    _set_mid("BTC", 100.0)
+    pc._update_open_trade_signal_data(
+        "L-STOP-FAIL", {"exchange_stop_order_id": "OLD-STOP", "stop_loss_price": 94.0}
+    )
+    cancelled: list[str] = []
+    monkeypatch.setattr(
+        pc,
+        "_place_live_protective",
+        lambda *a, **k: (_ for _ in ()).throw(HTTPException(status_code=502, detail="rejected")),
+    )
+    monkeypatch.setattr(pc, "_cancel_live_order", lambda asset, oid, vault=None: cancelled.append(oid) or True)
+
+    with pytest.raises(HTTPException):
+        pc.adjust_stop_loss(STRATEGY_ID, price=95.0)
+
+    assert cancelled == []
+    sd = json.loads(_get_trade("L-STOP-FAIL")["signal_data"])
+    assert sd["exchange_stop_order_id"] == "OLD-STOP"
+    assert sd["stop_loss_price"] == pytest.approx(94.0)
 
 
 # ── Sub-account (direction book) routing ────────────────────────────────────
@@ -612,7 +859,7 @@ def test_live_close_routes_to_trade_book(forven_db, monkeypatch):
 
     def _fake_close(asset, size, side="sell", testnet=True, vault_address=None, **kw):
         seen["vault"] = vault_address
-        return {"exit_price": 90.0, "order_id": "OID-EXIT"}
+        return {"exit_price": 90.0, "filled_size": size, "order_id": "OID-EXIT"}
 
     monkeypatch.setattr(hl, "close_position", _fake_close)
 


### PR DESCRIPTION
## What changed

- require confirmed filled quantities before releasing live close state
- preserve residual size and pending reconciliation after partial or ambiguous IOC closes
- make kill-switch ambiguity retry/pending instead of assuming completion
- configure venue leverage before manual live entry
- mark unknown manual entry fills for reconciliation instead of fabricating an entry
- pause new opens, attempt emergency stop protection, and alert when a filled manual entry cannot be persisted
- replace manual protective orders place-before-cancel and retain failed cancellation IDs
- surface nested exchange cancellation errors
- add a dedicated capital-integrity CI lane

## Why

Several live callers implemented different definitions of a successful fill. Partial or response-shape-ambiguous IOC results could close local state while venue exposure remained, or remove protection before a replacement was confirmed. Manual live entry also did not set venue leverage and could lose local ownership after an exchange-first/database-second failure.

## Operator impact

Ambiguous outcomes now remain visible and reconcilable. Confirmed residual exposure stays OPEN and protected. Manual entry fails closed on leverage configuration and pauses further opens if local ownership cannot be established after an exchange response.

## Validation

- capital-integrity CI lane: 106 passed
- exchange/protective parity suites: 70 passed
- full tracked Python Ruff gate: passed
- diff whitespace check: passed

The unrelated local `outputs/` directory is not included.