### PR TITLE
fix: honest evaluation — 5 pipeline defects that killed strategies on infrastructure, not merit

### DIFF
--- a/forven/api_core.py
+++ b/forven/api_core.py
@@ -9469,9 +9469,19 @@ def _resolve_backtest_context_from_results(
 
 
 def _normalize_strategy_type(value: object) -> str | None:
-    normalized = str(value or "").strip().lower()
-    if not normalized:
+    raw = str(value or "").strip()
+    if not raw:
         return None
+    from forven.strategies.sandbox_proxy import is_sandbox_only_type
+
+    # Namespaced sandbox types are exact worker-registry keys: case-sensitive and
+    # never family-aliased. Lowercasing one breaks the worker lookup for a
+    # mixed-case imported module (silent 0-signal runs), and the family alias /
+    # *_orb collapse below would execute the WRONG builtin class for an imported
+    # strategy whose module name ends in a family token.
+    if is_sandbox_only_type(raw):
+        return raw
+    normalized = raw.lower()
     aliases = {
         "bb": "bollinger",
         "bollinger_band": "bollinger",
@@ -10328,7 +10338,7 @@ def post_backtest_preview(body: BacktestPreviewBody):
         row = _require_existing_strategy_row(requested)
         if isinstance(row, dict):
             base_params = _parse_strategy_params_blob(row.get("params")) or {}
-            explicit_type = row.get("type")
+            explicit_type = resolve_execution_strategy_type(row)
             if not (asset and asset.strip()):
                 asset = _extract_base_asset_symbol(str(row.get("symbol") or body.symbol))
     except Exception:
@@ -11327,7 +11337,7 @@ def post_optimization_submit(body: OptimizationSubmitBody):
                 base_params = dict(audit_params)
                 inferred_params_for_backfill = dict(audit_params)
     strategy_type = _resolve_backtesting_strategy_type(
-        explicit_type=strategy_row.get("type"),
+        explicit_type=resolve_execution_strategy_type(strategy_row),
         strategy_name=strategy_name or strategy_id,
         params=base_params,
         payload=body.definition_json,

--- a/forven/api_core.py
+++ b/forven/api_core.py
@@ -9596,6 +9596,37 @@ def _resolve_backtesting_strategy_type(
     return _normalize_strategy_type(_infer_strategy_type_from_name(strategy_name))
 
 
+def resolve_execution_strategy_type(strategy_row: object) -> str | None:
+    """Return the column that names the EXECUTABLE type for a strategies row.
+
+    Dropzone/imported strategies carry a bare ``type`` (the author's TYPE_NAME)
+    plus a namespaced ``runtime_type`` (``imported__<module>``) that routes
+    execution through the sandbox worker. Execution entry points must resolve
+    the runtime_type: the bare type's source file was moved to ``imported/`` at
+    registration, so resolving it scans ``custom/`` and lands on the orphan
+    guard.
+    """
+    from forven.strategies.sandbox_proxy import is_sandbox_only_type
+
+    if strategy_row is None:
+        return None
+
+    def _column(key: str) -> object:
+        try:
+            if isinstance(strategy_row, dict):
+                return strategy_row.get(key)
+            return strategy_row[key]
+        except (IndexError, KeyError, TypeError):
+            return None
+
+    runtime_type = str(_column("runtime_type") or "").strip()
+    if runtime_type and is_sandbox_only_type(runtime_type):
+        return runtime_type
+    bare = _column("type")
+    text = str(bare).strip() if bare is not None else ""
+    return text or None
+
+
 def _infer_strategy_context_from_task_audit(strategy_id: str) -> dict | None:
     target = str(strategy_id or "").strip()
     if not target:
@@ -10935,7 +10966,7 @@ def post_backtest_submit(body: BacktestSubmitBody, *, skip_auto_trash: bool = Fa
     requested_params = body.params if isinstance(body.params, dict) else {}
     merged_params = {**base_params, **requested_params}
     strategy_type = _resolve_backtesting_strategy_type(
-        explicit_type=strategy_row.get("type"),
+        explicit_type=resolve_execution_strategy_type(strategy_row),
         strategy_name=strategy_name or strategy_id,
         params=merged_params,
         payload=strategy_definition_json,
@@ -11935,7 +11966,8 @@ def post_backtesting_run(body: dict):
                 if _bt_leverage is None:
                     _bt_leverage = _coerce_float(merged_params.get("leverage"), None)
                 strategy_type = _resolve_backtesting_strategy_type(
-                    explicit_type=body.get("strategy_type") or (strategy_row.get("type") if strategy_row else None),
+                    explicit_type=body.get("strategy_type")
+                    or (resolve_execution_strategy_type(strategy_row) if strategy_row else None),
                     strategy_name=(strategy_row.get("name") if strategy_row else strategy_id) or strategy_id,
                     params=merged_params,
                     payload={

--- a/forven/brain.py
+++ b/forven/brain.py
@@ -29,6 +29,7 @@ from forven.db import (
     format_prefixed_id,
     _extract_numeric_suffix,
     update_display_id,
+    verify_evidence_before_reject,
     verify_fitness_before_archive,
     log_pipeline_container_transition,
 )
@@ -2010,7 +2011,14 @@ def transition_stage(
                 # leave the strategy non-canonical but still active.
                 clear_canonical_on_commit = True
 
-        # Guardrail #1: Verify fitness before archive (skip for force-bypass)
+        # Guardrail #1: Verify evidence before a terminal transition (skip for
+        # force-bypass). `rejected` is just as terminal as `archived` — without a
+        # guard a strategy that never produced metrics (orphaned runtime, infra
+        # failure) gets a no-evidence terminal reject (the S06890 case, 2026-07-11).
+        # `rejected` uses the evidence-only variant (no fitness-key requirement —
+        # gate-failure rejects legitimately carry metrics but no scored fitness).
+        # Real losing metrics still reject normally; a stuck no-metrics strategy is
+        # reaped by the 7-day quick_screen stale sweep.
         if normalized_target == "archived" and not force:
             can_archive, error_msg = verify_fitness_before_archive(strategy_id)
             if not can_archive:
@@ -2027,6 +2035,13 @@ def transition_stage(
                 details={"reason": reason, "actor": actor},
                 conn=conn,
             )
+        elif normalized_target == "rejected" and not force:
+            can_reject, error_msg = verify_evidence_before_reject(strategy_id)
+            if not can_reject:
+                return _record_blocked_transition(
+                    block_reason=error_msg,
+                    motion="archive_rejected_ghost_protection",
+                )
         elif normalized_target == "archived":
             event_reason = _build_retirement_reason(
                 current_stage=current_stage,

--- a/forven/db.py
+++ b/forven/db.py
@@ -7442,41 +7442,68 @@ def log_pipeline_container_transition(
         )
 
 
+def _terminal_evidence_error(
+    strategy_id: str,
+    *,
+    require_fitness: bool,
+    no_metrics_msg: str,
+    invalid_json_msg: str,
+    no_perf_msg: str,
+) -> str:
+    """Shared ghost-protection core for terminal transitions: returns the
+    blocking error message, or "" when the strategy carries real evidence.
+    One definition so the archive and reject guards can never drift on what
+    counts as evidence."""
+    with get_db() as conn:
+        row = conn.execute(
+            "SELECT metrics FROM strategies WHERE id = ?",
+            (strategy_id,),
+        ).fetchone()
+
+        if not row:
+            return f"Strategy {strategy_id} not found"
+
+        metrics_json = row[0]
+        if not metrics_json:
+            return no_metrics_msg
+
+        try:
+            metrics = json.loads(metrics_json) if isinstance(metrics_json, str) else metrics_json
+        except Exception:
+            return invalid_json_msg
+
+        if not isinstance(metrics, dict) or not metrics:
+            return no_metrics_msg
+
+        if require_fitness and metrics.get("fitness") is None:
+            return (
+                f"Strategy {strategy_id} has NULL fitness - archive REJECTED "
+                "(ghost container protection)"
+            )
+
+        # Critical performance metrics (handle both key name variants)
+        has_sharpe = metrics.get("sharpe") is not None or metrics.get("sharpe_ratio") is not None
+        has_return = metrics.get("total_return_pct") is not None or metrics.get("total_return") is not None
+        if not has_sharpe and not has_return:
+            return no_perf_msg
+
+        return ""
+
+
 def verify_fitness_before_archive(strategy_id: str) -> tuple[bool, str]:
     """
     Pre-Archival Metric Verification (Guardrail #1).
     REJECT archive if fitness is NULL or missing.
     Returns (can_archive, error_message).
     """
-    with get_db() as conn:
-        row = conn.execute(
-            "SELECT metrics FROM strategies WHERE id = ?",
-            (strategy_id,),
-        ).fetchone()
-        
-        if not row:
-            return False, f"Strategy {strategy_id} not found"
-        
-        metrics_json = row[0]
-        if not metrics_json:
-            return False, f"Strategy {strategy_id} has no metrics - archive REJECTED"
-        
-        try:
-            metrics = json.loads(metrics_json) if isinstance(metrics_json, str) else metrics_json
-        except Exception:
-            return False, f"Strategy {strategy_id} has invalid metrics JSON"
-        
-        fitness = metrics.get("fitness")
-        if fitness is None:
-            return False, f"Strategy {strategy_id} has NULL fitness - archive REJECTED (ghost container protection)"
-        
-        # Also check for critical metrics (handle both key name variants)
-        has_sharpe = metrics.get("sharpe") is not None or metrics.get("sharpe_ratio") is not None
-        has_return = metrics.get("total_return_pct") is not None or metrics.get("total_return") is not None
-        if not has_sharpe and not has_return:
-            return False, f"Strategy {strategy_id} has no valid performance metrics - archive REJECTED"
-
-        return True, ""
+    error = _terminal_evidence_error(
+        strategy_id,
+        require_fitness=True,
+        no_metrics_msg=f"Strategy {strategy_id} has no metrics - archive REJECTED",
+        invalid_json_msg=f"Strategy {strategy_id} has invalid metrics JSON",
+        no_perf_msg=f"Strategy {strategy_id} has no valid performance metrics - archive REJECTED",
+    )
+    return (error == ""), error
 
 
 def verify_evidence_before_reject(strategy_id: str) -> tuple[bool, str]:
@@ -7488,36 +7515,21 @@ def verify_evidence_before_reject(strategy_id: str) -> tuple[bool, str]:
     that never got a fair run (orphaned runtime, infra failure) must not be
     terminally rejected on the absence of evidence.
     Returns (can_reject, error_message)."""
-    with get_db() as conn:
-        row = conn.execute(
-            "SELECT metrics FROM strategies WHERE id = ?",
-            (strategy_id,),
-        ).fetchone()
-
-        if not row:
-            return False, f"Strategy {strategy_id} not found"
-
-        metrics_json = row[0]
-        if not metrics_json:
-            return False, f"Strategy {strategy_id} has no metrics - terminal reject blocked (ghost protection)"
-
-        try:
-            metrics = json.loads(metrics_json) if isinstance(metrics_json, str) else metrics_json
-        except Exception:
-            return False, f"Strategy {strategy_id} has invalid metrics JSON - terminal reject blocked"
-
-        if not isinstance(metrics, dict) or not metrics:
-            return False, f"Strategy {strategy_id} has no metrics - terminal reject blocked (ghost protection)"
-
-        has_sharpe = metrics.get("sharpe") is not None or metrics.get("sharpe_ratio") is not None
-        has_return = metrics.get("total_return_pct") is not None or metrics.get("total_return") is not None
-        if not has_sharpe and not has_return:
-            return False, (
-                f"Strategy {strategy_id} has no valid performance metrics - "
-                "terminal reject blocked (ghost protection)"
-            )
-
-        return True, ""
+    error = _terminal_evidence_error(
+        strategy_id,
+        require_fitness=False,
+        no_metrics_msg=(
+            f"Strategy {strategy_id} has no metrics - terminal reject blocked (ghost protection)"
+        ),
+        invalid_json_msg=(
+            f"Strategy {strategy_id} has invalid metrics JSON - terminal reject blocked"
+        ),
+        no_perf_msg=(
+            f"Strategy {strategy_id} has no valid performance metrics - "
+            "terminal reject blocked (ghost protection)"
+        ),
+    )
+    return (error == ""), error
 
 
 def detect_ghost_containers() -> list[dict]:

--- a/forven/db.py
+++ b/forven/db.py
@@ -7475,7 +7475,48 @@ def verify_fitness_before_archive(strategy_id: str) -> tuple[bool, str]:
         has_return = metrics.get("total_return_pct") is not None or metrics.get("total_return") is not None
         if not has_sharpe and not has_return:
             return False, f"Strategy {strategy_id} has no valid performance metrics - archive REJECTED"
-        
+
+        return True, ""
+
+
+def verify_evidence_before_reject(strategy_id: str) -> tuple[bool, str]:
+    """Ghost protection for the `rejected` terminal, mirroring
+    verify_fitness_before_archive WITHOUT the fitness-key requirement: `rejected`
+    is reached by gate failures where metrics exist but no fitness was ever
+    scored, so demanding the fitness key would block legitimate merit rejects.
+    Blocks only rejects with NO metrics / NO performance evidence — a strategy
+    that never got a fair run (orphaned runtime, infra failure) must not be
+    terminally rejected on the absence of evidence.
+    Returns (can_reject, error_message)."""
+    with get_db() as conn:
+        row = conn.execute(
+            "SELECT metrics FROM strategies WHERE id = ?",
+            (strategy_id,),
+        ).fetchone()
+
+        if not row:
+            return False, f"Strategy {strategy_id} not found"
+
+        metrics_json = row[0]
+        if not metrics_json:
+            return False, f"Strategy {strategy_id} has no metrics - terminal reject blocked (ghost protection)"
+
+        try:
+            metrics = json.loads(metrics_json) if isinstance(metrics_json, str) else metrics_json
+        except Exception:
+            return False, f"Strategy {strategy_id} has invalid metrics JSON - terminal reject blocked"
+
+        if not isinstance(metrics, dict) or not metrics:
+            return False, f"Strategy {strategy_id} has no metrics - terminal reject blocked (ghost protection)"
+
+        has_sharpe = metrics.get("sharpe") is not None or metrics.get("sharpe_ratio") is not None
+        has_return = metrics.get("total_return_pct") is not None or metrics.get("total_return") is not None
+        if not has_sharpe and not has_return:
+            return False, (
+                f"Strategy {strategy_id} has no valid performance metrics - "
+                "terminal reject blocked (ghost protection)"
+            )
+
         return True, ""
 
 

--- a/forven/gauntlet/status.py
+++ b/forven/gauntlet/status.py
@@ -118,6 +118,8 @@ def _latest_robustness_results(strategy_id: str) -> dict[str, dict[str, Any]]:
             (strategy_id,),
         ).fetchall()
 
+    from forven.policy import is_errored_validation_row, is_nonresult_wfa_row
+
     latest: dict[str, dict[str, Any]] = {}
     for row in rows:
         result_type = str(row["result_type"] or "").strip().lower()
@@ -126,6 +128,19 @@ def _latest_robustness_results(strategy_id: str) -> dict[str, dict[str, Any]]:
             continue
         metrics = _parse_json(row["metrics_json"], {})
         config = _parse_json(row["config_json"], {})
+        # Skip-don't-claim, mirroring the paper-gate extractor: an errored/
+        # timed-out row or a completed 0-fold walk_forward measured nothing and
+        # must not displace an older genuine result as "latest" — otherwise
+        # run_paper_promotion_gate merit-fails on a phantom verdict the policy
+        # gate itself would ignore. Pending/running rows still surface (this
+        # reader also drives the live status display).
+        if is_errored_validation_row(
+            metrics if isinstance(metrics, dict) else {},
+            config if isinstance(config, dict) else {},
+        ):
+            continue
+        if step_key == "walk_forward" and is_nonresult_wfa_row(metrics):
+            continue
         verdict = metrics.get("verdict") if isinstance(metrics, dict) else None
         # A walk-forward run where EVERY fold is below wfa_min_fold_trades judged
         # nothing — the window was too short for the strategy's trade rate. Its

--- a/forven/gauntlet/tasks.py
+++ b/forven/gauntlet/tasks.py
@@ -740,15 +740,21 @@ def _best_sweep_result(
         ).fetchall()
 
     best_tf = str(fallback_tf or "1h").strip() or "1h"
-    declared_tf = best_tf.lower()
+    # The author's declaration comes from the IMMUTABLE params (_timeframe) when
+    # available: strategies.timeframe (fallback_tf) is overwritten by
+    # _persist_quick_screen_winner, so after one legitimate crowning a re-sweep
+    # reading only the column would defend the previously-crowned timeframe
+    # instead of the author's.
+    declared_display = (
+        str((params or {}).get("_timeframe") or "").strip() or best_tf
+    )
+    declared_tf = declared_display.lower()
     best_result_id: str | None = None
     best_metrics: dict[str, Any] = {}
     best_score = float("-inf")
     best_sharpe = float("-inf")
     declared_score = float("-inf")
     declared_pick: tuple[str, str | None, dict[str, Any]] | None = None
-    declared_degen_pick: tuple[str, str | None, dict[str, Any]] | None = None
-    declared_degen_trades = -1.0
     # Least-degenerate fallback, used ONLY if no context clears the validity floor —
     # so a strategy that genuinely can't trade anywhere is judged (and failed) on its
     # most-traded context, never crowned by a lucky 4-trade slice.
@@ -777,9 +783,6 @@ def _best_sweep_result(
         # strategy's stored metrics (the gate then reads IS Sharpe 0.00 and rejects).
         # Such a slice can never be the sweep winner.
         if is_degenerate_backtest_metrics(metrics):
-            if tf.lower() == declared_tf and float(trades) > declared_degen_trades:
-                declared_degen_pick = (tf, rid, metrics)
-                declared_degen_trades = float(trades)
             continue
         score = sharpe * 10.0 + min(trades, 100.0) * 0.01 + total_return * 0.01
         if tf.lower() == declared_tf and score > declared_score:
@@ -789,20 +792,24 @@ def _best_sweep_result(
             best_score = score
             best_sharpe = float(sharpe)
             best_tf, best_result_id, best_metrics = tf, rid, metrics
-    # Prefer-declared bias (see docstring): an off-declared winner must BEAT the
-    # declared context and carry positive Sharpe, else the declared context stands.
+    # No context cleared the validity floor: judge on the most-traded context
+    # (never crowned by a lucky slice — see fb comment above).
+    if best_score == float("-inf"):
+        return fb_tf, fb_result_id, fb_metrics
+    # Prefer-declared bias (see docstring). Declared rows join the same global
+    # max, so when the winner is off-declared the load-bearing quality bar is
+    # POSITIVE Sharpe (the score comparison only breaks exact ties).
     if declared_pick is not None and best_tf.lower() != declared_tf:
         if not (best_score > declared_score and best_sharpe > 0.0):
             return declared_pick
-    if (
-        declared_pick is None
-        and declared_degen_pick is not None
-        and best_score != float("-inf")
-        and best_sharpe <= 0.0
-    ):
-        return declared_degen_pick
-    if best_score == float("-inf"):
-        return fb_tf, fb_result_id, fb_metrics
+    if declared_pick is None and best_sharpe <= 0.0:
+        # Every survivor is negative and the declared context is unmeasured
+        # (absent or degeneracy-skipped): return the declared timeframe
+        # UNMEASURED — no result id, no metrics — so the caller's gate takes the
+        # retryable missing-evidence path instead of judging/persisting a
+        # context the author never declared, or contaminating strategies.metrics
+        # with a degenerate lucky slice.
+        return declared_display, None, {}
     return best_tf, best_result_id, best_metrics
 
 

--- a/forven/gauntlet/tasks.py
+++ b/forven/gauntlet/tasks.py
@@ -714,7 +714,17 @@ def _best_sweep_result(
     author-declared/default timeframe. ``run_quick_screen_gate`` uses it (since the
     timeframe_sweep now runs before the gate, definition v3) and so does
     ``run_validation_optimization``. Rows with empty metrics are ignored; if none are
-    usable the fallback timeframe is returned with no result and empty metrics."""
+    usable the fallback timeframe is returned with no result and empty metrics.
+
+    Prefer-declared bias: the declared timeframe (``fallback_tf``) is the reference
+    context. A NON-declared timeframe wins the crown only when it beats the declared
+    context's score AND carries positive Sharpe — a negative off-declared context must
+    never displace the author's timeframe (S06895, 2026-07-11: the declared-4h row
+    missed the degeneracy floor by one trade and the strategy was crowned, judged,
+    and merit-archived on a Sharpe −2.40 1h context it never declared). When the
+    declared row exists but is degeneracy-skipped and every survivor is negative,
+    the declared context is returned rather than crowning a negative one. A genuinely
+    better positive off-declared timeframe still wins — the enhancement stands."""
     from forven.db import get_db
 
     with get_db() as conn:
@@ -730,9 +740,15 @@ def _best_sweep_result(
         ).fetchall()
 
     best_tf = str(fallback_tf or "1h").strip() or "1h"
+    declared_tf = best_tf.lower()
     best_result_id: str | None = None
     best_metrics: dict[str, Any] = {}
     best_score = float("-inf")
+    best_sharpe = float("-inf")
+    declared_score = float("-inf")
+    declared_pick: tuple[str, str | None, dict[str, Any]] | None = None
+    declared_degen_pick: tuple[str, str | None, dict[str, Any]] | None = None
+    declared_degen_trades = -1.0
     # Least-degenerate fallback, used ONLY if no context clears the validity floor —
     # so a strategy that genuinely can't trade anywhere is judged (and failed) on its
     # most-traded context, never crowned by a lucky 4-trade slice.
@@ -761,11 +777,30 @@ def _best_sweep_result(
         # strategy's stored metrics (the gate then reads IS Sharpe 0.00 and rejects).
         # Such a slice can never be the sweep winner.
         if is_degenerate_backtest_metrics(metrics):
+            if tf.lower() == declared_tf and float(trades) > declared_degen_trades:
+                declared_degen_pick = (tf, rid, metrics)
+                declared_degen_trades = float(trades)
             continue
         score = sharpe * 10.0 + min(trades, 100.0) * 0.01 + total_return * 0.01
+        if tf.lower() == declared_tf and score > declared_score:
+            declared_score = score
+            declared_pick = (tf, rid, metrics)
         if score > best_score:
             best_score = score
+            best_sharpe = float(sharpe)
             best_tf, best_result_id, best_metrics = tf, rid, metrics
+    # Prefer-declared bias (see docstring): an off-declared winner must BEAT the
+    # declared context and carry positive Sharpe, else the declared context stands.
+    if declared_pick is not None and best_tf.lower() != declared_tf:
+        if not (best_score > declared_score and best_sharpe > 0.0):
+            return declared_pick
+    if (
+        declared_pick is None
+        and declared_degen_pick is not None
+        and best_score != float("-inf")
+        and best_sharpe <= 0.0
+    ):
+        return declared_degen_pick
     if best_score == float("-inf"):
         return fb_tf, fb_result_id, fb_metrics
     return best_tf, best_result_id, best_metrics

--- a/forven/policy.py
+++ b/forven/policy.py
@@ -1006,34 +1006,51 @@ def _check_params_applied(strategy_id: str) -> tuple[bool, str]:
     return True, "Strategy params match optimization best params"
 
 
-def _latest_genuine_optimization_time(conn, strategy_id: str) -> str:
-    """Raw created_at of the newest optimization that actually COMPLETED.
+def _latest_genuine_result_time(conn, strategy_id: str, result_type: str) -> str:
+    """Raw created_at of the newest row of ``result_type`` that actually
+    COMPLETED (not pending/errored/timed-out/restart-killed).
 
-    A failed / restart-killed / still-running optimization row (e.g. "Server
-    restarted while job was running") measured nothing: letting it set the
-    ordering/freshness baseline spuriously invalidates every genuine
-    walk_forward run before it (the S06885 promotion deadlock, 2026-07-11).
-    Returns "" when no genuine optimization exists.
+    A non-result row measured nothing: letting it set an ordering/freshness
+    timestamp either spuriously invalidates every genuine run before it (a
+    restart-killed optimization vs a real walk_forward — the S06885 promotion
+    deadlock, 2026-07-11) or makes a stale surviving verdict look fresh (an
+    errored newer walk_forward masking that the verdict the gate actually reads
+    predates the optimization). Status/error are extracted in SQL — no
+    metric-blob fetch, no row cap; rows with unparseable JSON count as genuine,
+    matching the pre-fix readers. Returns "" when no genuine row exists.
     """
     rows = conn.execute(
-        """SELECT created_at, metrics_json, config_json FROM backtest_results
+        """SELECT created_at,
+                  CASE WHEN json_valid(COALESCE(metrics_json, ''))
+                       THEN LOWER(TRIM(COALESCE(json_extract(metrics_json, '$.status'), '')))
+                       ELSE '' END AS m_status,
+                  CASE WHEN json_valid(COALESCE(metrics_json, ''))
+                       THEN TRIM(COALESCE(json_extract(metrics_json, '$.error'), ''))
+                       ELSE '' END AS m_error,
+                  CASE WHEN json_valid(COALESCE(config_json, ''))
+                       THEN LOWER(TRIM(COALESCE(json_extract(config_json, '$.status'), '')))
+                       ELSE '' END AS c_status,
+                  CASE WHEN json_valid(COALESCE(config_json, ''))
+                       THEN TRIM(COALESCE(json_extract(config_json, '$.error'), ''))
+                       ELSE '' END AS c_error
+           FROM backtest_results
            WHERE strategy_id = ?
-             AND LOWER(TRIM(COALESCE(result_type, 'backtest'))) = 'optimization'
+             AND LOWER(TRIM(COALESCE(result_type, 'backtest'))) = ?
              AND (deleted_at IS NULL OR TRIM(COALESCE(deleted_at, '')) = '')
-           ORDER BY datetime(created_at) DESC LIMIT 50""",
-        (strategy_id,),
+           ORDER BY datetime(created_at) DESC""",
+        (strategy_id, str(result_type or "").strip().lower()),
     ).fetchall()
     for row in rows:
-        metrics_blob = _parse_json_blob(row["metrics_json"], {})
-        config_blob = _parse_json_blob(row["config_json"], {})
-        if not isinstance(metrics_blob, dict):
-            metrics_blob = {}
-        if not isinstance(config_blob, dict):
-            config_blob = {}
+        metrics_blob = {"status": row["m_status"], "error": row["m_error"]}
+        config_blob = {"status": row["c_status"], "error": row["c_error"]}
         if is_nonresult_validation_row(metrics_blob, config_blob):
             continue
         return str(row["created_at"] or "")
     return ""
+
+
+def _latest_genuine_optimization_time(conn, strategy_id: str) -> str:
+    return _latest_genuine_result_time(conn, strategy_id, "optimization")
 
 
 def _check_confirmation_backtest(strategy_id: str) -> tuple[bool, str]:
@@ -1069,48 +1086,27 @@ def _check_artifact_ordering(strategy_id: str, required_types: list[str] | None 
     """Verify artifacts were created in the correct order:
     multi-TF backtests → optimization → confirmation backtest → validation tests.
     """
-    with get_db() as conn:
-        rows = conn.execute(
-            """SELECT LOWER(TRIM(COALESCE(result_type, 'backtest'))) AS rt,
-                      MAX(datetime(created_at)) AS latest
-               FROM backtest_results
-               WHERE strategy_id = ?
-                 AND (deleted_at IS NULL OR TRIM(COALESCE(deleted_at, '')) = '')
-               GROUP BY LOWER(TRIM(COALESCE(result_type, 'backtest')))""",
-            (strategy_id,),
-        ).fetchall()
-
-        # The optimization baseline must be a GENUINE completed run — a failed/
-        # restart-killed row would spuriously flag every earlier walk_forward as
-        # stale. Normalize through SQLite datetime() so it compares against the
-        # MAX(datetime(...)) validation timestamps in the same format.
-        opt_time = ""
-        raw_opt_time = _latest_genuine_optimization_time(conn, strategy_id)
-        if raw_opt_time:
-            normalized = conn.execute(
-                "SELECT datetime(?) AS t", (raw_opt_time,)
-            ).fetchone()
-            opt_time = str((normalized["t"] if normalized else "") or "")
-
-    timestamps: dict[str, str] = {}
-    for row in rows:
-        rt = str(row["rt"] or "")
-        timestamps[rt] = str(row["latest"] or "")
-
-    # Check ordering: optimization before validation tests
+    # Check ordering: optimization before validation tests. BOTH sides of the
+    # comparison must be GENUINE completed runs: a failed/restart-killed
+    # optimization would spuriously flag every earlier walk_forward as stale,
+    # and an errored newer validation row would make a stale surviving verdict
+    # look correctly ordered. Raw created_at strings compare consistently
+    # (same column, same writer).
     required = {
         _canonicalize_gauntlet_verdict_test(rt)
         for rt in (required_types or [])
         if str(rt or "").strip()
     }
     validation_types = sorted(required) if required else list(_GAUNTLET_VALIDATION_TYPES)
-    for vt in validation_types:
-        vt_time = timestamps.get(vt, "")
-        if vt_time and opt_time and vt_time < opt_time:
-            return False, GateRejection(
-                f"Ordering violation: {vt} was run before optimization — re-run after optimization",
-                reason_code="stale_validation",
-            )
+    with get_db() as conn:
+        opt_time = _latest_genuine_optimization_time(conn, strategy_id)
+        for vt in validation_types:
+            vt_time = _latest_genuine_result_time(conn, strategy_id, vt)
+            if vt_time and opt_time and vt_time < opt_time:
+                return False, GateRejection(
+                    f"Ordering violation: {vt} was run before optimization — re-run after optimization",
+                    reason_code="stale_validation",
+                )
 
     return True, "Artifact ordering is correct"
 
@@ -1138,15 +1134,11 @@ def _check_validation_freshness(strategy_id: str, required_types: list[str] | No
     stale = []
     with get_db() as conn:
         for vt in validation_types:
-            row = conn.execute(
-                """SELECT created_at FROM backtest_results
-                   WHERE strategy_id = ?
-                     AND LOWER(TRIM(COALESCE(result_type, 'backtest'))) = ?
-                     AND (deleted_at IS NULL OR TRIM(COALESCE(deleted_at, '')) = '')
-                   ORDER BY datetime(created_at) DESC LIMIT 1""",
-                (strategy_id, vt),
-            ).fetchone()
-            if row and str(row["created_at"] or "") < baseline:
+            # Genuine rows only: an errored/timed-out newer re-run must not make
+            # the verdict the gate actually reads (an older genuine run) look
+            # fresh against the optimization baseline.
+            vt_time = _latest_genuine_result_time(conn, strategy_id, vt)
+            if vt_time and vt_time < baseline:
                 stale.append(vt)
 
     if stale:
@@ -2042,6 +2034,18 @@ _VALIDATION_NONRESULT_STATUSES = {
 }
 
 
+def is_errored_validation_row(metrics_blob: object, config_blob: object) -> bool:
+    """True when a persisted validation row ERRORED (failed/timed-out/crashed or
+    carries an error string) — it measured nothing and must never be read as a
+    merit verdict. Excludes pending/running rows: use is_nonresult_validation_row
+    where in-flight rows must also be skipped."""
+    metrics = metrics_blob if isinstance(metrics_blob, dict) else {}
+    config = config_blob if isinstance(config_blob, dict) else {}
+    status = str(metrics.get("status") or config.get("status") or "").strip().lower()
+    error_text = str(metrics.get("error") or config.get("error") or "").strip()
+    return bool(error_text) or status in _VALIDATION_NONRESULT_STATUSES
+
+
 def is_nonresult_validation_row(metrics_blob: object, config_blob: object) -> bool:
     """True when a persisted validation row is a NON-RESULT — pending, errored,
     timed out, or crashed — i.e. it measured nothing and must never be read as a
@@ -2054,11 +2058,10 @@ def is_nonresult_validation_row(metrics_blob: object, config_blob: object) -> bo
     status = str(metrics.get("status") or config.get("status") or "").strip().lower()
     if status in _VALIDATION_PENDING_STATUSES:
         return True
-    error_text = str(metrics.get("error") or config.get("error") or "").strip()
-    return bool(error_text) or status in _VALIDATION_NONRESULT_STATUSES
+    return is_errored_validation_row(metrics, config)
 
 
-def _is_nonresult_wfa_row(metrics_blob: object) -> bool:
+def is_nonresult_wfa_row(metrics_blob: object) -> bool:
     """True when a COMPLETED walk_forward row EXPLICITLY measured nothing: an
     empty splits list and zero OOS trades. Such a run carries no evidence in
     either direction.
@@ -2133,6 +2136,15 @@ def _extract_gauntlet_verdict_payloads(strategy_id: str, row, metrics: dict) -> 
             "SELECT params FROM strategies WHERE id = ?", (strategy_id,)
         ).fetchone()
 
+    # Parse configs ONCE (reused by both the preference partition and the main
+    # loop — this extractor runs per strategy per gate evaluation).
+    parsed_rows: list[tuple[object, dict]] = []
+    for result_row in rows:
+        config_blob = _parse_json_blob(result_row["config_json"], {})
+        if not isinstance(config_blob, dict):
+            config_blob = {}
+        parsed_rows.append((result_row, config_blob))
+
     # Prefer rows validated against the strategy's CURRENT params (the fingerprint
     # is stamped into each row's config at submission; see gauntlet/status.py's
     # staleness display). First-per-type-wins below then means "newest genuine
@@ -2150,28 +2162,20 @@ def _extract_gauntlet_verdict_payloads(strategy_id: str, row, metrics: dict) -> 
     if current_params_hash:
         matching = []
         others = []
-        for result_row in rows:
-            config_blob = _parse_json_blob(result_row["config_json"], {})
-            stamped = (
-                str(config_blob.get("params_hash") or "").strip()
-                if isinstance(config_blob, dict)
-                else ""
-            )
-            (matching if stamped == current_params_hash else others).append(result_row)
+        for pair in parsed_rows:
+            stamped = str(pair[1].get("params_hash") or "").strip()
+            (matching if stamped == current_params_hash else others).append(pair)
         if matching:
-            rows = matching + others
+            parsed_rows = matching + others
 
     stale_engine_types: set[str] = set()
-    for result_row in rows:
+    for result_row, config_blob in parsed_rows:
         normalized_type = _canonicalize_gauntlet_verdict_test(result_row["result_type"])
         if normalized_type in payloads or normalized_type in stale_engine_types:
             continue
         metrics_blob = _parse_json_blob(result_row["metrics_json"], {})
-        config_blob = _parse_json_blob(result_row["config_json"], {})
         if not isinstance(metrics_blob, dict):
             metrics_blob = {}
-        if not isinstance(config_blob, dict):
-            config_blob = {}
         # A verdict produced by a DIFFERENT engine version must never be compared
         # against fresh numbers. It CLAIMS its test type (so an even-older row or
         # the cached fallback blob cannot sneak in as the verdict) but contributes
@@ -2230,7 +2234,7 @@ def _extract_gauntlet_verdict_payloads(strategy_id: str, row, metrics: dict) -> 
         # signals). Skip it like an errored row so the newest GENUINE verdict
         # surfaces; a re-run with real folds that fails still displaces an older
         # pass, and legacy verdict-only rows (no splits key) stay honored.
-        if normalized_type == "walk_forward" and _is_nonresult_wfa_row(metrics_blob):
+        if normalized_type == "walk_forward" and is_nonresult_wfa_row(metrics_blob):
             continue
         payload = _validation_row_to_verdict_payload(normalized_type, metrics_blob, config_blob)
         legitimacy_payload = dict(config_blob)

--- a/forven/policy.py
+++ b/forven/policy.py
@@ -2014,6 +2014,28 @@ def _validation_row_to_verdict_payload(result_type: str, metrics: dict, config: 
     return {"status": status, "passed": status == "pass", "verdict": verdict}
 
 
+_VALIDATION_PENDING_STATUSES = {"pending", "queued", "running", "started", "submitted"}
+_VALIDATION_NONRESULT_STATUSES = {
+    "failed", "error", "errored", "cancelled", "canceled", "timeout", "timed_out", "crashed",
+}
+
+
+def is_nonresult_validation_row(metrics_blob: object, config_blob: object) -> bool:
+    """True when a persisted validation row is a NON-RESULT — pending, errored,
+    timed out, or crashed — i.e. it measured nothing and must never be read as a
+    merit verdict. Single source of truth shared by the paper-gate verdict
+    extractor and the robustness score recalculator so the two readers cannot
+    drift (the 2026-07-11 leak: the gate skipped errored rows but the score
+    recalc counted them as failed tests)."""
+    metrics = metrics_blob if isinstance(metrics_blob, dict) else {}
+    config = config_blob if isinstance(config_blob, dict) else {}
+    status = str(metrics.get("status") or config.get("status") or "").strip().lower()
+    if status in _VALIDATION_PENDING_STATUSES:
+        return True
+    error_text = str(metrics.get("error") or config.get("error") or "").strip()
+    return bool(error_text) or status in _VALIDATION_NONRESULT_STATUSES
+
+
 def _extract_gauntlet_verdict_payloads(strategy_id: str, row, metrics: dict) -> tuple[dict[str, object], str | None]:
     from forven.engine_provenance import is_stale_engine_artifact
 
@@ -2105,25 +2127,19 @@ def _extract_gauntlet_verdict_payloads(strategy_id: str, row, metrics: dict) -> 
             )
             stale_engine_types.add(normalized_type)
             continue
-        status = str(metrics_blob.get("status") or config_blob.get("status") or "").strip().lower()
-        if status in {"pending", "queued", "running", "started", "submitted"}:
-            continue
-        # An ERRORED validation job is a NON-RESULT, not a quality verdict — skip it
-        # exactly like a pending one. Example: a walk_forward that could not run because
-        # "lookback (210) exceeds available bars per split (84)" on an incompatible
-        # (e.g. stale-container 1d) timeframe, a worker crash, or a data gap. Such a row
-        # carries status='failed'/'error' + an `error` string and NO splits/verdict.
-        # Reading it as a verdict turns a missing run into a PHANTOM merit FAIL — folds
-        # default to 0 ("Walk-forward has 0 folds" S00552 reject), trades to 0
-        # (degenerate reject) — which then ARCHIVES a strategy whose genuine (succeeded)
-        # validation on the correct timeframe actually passed (the S03523 case: a valid
-        # 5-fold BTC-1h walk_forward existed, but the errored BTC-1d row drove the gate).
-        # Genuine PASS/FAIL verdicts use status='succeeded' with splits + a verdict and
-        # carry NO error field, so they are unaffected.
-        error_text = str(metrics_blob.get("error") or config_blob.get("error") or "").strip()
-        if error_text or status in {
-            "failed", "error", "errored", "cancelled", "canceled", "timeout", "timed_out", "crashed",
-        }:
+        # A PENDING or ERRORED validation job is a NON-RESULT, not a quality verdict —
+        # skip it. Example: a walk_forward that could not run because "lookback (210)
+        # exceeds available bars per split (84)" on an incompatible (e.g.
+        # stale-container 1d) timeframe, a worker crash, a timeout, or a data gap. Such
+        # a row carries status='failed'/'error' + an `error` string and NO
+        # splits/verdict. Reading it as a verdict turns a missing run into a PHANTOM
+        # merit FAIL — folds default to 0 ("Walk-forward has 0 folds" S00552 reject),
+        # trades to 0 (degenerate reject) — which then ARCHIVES a strategy whose
+        # genuine (succeeded) validation on the correct timeframe actually passed (the
+        # S03523 case: a valid 5-fold BTC-1h walk_forward existed, but the errored
+        # BTC-1d row drove the gate). Genuine PASS/FAIL verdicts use status='succeeded'
+        # with splits + a verdict and carry NO error field, so they are unaffected.
+        if is_nonresult_validation_row(metrics_blob, config_blob):
             continue
         payload = _validation_row_to_verdict_payload(normalized_type, metrics_blob, config_blob)
         legitimacy_payload = dict(config_blob)

--- a/forven/policy.py
+++ b/forven/policy.py
@@ -1006,6 +1006,36 @@ def _check_params_applied(strategy_id: str) -> tuple[bool, str]:
     return True, "Strategy params match optimization best params"
 
 
+def _latest_genuine_optimization_time(conn, strategy_id: str) -> str:
+    """Raw created_at of the newest optimization that actually COMPLETED.
+
+    A failed / restart-killed / still-running optimization row (e.g. "Server
+    restarted while job was running") measured nothing: letting it set the
+    ordering/freshness baseline spuriously invalidates every genuine
+    walk_forward run before it (the S06885 promotion deadlock, 2026-07-11).
+    Returns "" when no genuine optimization exists.
+    """
+    rows = conn.execute(
+        """SELECT created_at, metrics_json, config_json FROM backtest_results
+           WHERE strategy_id = ?
+             AND LOWER(TRIM(COALESCE(result_type, 'backtest'))) = 'optimization'
+             AND (deleted_at IS NULL OR TRIM(COALESCE(deleted_at, '')) = '')
+           ORDER BY datetime(created_at) DESC LIMIT 50""",
+        (strategy_id,),
+    ).fetchall()
+    for row in rows:
+        metrics_blob = _parse_json_blob(row["metrics_json"], {})
+        config_blob = _parse_json_blob(row["config_json"], {})
+        if not isinstance(metrics_blob, dict):
+            metrics_blob = {}
+        if not isinstance(config_blob, dict):
+            config_blob = {}
+        if is_nonresult_validation_row(metrics_blob, config_blob):
+            continue
+        return str(row["created_at"] or "")
+    return ""
+
+
 def _check_confirmation_backtest(strategy_id: str) -> tuple[bool, str]:
     """Verify a full backtest exists that was run AFTER the latest optimization.
 
@@ -1013,18 +1043,9 @@ def _check_confirmation_backtest(strategy_id: str) -> tuple[bool, str]:
     backtest that was soft-deleted by quality gates still counts.
     """
     with get_db() as conn:
-        opt_row = conn.execute(
-            """SELECT created_at FROM backtest_results
-               WHERE strategy_id = ?
-                 AND LOWER(TRIM(COALESCE(result_type, 'backtest'))) = 'optimization'
-                 AND (deleted_at IS NULL OR TRIM(COALESCE(deleted_at, '')) = '')
-               ORDER BY datetime(created_at) DESC LIMIT 1""",
-            (strategy_id,),
-        ).fetchone()
-        if not opt_row:
+        opt_time = _latest_genuine_optimization_time(conn, strategy_id)
+        if not opt_time:
             return False, "No optimization found — cannot verify confirmation backtest"
-
-        opt_time = str(opt_row["created_at"] or "")
         # Include trashed backtests — auto-trash quality gates should not
         # invalidate the fact that a confirmation backtest was run.
         bt_row = conn.execute(
@@ -1059,12 +1080,22 @@ def _check_artifact_ordering(strategy_id: str, required_types: list[str] | None 
             (strategy_id,),
         ).fetchall()
 
+        # The optimization baseline must be a GENUINE completed run — a failed/
+        # restart-killed row would spuriously flag every earlier walk_forward as
+        # stale. Normalize through SQLite datetime() so it compares against the
+        # MAX(datetime(...)) validation timestamps in the same format.
+        opt_time = ""
+        raw_opt_time = _latest_genuine_optimization_time(conn, strategy_id)
+        if raw_opt_time:
+            normalized = conn.execute(
+                "SELECT datetime(?) AS t", (raw_opt_time,)
+            ).fetchone()
+            opt_time = str((normalized["t"] if normalized else "") or "")
+
     timestamps: dict[str, str] = {}
     for row in rows:
         rt = str(row["rt"] or "")
         timestamps[rt] = str(row["latest"] or "")
-
-    opt_time = timestamps.get("optimization", "")
 
     # Check ordering: optimization before validation tests
     required = {
@@ -1093,16 +1124,7 @@ def _check_validation_freshness(strategy_id: str, required_types: list[str] | No
     actual param edits), which caused fresh validation tests to appear stale.
     """
     with get_db() as conn:
-        opt_row = conn.execute(
-            """SELECT created_at FROM backtest_results
-               WHERE strategy_id = ?
-                 AND LOWER(TRIM(COALESCE(result_type, 'backtest'))) = 'optimization'
-                 AND (deleted_at IS NULL OR TRIM(COALESCE(deleted_at, '')) = '')
-               ORDER BY datetime(created_at) DESC LIMIT 1""",
-            (strategy_id,),
-        ).fetchone()
-
-    baseline = str(opt_row["created_at"] or "") if opt_row else ""
+        baseline = _latest_genuine_optimization_time(conn, strategy_id)
 
     if not baseline:
         return True, "No optimization found — freshness check skipped"
@@ -2036,6 +2058,37 @@ def is_nonresult_validation_row(metrics_blob: object, config_blob: object) -> bo
     return bool(error_text) or status in _VALIDATION_NONRESULT_STATUSES
 
 
+def _is_nonresult_wfa_row(metrics_blob: object) -> bool:
+    """True when a COMPLETED walk_forward row EXPLICITLY measured nothing: an
+    empty splits list and zero OOS trades. Such a run carries no evidence in
+    either direction.
+
+    Distinct from is_nonresult_validation_row (errored/pending rows): this row
+    completes with status='succeeded' and no error — e.g. a run against an
+    orphaned runtime class emits zero signals and persists a 0-fold FAIL /
+    INSUFFICIENT verdict, which then displaces a genuine earlier pass as the
+    "latest" row (the S06885 case, 2026-07-11). Deliberately narrow:
+    - a re-run with REAL folds that genuinely fails must still displace an
+      older pass (degraded re-runs are never masked);
+    - a legacy verdict-only row (no `splits` key at all) is shape-unknown, not
+      measured-zero — its verdict stays honored;
+    - real-but-tiny folds keep the designed "insufficient evidence" handling."""
+    metrics = metrics_blob if isinstance(metrics_blob, dict) else {}
+    splits = metrics.get("splits")
+    if not isinstance(splits, list) or len(splits) > 0:
+        return False
+    aggregate_oos = metrics.get("aggregate_oos") if isinstance(metrics.get("aggregate_oos"), dict) else {}
+    oos_trades = (
+        metrics.get("total_oos_trades")
+        or metrics.get("oos_trades")
+        or aggregate_oos.get("total_trades")
+    )
+    try:
+        return float(oos_trades or 0.0) <= 0.0
+    except (TypeError, ValueError):
+        return True
+
+
 def _extract_gauntlet_verdict_payloads(strategy_id: str, row, metrics: dict) -> tuple[dict[str, object], str | None]:
     from forven.engine_provenance import is_stale_engine_artifact
 
@@ -2076,6 +2129,37 @@ def _extract_gauntlet_verdict_payloads(strategy_id: str, row, metrics: dict) -> 
             """,
             (strategy_id,),
         ).fetchall()
+        current_params_row = conn.execute(
+            "SELECT params FROM strategies WHERE id = ?", (strategy_id,)
+        ).fetchone()
+
+    # Prefer rows validated against the strategy's CURRENT params (the fingerprint
+    # is stamped into each row's config at submission; see gauntlet/status.py's
+    # staleness display). First-per-type-wins below then means "newest genuine
+    # current-params verdict, else newest genuine verdict" — a re-run scored on
+    # since-changed params cannot displace a current-params verdict. Unstamped
+    # legacy rows stay eligible as the fallback (never cry wolf on old history).
+    try:
+        from forven.util import params_fingerprint
+
+        current_params_hash = params_fingerprint(
+            current_params_row["params"] if current_params_row else None
+        )
+    except Exception:
+        current_params_hash = None
+    if current_params_hash:
+        matching = []
+        others = []
+        for result_row in rows:
+            config_blob = _parse_json_blob(result_row["config_json"], {})
+            stamped = (
+                str(config_blob.get("params_hash") or "").strip()
+                if isinstance(config_blob, dict)
+                else ""
+            )
+            (matching if stamped == current_params_hash else others).append(result_row)
+        if matching:
+            rows = matching + others
 
     stale_engine_types: set[str] = set()
     for result_row in rows:
@@ -2140,6 +2224,13 @@ def _extract_gauntlet_verdict_payloads(strategy_id: str, row, metrics: dict) -> 
         # BTC-1d row drove the gate). Genuine PASS/FAIL verdicts use status='succeeded'
         # with splits + a verdict and carry NO error field, so they are unaffected.
         if is_nonresult_validation_row(metrics_blob, config_blob):
+            continue
+        # A COMPLETED walk_forward with an explicitly EMPTY splits list and 0 OOS
+        # trades measured nothing (e.g. an orphaned-runtime re-run emitting zero
+        # signals). Skip it like an errored row so the newest GENUINE verdict
+        # surfaces; a re-run with real folds that fails still displaces an older
+        # pass, and legacy verdict-only rows (no splits key) stay honored.
+        if normalized_type == "walk_forward" and _is_nonresult_wfa_row(metrics_blob):
             continue
         payload = _validation_row_to_verdict_payload(normalized_type, metrics_blob, config_blob)
         legitimacy_payload = dict(config_blob)

--- a/forven/routers/robustness.py
+++ b/forven/routers/robustness.py
@@ -2172,21 +2172,28 @@ def _recalculate_robustness_score(strategy_id: str) -> None:
         if not rows:
             return
 
-        from forven.policy import load_pipeline_config
+        from forven.policy import is_nonresult_validation_row, load_pipeline_config
 
         gauntlet_cfg = load_pipeline_config().get("gauntlet", {})
         min_trades = int(gauntlet_cfg.get("min_trades", 10) or 10)
 
-        # Deduplicate by result_type (keep latest)
+        # Deduplicate by result_type (keep the latest GENUINE verdict). A pending or
+        # errored/timed-out row is a NON-RESULT: skip it without claiming the type so
+        # an older genuine verdict can still surface — mirroring the paper gate's
+        # extractor. Counting an infra failure as `passed=False` here dragged
+        # composite_robustness_score/robustness_tests_passed and the brain then
+        # archived on a phantom merit fail (2026-07-11).
         seen = set()
         tests: list[dict] = []
         for r in rows:
             rt = str(r["result_type"] or "").strip().lower()
             if rt in seen:
                 continue
-            seen.add(rt)
             metrics = _parse_json_object(r["metrics_json"])
             config = _parse_json_object(r["config_json"])
+            if is_nonresult_validation_row(metrics, config):
+                continue
+            seen.add(rt)
             passed_result, reason = _validation_row_passed(
                 rt,
                 metrics,

--- a/forven/routers/robustness.py
+++ b/forven/routers/robustness.py
@@ -442,27 +442,20 @@ def _load_strategy_row(strategy_id: str):
 
 
 def _extract_strategy_info(row) -> tuple[str, dict]:
-    from forven.strategies.sandbox_proxy import is_sandbox_only_type
-
     strategy_type: str = ""
-    # Imported/dropzone rows execute under their namespaced runtime_type; the
-    # bare `type` has no source in custom/ (moved to imported/ at registration)
-    # and resolves to the orphan guard.
     try:
-        runtime_type = str(row["runtime_type"] or "").strip()
+        explicit = row["strategy_type"]
     except (IndexError, KeyError):
-        runtime_type = ""
-    if runtime_type and is_sandbox_only_type(runtime_type):
-        strategy_type = runtime_type
-    if not strategy_type:
-        for col in ("strategy_type", "type"):
-            try:
-                value = row[col]
-                if value:
-                    strategy_type = str(value)
-                    break
-            except (IndexError, KeyError):
-                continue
+        explicit = None
+    if explicit:
+        strategy_type = str(explicit)
+    else:
+        # Single source of truth for the executable type: imported/dropzone rows
+        # run under their namespaced runtime_type (the bare `type` has no source
+        # in custom/ and resolves to the orphan guard).
+        from forven.api_core import resolve_execution_strategy_type
+
+        strategy_type = resolve_execution_strategy_type(row) or ""
 
     raw_params: str | dict = "{}"
     for col in ("params", "params_json", "definition_json"):
@@ -2172,7 +2165,11 @@ def _recalculate_robustness_score(strategy_id: str) -> None:
         if not rows:
             return
 
-        from forven.policy import is_nonresult_validation_row, load_pipeline_config
+        from forven.policy import (
+            is_nonresult_validation_row,
+            is_nonresult_wfa_row,
+            load_pipeline_config,
+        )
 
         gauntlet_cfg = load_pipeline_config().get("gauntlet", {})
         min_trades = int(gauntlet_cfg.get("min_trades", 10) or 10)
@@ -2183,15 +2180,36 @@ def _recalculate_robustness_score(strategy_id: str) -> None:
         # extractor. Counting an infra failure as `passed=False` here dragged
         # composite_robustness_score/robustness_tests_passed and the brain then
         # archived on a phantom merit fail (2026-07-11).
+        parsed = [
+            (
+                str(r["result_type"] or "").strip().lower(),
+                _parse_json_object(r["metrics_json"]),
+                _parse_json_object(r["config_json"]),
+            )
+            for r in rows
+        ]
+        # Mirror the paper-gate extractor's current-params preference: a re-run
+        # scored on since-changed params must not displace a current-params
+        # verdict here either (the two readers feed the same brain decisions).
+        current_hash = _current_params_hash(strategy_id)
+        if current_hash:
+            matching = [
+                p for p in parsed
+                if str((p[2] or {}).get("params_hash") or "").strip() == current_hash
+            ]
+            if matching:
+                parsed = matching + [p for p in parsed if p not in matching]
+
         seen = set()
         tests: list[dict] = []
-        for r in rows:
-            rt = str(r["result_type"] or "").strip().lower()
+        for rt, metrics, config in parsed:
             if rt in seen:
                 continue
-            metrics = _parse_json_object(r["metrics_json"])
-            config = _parse_json_object(r["config_json"])
             if is_nonresult_validation_row(metrics, config):
+                continue
+            # A completed 0-fold/0-trade walk_forward measured nothing — same
+            # rule as the paper-gate extractor (policy.is_nonresult_wfa_row).
+            if rt == "walk_forward" and is_nonresult_wfa_row(metrics):
                 continue
             seen.add(rt)
             passed_result, reason = _validation_row_passed(
@@ -2203,8 +2221,11 @@ def _recalculate_robustness_score(strategy_id: str) -> None:
             margin = _test_pass_margin(rt, metrics, config) if passed_result else 0.0
             tests.append({"type": rt, "passed": passed_result, "reason": reason, "margin": margin})
 
-        if not tests:
-            return
+        # NOTE: no early return when tests is empty — if every persisted row is a
+        # non-result the score below computes to 0 and OVERWRITES whatever stale
+        # composite was last written (matching the pre-fix net effect for the
+        # all-errored case; leaving a stale 100 standing would let the brain keep
+        # reading robustness no surviving evidence supports).
 
         # Denominator = the canonical REQUIRED test set, NOT just the tests that happen
         # to have a row. Counting only measured tests means a single passing test of N
@@ -2316,6 +2337,8 @@ def _collect_succeeded_validation_types(strategy_id: str) -> set[str]:
             """,
             (strategy_id,),
         ).fetchall()
+    from forven.policy import is_nonresult_validation_row, is_nonresult_wfa_row
+
     gauntlet_cfg = load_pipeline_config().get("gauntlet", {})
     min_trades = int(gauntlet_cfg.get("min_trades", 10) or 10)
     seen: set[str] = set()
@@ -2324,9 +2347,16 @@ def _collect_succeeded_validation_types(strategy_id: str) -> set[str]:
         rt = _canonicalize_required_validation_type(row["result_type"])
         if not rt or rt in seen:
             continue
-        seen.add(rt)
         metrics = _parse_json_object(row["metrics_json"])
         config = _parse_json_object(row["config_json"])
+        # Non-result rows must not CLAIM the type: a newer errored/0-fold re-run
+        # would otherwise hide an older genuine PASS from the auto-promotion
+        # reconcile (same skip semantics as the paper-gate extractor).
+        if is_nonresult_validation_row(metrics, config):
+            continue
+        if rt == "walk_forward" and is_nonresult_wfa_row(metrics):
+            continue
+        seen.add(rt)
         passed_result, _reason = _validation_row_passed(
             rt,
             metrics,
@@ -2357,6 +2387,8 @@ def _has_paper_readiness_artifacts(strategy_id: str) -> bool:
     if not rows:
         return False
 
+    from forven.policy import is_nonresult_validation_row, is_nonresult_wfa_row
+
     gauntlet_cfg = load_pipeline_config().get("gauntlet", {})
     min_trades = int(gauntlet_cfg.get("min_trades", 10) or 10)
     seen: set[str] = set()
@@ -2364,9 +2396,15 @@ def _has_paper_readiness_artifacts(strategy_id: str) -> bool:
         rt = _canonicalize_required_validation_type(row["result_type"])
         if rt in seen:
             continue
-        seen.add(rt)
         metrics = _parse_json_object(row["metrics_json"])
         config = _parse_json_object(row["config_json"])
+        # Same skip-don't-claim rule as the paper-gate extractor: an errored or
+        # 0-fold re-run must not hide an older genuine artifact.
+        if is_nonresult_validation_row(metrics, config):
+            continue
+        if rt == "walk_forward" and is_nonresult_wfa_row(metrics):
+            continue
+        seen.add(rt)
         if rt == "walk_forward":
             passed_result, _reason = _validation_row_passed(
                 rt,

--- a/forven/routers/robustness.py
+++ b/forven/routers/robustness.py
@@ -442,15 +442,27 @@ def _load_strategy_row(strategy_id: str):
 
 
 def _extract_strategy_info(row) -> tuple[str, dict]:
+    from forven.strategies.sandbox_proxy import is_sandbox_only_type
+
     strategy_type: str = ""
-    for col in ("strategy_type", "type"):
-        try:
-            value = row[col]
-            if value:
-                strategy_type = str(value)
-                break
-        except (IndexError, KeyError):
-            continue
+    # Imported/dropzone rows execute under their namespaced runtime_type; the
+    # bare `type` has no source in custom/ (moved to imported/ at registration)
+    # and resolves to the orphan guard.
+    try:
+        runtime_type = str(row["runtime_type"] or "").strip()
+    except (IndexError, KeyError):
+        runtime_type = ""
+    if runtime_type and is_sandbox_only_type(runtime_type):
+        strategy_type = runtime_type
+    if not strategy_type:
+        for col in ("strategy_type", "type"):
+            try:
+                value = row[col]
+                if value:
+                    strategy_type = str(value)
+                    break
+            except (IndexError, KeyError):
+                continue
 
     raw_params: str | dict = "{}"
     for col in ("params", "params_json", "definition_json"):

--- a/forven/strategies/backtest.py
+++ b/forven/strategies/backtest.py
@@ -10868,7 +10868,37 @@ def walk_forward(
         # here so every WFA caller (gauntlet run_walk_forward passes no window) honors it.
         duration_days = stage_backtest_duration_days("walk_forward", settings)
         minutes_per_bar = max(_timeframe_to_minutes(resolved_timeframe), 1)
-        total_bars = (duration_days * 24 * 60) // minutes_per_bar
+        if start_date or end_date:
+            # A DATED window (the gauntlet passes the optimizer's validation
+            # window) sizes by the SPAN: the loader slices by the dates, so a
+            # stage-days bar count is unrelated to the data actually loaded —
+            # it made the pre-load floor read a 3-year 1d span as "365 requested
+            # bars" and error before loading. The post-load len(df) check stays
+            # authoritative for what the lake really returned.
+            try:
+                from datetime import datetime as _dt
+                from datetime import timezone as _tz
+
+                def _parse_wfa_date(value: object) -> _dt | None:
+                    text = str(value or "").strip()
+                    if not text:
+                        return None
+                    parsed = _dt.fromisoformat(text.replace("Z", "+00:00"))
+                    if parsed.tzinfo is None:
+                        parsed = parsed.replace(tzinfo=_tz.utc)
+                    return parsed
+
+                span_start = _parse_wfa_date(start_date)
+                span_end = _parse_wfa_date(end_date) or _dt.now(_tz.utc)
+                if span_start is not None and span_end > span_start:
+                    span_days = (span_end - span_start).total_seconds() / 86400.0
+                    total_bars = max(int(span_days * 24 * 60) // minutes_per_bar, 1)
+                else:
+                    total_bars = (duration_days * 24 * 60) // minutes_per_bar
+            except Exception:  # noqa: BLE001 — unparseable dates fall back to stage days
+                total_bars = (duration_days * 24 * 60) // minutes_per_bar
+        else:
+            total_bars = (duration_days * 24 * 60) // minutes_per_bar
 
 
     

--- a/forven/strategies/backtest.py
+++ b/forven/strategies/backtest.py
@@ -10874,23 +10874,8 @@ def walk_forward(
     
 
 
-    if total_bars is not None and int(total_bars) < 420:
-        return {"error": f"Insufficient data for walk-forward: {int(total_bars)} bars requested (need 420+)"}
-    resolved_total_bars = max(int(total_bars), 420)
-
-    # Cap total bars for walk-forward to prevent excessive computation.
-    # For sub-hourly timeframes on large date ranges, the bar count can
-    # explode (e.g. 5m over 2 years ≈ 210K bars).  The bar-by-bar slow
-    # path is O(n) per split so 50K bars keeps runtime reasonable.
-    _WFA_MAX_BARS = 50_000
-    if resolved_total_bars > _WFA_MAX_BARS:
-        log.warning(
-            "Walk-forward capping bars from %d to %d for %s (%s)",
-            resolved_total_bars, _WFA_MAX_BARS, strategy_id, resolved_timeframe,
-        )
-        resolved_total_bars = _WFA_MAX_BARS
-
     # P25-1: WFA knobs from pipeline config (versioned, explicit), with settings fallback.
+    # Resolved BEFORE the minimum-bars gate — the window sizing below needs them.
     try:
         from forven.policy import load_pipeline_config as _load_wfa_config
         wfa_cfg = _load_wfa_config().get("walk_forward", {})
@@ -10907,12 +10892,20 @@ def walk_forward(
         else settings.get("walkforward_folds", wfa_cfg.get("n_folds", 5))
     )
 
+    resolved_total_bars = int(total_bars)
+
     # Trade-frequency-aware window floor (S05925): a defaulted window must give
     # every OOS fold a judgeable trade sample (wfa_min_fold_trades), or the fold
     # pass rate degenerates to coin flips — the stage calendar window handed a
     # ~3-trades/month 4h strategy folds of 1-3 OOS trades. Raise (never shrink)
     # the defaulted window to the recommendation; explicit caller windows are
     # untouched. The resolver caps itself at the same _WFA_MAX_BARS ceiling.
+    #
+    # This sizing MUST run before the minimum-bars gate below: at 1d the stage
+    # calendar window is bars==days, so a 365-day default is 365 bars — the old
+    # order returned "need 420+" before the lift could size 1d to its multi-year
+    # window, making every 1d strategy structurally un-promotable (2026-07-11:
+    # all five persisted "365 bars requested" WFA failures were 1d).
     if window_defaulted:
         try:
             from forven.wfa_window import recommended_wfa_window
@@ -10934,6 +10927,30 @@ def walk_forward(
                 resolved_total_bars = _rec_bars
         except Exception as exc:  # noqa: BLE001 — sizing must never break the run
             log.warning("WFA window recommendation failed for %s: %s", strategy_id, exc)
+        # Belt-and-braces: even if the recommender fails open, a DEFAULTED window
+        # is lifted to the fold floor rather than erroring — only explicit caller
+        # windows may fail the minimum-bars gate.
+        if resolved_total_bars < 420:
+            log.info(
+                "WFA window lifted to the 420-bar fold floor for %s (%s, was %d)",
+                strategy_id, resolved_timeframe, resolved_total_bars,
+            )
+            resolved_total_bars = 420
+
+    if resolved_total_bars < 420:
+        return {"error": f"Insufficient data for walk-forward: {int(resolved_total_bars)} bars requested (need 420+)"}
+
+    # Cap total bars for walk-forward to prevent excessive computation.
+    # For sub-hourly timeframes on large date ranges, the bar count can
+    # explode (e.g. 5m over 2 years ≈ 210K bars).  The bar-by-bar slow
+    # path is O(n) per split so 50K bars keeps runtime reasonable.
+    _WFA_MAX_BARS = 50_000
+    if resolved_total_bars > _WFA_MAX_BARS:
+        log.warning(
+            "Walk-forward capping bars from %d to %d for %s (%s)",
+            resolved_total_bars, _WFA_MAX_BARS, strategy_id, resolved_timeframe,
+        )
+        resolved_total_bars = _WFA_MAX_BARS
 
     resolved_fee_bps = float(
         fee_bps if fee_bps is not None

--- a/forven/strategies/registry.py
+++ b/forven/strategies/registry.py
@@ -499,7 +499,7 @@ def _ensure_active_db_strategy_modules() -> None:
         from forven.db import get_db
         with get_db() as conn:
             rows = conn.execute(
-                "SELECT type AS stype, source_ref FROM strategies "
+                "SELECT type AS stype, runtime_type AS rtype, source_ref FROM strategies "
                 "WHERE LOWER(TRIM(COALESCE(stage, ''))) IN "
                 "('paper', 'paper_trading', 'live_graduated', 'deployed', 'gauntlet', 'quick_screen') "
                 "AND LOWER(TRIM(COALESCE(status, ''))) NOT IN ('archived', 'rejected')"
@@ -510,10 +510,18 @@ def _ensure_active_db_strategy_modules() -> None:
     loaded = 0
     for row in rows:
         stype = str(row["stype"] or "").strip()
+        rtype = str(row["rtype"] or "").strip()
         # Untrusted-origin (imported, sandbox-only) types are NEVER imported into the
-        # trusted parent — their class lives only in the worker. Skip so this sweep
-        # can't even attempt an in-process import of an imported module.
-        if not stype or stype in _TYPE_MAP or stype.startswith(IMPORTED_TYPE_PREFIX):
+        # trusted parent — their class lives only in the worker. Dropzone rows carry
+        # the imported__ prefix in runtime_type while their bare `type` keeps the
+        # author's TYPE_NAME, so both columns must be checked or the sweep attempts a
+        # doomed forven.strategies.custom.dropzone_* import for every imported row.
+        if (
+            not stype
+            or stype in _TYPE_MAP
+            or stype.startswith(IMPORTED_TYPE_PREFIX)
+            or rtype.startswith(IMPORTED_TYPE_PREFIX)
+        ):
             continue
         src = str(row["source_ref"] or "").strip()
         if not src:

--- a/tests/test_broken_wfa_rerun_does_not_displace_pass.py
+++ b/tests/test_broken_wfa_rerun_does_not_displace_pass.py
@@ -133,3 +133,27 @@ def test_stale_params_rerun_does_not_shadow_current_params_pass(forven_db):
         "a re-run scored on since-changed params must not shadow the "
         "current-params verdict"
     )
+
+
+def test_gauntlet_status_reader_skips_broken_rerun(forven_db):
+    """The gauntlet status reader feeds run_paper_promotion_gate's merit
+    bucketing: the 0-fold completed re-run must not surface as the latest
+    walk_forward verdict there either (it merit-failed strategies the policy
+    gate itself would pass)."""
+    from forven.gauntlet.status import _latest_robustness_results
+
+    sid = "S-WFDSP4"
+    _insert_strategy(sid)
+    _insert_wf(sid, "wf-pass", "2026-07-11T10:00:00+00:00",
+               metrics=_genuine_pass_metrics(),
+               config={"status": "succeeded", "params_hash": _hash()})
+    _insert_wf(sid, "wf-broken", "2026-07-11T17:20:00+00:00",
+               metrics=_broken_zero_fold_metrics(),
+               config={"status": "succeeded", "params_hash": _hash()})
+
+    latest = _latest_robustness_results(sid)
+    wf = latest.get("walk_forward")
+    assert wf is not None
+    assert wf["result_id"] == "wf-pass", (
+        "status reader must surface the genuine pass, not the 0-fold re-run"
+    )

--- a/tests/test_broken_wfa_rerun_does_not_displace_pass.py
+++ b/tests/test_broken_wfa_rerun_does_not_displace_pass.py
@@ -1,0 +1,135 @@
+"""A COMPLETED walk_forward re-run that judged ZERO folds with ZERO OOS trades
+measured nothing — it must not displace a genuine earlier pass as the "latest"
+row. Live case S06885 (2026-07-11): a post-restart re-run against an orphaned
+runtime class emitted zero signals, completed with status='succeeded' and no
+error, and its 0-fold FAIL replaced a genuine 5-fold paper-tier pass — flipping
+the gate to "missing passing artifact". The honesty boundary: a re-run with
+REAL folds that genuinely fails MUST still displace the older pass, and a row
+validated against since-changed params must not shadow a current-params one."""
+
+from __future__ import annotations
+
+import json
+
+from forven.db import get_db
+from forven.policy import _extract_gauntlet_verdict_payloads
+from forven.util import params_fingerprint
+
+_PARAMS = {"kc_period": 10, "kc_mult": 3.0, "trend_period": 80}
+
+
+def _insert_strategy(sid: str):
+    with get_db() as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO strategies "
+            "(id, name, type, symbol, timeframe, params, metrics, status, owner, stage, "
+            " stage_changed_at, created_at, updated_at) "
+            "VALUES (?, ?, 'rsi_momentum', 'BTC', '4h', ?, '{}', 'gauntlet', 'brain', "
+            "'gauntlet', datetime('now'), datetime('now'), datetime('now'))",
+            (sid, sid, json.dumps(_PARAMS)),
+        )
+
+
+def _insert_wf(sid: str, rid: str, created_at: str, *, metrics: dict, config: dict):
+    with get_db() as conn:
+        conn.execute(
+            "INSERT INTO backtest_results "
+            "(result_id, strategy_id, result_type, symbol, timeframe, metrics_json, config_json, created_at) "
+            "VALUES (?, ?, 'walk_forward', 'BTC/USDT', '4h', ?, ?, ?)",
+            (rid, sid, json.dumps(metrics), json.dumps(config), created_at),
+        )
+
+
+def _genuine_pass_metrics() -> dict:
+    return {
+        "status": "succeeded",
+        "verdict": "PASS",
+        "splits": [{"out_of_sample": {"sharpe": 1.0, "total_trades": 15}} for _ in range(5)],
+        "aggregate_oos": {"sharpe": 0.9, "total_trades": 75},
+        "avg_is_sharpe": 0.87,
+        "avg_oos_sharpe": 0.42,
+    }
+
+
+def _broken_zero_fold_metrics() -> dict:
+    # Completed (no error, succeeded) but judged nothing: no splits, no trades.
+    return {
+        "status": "succeeded",
+        "verdict": "FAIL",
+        "splits": [],
+        "aggregate_oos": {"sharpe": 0.0, "total_trades": 0},
+        "total_oos_trades": 0,
+    }
+
+
+def _genuine_fail_metrics() -> dict:
+    return {
+        "status": "succeeded",
+        "verdict": "FAIL",
+        "splits": [{"out_of_sample": {"sharpe": -1.5, "total_trades": 14}} for _ in range(5)],
+        "aggregate_oos": {"sharpe": -1.4, "total_trades": 70},
+        "avg_is_sharpe": 0.2,
+        "avg_oos_sharpe": -1.4,
+    }
+
+
+def _hash() -> str:
+    return params_fingerprint(_PARAMS)
+
+
+def test_zero_fold_rerun_does_not_displace_pass(forven_db):
+    sid = "S-WFDSP1"
+    _insert_strategy(sid)
+    _insert_wf(sid, "wf-pass", "2026-07-11T10:00:00+00:00",
+               metrics=_genuine_pass_metrics(),
+               config={"status": "succeeded", "params_hash": _hash()})
+    # NEWER, same params, completed-but-empty (the orphaned-runtime shape).
+    _insert_wf(sid, "wf-broken", "2026-07-11T17:20:00+00:00",
+               metrics=_broken_zero_fold_metrics(),
+               config={"status": "succeeded", "params_hash": _hash()})
+
+    payloads, _overall = _extract_gauntlet_verdict_payloads(sid, {"verdict": ""}, {})
+    wf = payloads.get("walk_forward")
+    assert isinstance(wf, dict), "the genuine pass must be present"
+    assert int(wf.get("folds") or 0) == 5, "the 0-fold re-run must not displace the 5-fold pass"
+    assert wf.get("passed") is True
+
+
+def test_real_failing_rerun_still_displaces_pass(forven_db):
+    sid = "S-WFDSP2"
+    _insert_strategy(sid)
+    _insert_wf(sid, "wf-pass-old", "2026-07-11T10:00:00+00:00",
+               metrics=_genuine_pass_metrics(),
+               config={"status": "succeeded", "params_hash": _hash()})
+    _insert_wf(sid, "wf-real-fail", "2026-07-11T17:20:00+00:00",
+               metrics=_genuine_fail_metrics(),
+               config={"status": "succeeded", "params_hash": _hash()})
+
+    payloads, _overall = _extract_gauntlet_verdict_payloads(sid, {"verdict": ""}, {})
+    wf = payloads.get("walk_forward")
+    assert isinstance(wf, dict)
+    assert wf.get("passed") is False, (
+        "a re-run with REAL failing folds must displace the older pass — "
+        "degraded re-runs are never masked"
+    )
+
+
+def test_stale_params_rerun_does_not_shadow_current_params_pass(forven_db):
+    sid = "S-WFDSP3"
+    _insert_strategy(sid)
+    # Older run validated the CURRENT params and passed.
+    _insert_wf(sid, "wf-current-pass", "2026-07-11T10:00:00+00:00",
+               metrics=_genuine_pass_metrics(),
+               config={"status": "succeeded", "params_hash": _hash()})
+    # Newer REAL fail — but validated against different (since-reverted) params.
+    _insert_wf(sid, "wf-stale-fail", "2026-07-11T17:20:00+00:00",
+               metrics=_genuine_fail_metrics(),
+               config={"status": "succeeded", "params_hash": "0000deadbeef"})
+
+    payloads, _overall = _extract_gauntlet_verdict_payloads(sid, {"verdict": ""}, {})
+    wf = payloads.get("walk_forward")
+    assert isinstance(wf, dict)
+    assert wf.get("passed") is True, (
+        "a re-run scored on since-changed params must not shadow the "
+        "current-params verdict"
+    )

--- a/tests/test_dropzone_runtime_resolution.py
+++ b/tests/test_dropzone_runtime_resolution.py
@@ -96,3 +96,23 @@ def test_active_registration_sweep_skips_imported_rows(forven_db, monkeypatch):
         "dropzone_zz_dropzone_sweep_s63999_deadbeef0000"
         not in reg._FAILED_CUSTOM_MODULES
     )
+
+
+def test_normalize_passes_imported_types_through_unchanged():
+    """_normalize_strategy_type must never lowercase or family-alias a namespaced
+    sandbox type: the worker registry lookup is case-sensitive, and the *_orb
+    suffix collapse would execute the WRONG builtin class for an imported module
+    whose name ends in a family token."""
+    from forven.api_core import _normalize_strategy_type
+
+    assert (
+        _normalize_strategy_type("imported__dropzone_MyStrat_AB12cd34")
+        == "imported__dropzone_MyStrat_AB12cd34"
+    )
+    assert (
+        _normalize_strategy_type("imported__breakout_orb")
+        == "imported__breakout_orb"
+    )
+    # Non-imported behavior unchanged.
+    assert _normalize_strategy_type("Breakout_ORB") == "orb"
+    assert _normalize_strategy_type("bb") == "bollinger"

--- a/tests/test_dropzone_runtime_resolution.py
+++ b/tests/test_dropzone_runtime_resolution.py
@@ -1,0 +1,98 @@
+"""Dropzone/imported strategies must resolve to their namespaced runtime_type on
+execution paths. Registration stamps `type` = bare TYPE_NAME (whose source file is
+MOVED custom/ -> imported/) and `runtime_type` = `imported__dropzone_<name>_<hash>`.
+Resolving the bare type scans custom/ and lands on the orphan guard — the bug that
+orphaned the whole 2026-07-11 dropzone fleet on /api/backtesting/run, /api/backtests,
+and every /api/robustness/* path."""
+
+from datetime import datetime, timezone
+
+import forven.strategies.registry as reg
+from forven.api_core import resolve_execution_strategy_type
+from forven.db import get_db
+from forven.routers.robustness import _extract_strategy_info
+from forven.strategies.sandbox_proxy import is_sandbox_only_type
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def test_resolves_sandbox_only_via_runtime_type():
+    row = {
+        "id": "S-DZ1",
+        "type": "btc_kc_pullback_thrust_s63201",  # bare TYPE_NAME, archived-style suffix
+        "runtime_type": "imported__dropzone_btc_kc_pullback_thrust_s63201_b8fe84c3ed8a",
+        "sandbox_only": 1,
+    }
+    resolved = resolve_execution_strategy_type(row)
+    assert resolved == "imported__dropzone_btc_kc_pullback_thrust_s63201_b8fe84c3ed8a"
+    assert is_sandbox_only_type(resolved)
+
+
+def test_falls_back_to_bare_type_without_runtime_type():
+    assert resolve_execution_strategy_type({"type": "macd", "runtime_type": None}) == "macd"
+    assert resolve_execution_strategy_type({"type": "macd"}) == "macd"
+    # A non-imported runtime_type must not shadow the bare type.
+    assert (
+        resolve_execution_strategy_type({"type": "macd", "runtime_type": "macd"}) == "macd"
+    )
+    assert resolve_execution_strategy_type(None) is None
+    assert resolve_execution_strategy_type({"type": ""}) is None
+
+
+def test_robustness_extract_strategy_info_prefers_runtime_type():
+    row = {
+        "type": "sol_er_tsmom_s63191",
+        "runtime_type": "imported__dropzone_sol_er_tsmom_s63191_c258087bc4a0",
+        "params": '{"_asset": "SOL", "_timeframe": "4h"}',
+    }
+    strategy_type, params = _extract_strategy_info(row)
+    assert strategy_type == "imported__dropzone_sol_er_tsmom_s63191_c258087bc4a0"
+    assert params["_asset"] == "SOL"
+
+
+def test_robustness_extract_strategy_info_bare_type_unchanged():
+    row = {"type": "bollinger", "runtime_type": "", "params": "{}"}
+    strategy_type, _params = _extract_strategy_info(row)
+    assert strategy_type == "bollinger"
+
+
+def test_active_registration_sweep_skips_imported_rows(forven_db, monkeypatch):
+    """The parent sweep must never attempt an in-process import of an imported
+    module: the dropzone row's bare `type` lacks the imported__ prefix, so the
+    guard has to key on runtime_type too (pre-fix it tried
+    forven.strategies.custom.dropzone_* every discover() and quarantined it)."""
+    with get_db() as conn:
+        conn.execute(
+            "INSERT INTO strategies (id, name, type, runtime_type, symbol, timeframe, "
+            "params, metrics, status, owner, stage, stage_changed_at, created_at, "
+            "updated_at, source_ref, sandbox_only) "
+            "VALUES (?, ?, ?, ?, 'BTC', '4h', '{}', '{}', 'active', 'brain', "
+            "'quick_screen', ?, ?, ?, ?, 1)",
+            (
+                "S-DZSWEEP",
+                "dz",
+                "zz_dropzone_sweep_s63999",
+                "imported__dropzone_zz_dropzone_sweep_s63999_deadbeef0000",
+                _now(),
+                _now(),
+                _now(),
+                r"C:\somewhere\imported\dropzone_zz_dropzone_sweep_s63999_deadbeef0000.py",
+            ),
+        )
+        conn.commit()
+
+    attempted: list[str] = []
+
+    def _record(modname: str):
+        attempted.append(modname)
+        raise AssertionError(f"sweep tried to import {modname} in the parent")
+
+    monkeypatch.setattr(reg, "_load_custom_strategy_module", _record)
+    reg._ensure_active_db_strategy_modules()
+    assert attempted == []
+    assert (
+        "dropzone_zz_dropzone_sweep_s63999_deadbeef0000"
+        not in reg._FAILED_CUSTOM_MODULES
+    )

--- a/tests/test_ordering_ignores_failed_optimization.py
+++ b/tests/test_ordering_ignores_failed_optimization.py
@@ -100,3 +100,27 @@ def test_killed_only_optimization_reads_as_no_optimization(forven_db):
     ok, msg = _check_confirmation_backtest(sid)
     assert not ok
     assert "No optimization found" in str(msg)
+
+
+def test_errored_newer_wfa_does_not_make_stale_verdict_look_fresh(forven_db):
+    """Symmetry: the VALIDATION side of the freshness/ordering comparison must
+    also be genuine-only. An errored re-run newer than the optimization must not
+    make the surviving (pre-optimization) verdict look fresh - the gate reads
+    the OLD pass, so freshness must flag it stale."""
+    sid = "S-ORD4"
+    _insert_strategy(sid)
+    m, c = _GENUINE_WF
+    _insert_result(sid, "wf-old-pass", "walk_forward", "2026-07-11T08:00:00+00:00", metrics=m, config=c)
+    m, c = _GENUINE_OPT
+    _insert_result(sid, "opt-good", "optimization", "2026-07-11T10:00:00+00:00", metrics=m, config=c)
+    _insert_result(
+        sid, "wf-errored", "walk_forward", "2026-07-11T11:00:00+00:00",
+        metrics={"status": "failed", "error": "Timed out after 600s"},
+        config={"status": "failed", "error": "Timed out after 600s"},
+    )
+
+    ok, rejection = _check_validation_freshness(sid, ["walk_forward"])
+    assert not ok, "the surviving verdict predates the optimization - must read stale"
+    assert "Stale validation tests" in str(rejection)
+    ok, rejection = _check_artifact_ordering(sid, ["walk_forward"])
+    assert not ok

--- a/tests/test_ordering_ignores_failed_optimization.py
+++ b/tests/test_ordering_ignores_failed_optimization.py
@@ -1,0 +1,102 @@
+"""A FAILED / restart-killed / still-running optimization row must not set the
+ordering or freshness baseline. Pre-fix, the startup sweep's "Server restarted
+while job was running" optimization rows tripped "Ordering violation:
+walk_forward was run before optimization" against a genuine earlier
+walk_forward — deadlocking promotion because every re-run raced the gauntlet's
+next auto-queued (and again killed) optimization (S06885, 2026-07-11)."""
+
+from __future__ import annotations
+
+import json
+
+from forven.policy import (
+    _check_artifact_ordering,
+    _check_confirmation_backtest,
+    _check_validation_freshness,
+)
+from forven.db import get_db
+
+
+def _insert_strategy(sid: str):
+    with get_db() as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO strategies "
+            "(id, name, type, symbol, timeframe, params, metrics, status, owner, stage, "
+            " stage_changed_at, created_at, updated_at) "
+            "VALUES (?, ?, 'rsi_momentum', 'BTC', '4h', '{}', '{}', 'gauntlet', 'brain', "
+            "'gauntlet', datetime('now'), datetime('now'), datetime('now'))",
+            (sid, sid),
+        )
+
+
+def _insert_result(sid: str, rid: str, rtype: str, created_at: str, *, metrics: dict, config: dict):
+    with get_db() as conn:
+        conn.execute(
+            "INSERT INTO backtest_results "
+            "(result_id, strategy_id, result_type, symbol, timeframe, metrics_json, config_json, created_at) "
+            "VALUES (?, ?, ?, 'BTC/USDT', '4h', ?, ?, ?)",
+            (rid, sid, rtype, json.dumps(metrics), json.dumps(config), created_at),
+        )
+
+
+_GENUINE_OPT = ({"status": "succeeded", "sharpe_ratio": 1.0}, {"status": "succeeded"})
+_KILLED_OPT = (
+    {"status": "failed", "error": "Server restarted while job was running"},
+    {"status": "failed", "error": "Server restarted while job was running"},
+)
+_GENUINE_WF = (
+    {
+        "status": "succeeded",
+        "verdict": "PASS",
+        "splits": [{"out_of_sample": {"sharpe": 1.0, "total_trades": 12}} for _ in range(5)],
+        "aggregate_oos": {"sharpe": 0.9, "total_trades": 60},
+    },
+    {"status": "succeeded"},
+)
+
+
+def test_failed_optimization_does_not_trip_ordering(forven_db):
+    sid = "S-ORD1"
+    _insert_strategy(sid)
+    m, c = _GENUINE_OPT
+    _insert_result(sid, "opt-good", "optimization", "2026-07-11T10:00:00+00:00", metrics=m, config=c)
+    _insert_result(sid, "bt-confirm", "backtest", "2026-07-11T10:30:00+00:00",
+                   metrics={"status": "succeeded", "total_trades": 20}, config={"status": "succeeded"})
+    m, c = _GENUINE_WF
+    _insert_result(sid, "wf-good", "walk_forward", "2026-07-11T11:00:00+00:00", metrics=m, config=c)
+    # NEWER killed optimization — must not reset the baseline.
+    m, c = _KILLED_OPT
+    _insert_result(sid, "opt-killed", "optimization", "2026-07-11T12:00:00+00:00", metrics=m, config=c)
+
+    ok, msg = _check_artifact_ordering(sid, ["walk_forward"])
+    assert ok, f"ordering must ignore the killed optimization: {msg}"
+    ok, msg = _check_validation_freshness(sid, ["walk_forward"])
+    assert ok, f"freshness must ignore the killed optimization: {msg}"
+    ok, msg = _check_confirmation_backtest(sid)
+    assert ok, f"confirmation must key on the genuine optimization: {msg}"
+
+
+def test_genuine_newer_optimization_still_trips_ordering(forven_db):
+    sid = "S-ORD2"
+    _insert_strategy(sid)
+    m, c = _GENUINE_WF
+    _insert_result(sid, "wf-old", "walk_forward", "2026-07-11T09:00:00+00:00", metrics=m, config=c)
+    m, c = _GENUINE_OPT
+    _insert_result(sid, "opt-newer", "optimization", "2026-07-11T10:00:00+00:00", metrics=m, config=c)
+
+    ok, rejection = _check_artifact_ordering(sid, ["walk_forward"])
+    assert not ok, "a GENUINE optimization newer than walk_forward must still trip ordering"
+    assert "Ordering violation" in str(rejection)
+
+
+def test_killed_only_optimization_reads_as_no_optimization(forven_db):
+    sid = "S-ORD3"
+    _insert_strategy(sid)
+    m, c = _KILLED_OPT
+    _insert_result(sid, "opt-killed-only", "optimization", "2026-07-11T12:00:00+00:00", metrics=m, config=c)
+
+    ok, _msg = _check_validation_freshness(sid, ["walk_forward"])
+    assert ok, "freshness is skipped when no genuine optimization exists"
+    ok, msg = _check_confirmation_backtest(sid)
+    assert not ok
+    assert "No optimization found" in str(msg)

--- a/tests/test_reject_no_metrics_guarded.py
+++ b/tests/test_reject_no_metrics_guarded.py
@@ -1,0 +1,90 @@
+"""quick_screen -> rejected is a TERMINAL transition and must carry evidence.
+Pre-fix only `archived` had ghost protection, so the brain terminally rejected
+strategies that never produced metrics (S06890: orphaned runtime -> "has no
+metrics" -> rejected 41 minutes after registration, 2026-07-11). Real losing
+metrics must still reject normally, and force bypasses as before."""
+
+import json
+from datetime import datetime, timezone
+
+from forven.brain import transition_stage
+from forven.db import create_strategy_container, get_db, init_db
+
+
+def _create_strategy(metrics: dict | None) -> str:
+    init_db()
+    with get_db() as conn:
+        strategy_id, _display_id, _base_id = create_strategy_container(
+            conn=conn,
+            name="Reject Guard Test",
+            type_="rsi_momentum",
+            symbol="BTC/USDT",
+            timeframe="1h",
+            params={"rsi_period": 14},
+            stage="quick_screen",
+        )
+        conn.execute(
+            "UPDATE strategies SET metrics = ? WHERE id = ?",
+            (json.dumps(metrics) if metrics is not None else None, strategy_id),
+        )
+        conn.commit()
+    return strategy_id
+
+
+def _stage(strategy_id: str) -> str:
+    with get_db() as conn:
+        row = conn.execute(
+            "SELECT stage FROM strategies WHERE id = ?", (strategy_id,)
+        ).fetchone()
+    return str(row["stage"])
+
+
+def test_no_metrics_reject_is_blocked(forven_db):
+    strategy_id = _create_strategy(None)
+    transition_stage(
+        strategy_id,
+        "rejected",
+        reason="Strategy has no metrics - archive REJECTED",
+        actor="brain",
+    )
+    assert _stage(strategy_id) == "quick_screen", (
+        "a no-metrics strategy must not be terminally rejected"
+    )
+
+
+def test_empty_metrics_reject_is_blocked(forven_db):
+    strategy_id = _create_strategy({})
+    transition_stage(strategy_id, "rejected", reason="no evidence", actor="brain")
+    assert _stage(strategy_id) == "quick_screen"
+
+
+def test_real_losing_metrics_still_reject(forven_db):
+    strategy_id = _create_strategy(
+        {
+            "sharpe": -2.4,
+            "total_return_pct": -0.09,
+            "total_trades": 31,
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+    transition_stage(
+        strategy_id,
+        "rejected",
+        reason="Gate1: IS Sharpe negative",
+        actor="brain",
+    )
+    assert _stage(strategy_id) == "rejected", (
+        "a genuine merit reject (real metrics, no fitness key) must proceed"
+    )
+
+
+def test_force_bypasses_reject_guard(forven_db):
+    strategy_id = _create_strategy(None)
+    transition_stage(
+        strategy_id,
+        "rejected",
+        reason="operator force",
+        actor="ui",
+        force=True,
+    )
+    assert _stage(strategy_id) == "rejected"

--- a/tests/test_robustness_score_skips_nonresult_rows.py
+++ b/tests/test_robustness_score_skips_nonresult_rows.py
@@ -170,3 +170,108 @@ def test_recalc_missing_test_still_pulls_score_down(forven_db):
     score, passed = _score_fields(strategy_id)
     assert passed == 2
     assert score < 100.0
+
+
+def test_recalc_skips_zero_fold_wfa_and_surfaces_older_pass(forven_db):
+    """The S06885 shape via the SCORE path: a completed (no error) walk_forward
+    with an empty splits list and 0 OOS trades must not displace the older
+    genuine pass in _recalculate_robustness_score - same rule as the paper-gate
+    extractor, or the two readers drift again."""
+    strategy_id = _create_strategy()
+    _set_required_tests(["walk_forward", "param_jitter", "cost_stress"])
+
+    base = datetime(2026, 7, 11, 12, 0, 0, tzinfo=timezone.utc)
+    for i, (rt, (metrics, config)) in enumerate(_PASS_ROWS.items()):
+        _insert_result(
+            strategy_id,
+            result_id=f"{rt}-pass",
+            result_type=rt,
+            metrics=metrics,
+            config=config,
+            created_at=(base + timedelta(minutes=i)).isoformat(),
+        )
+    _insert_result(
+        strategy_id,
+        result_id="walk_forward-zerofold",
+        result_type="walk_forward",
+        metrics={
+            "status": "succeeded",
+            "verdict": "FAIL",
+            "splits": [],
+            "aggregate_oos": {"sharpe": 0.0, "total_trades": 0},
+        },
+        config={"status": "succeeded"},
+        created_at=(base + timedelta(hours=1)).isoformat(),
+    )
+
+    robustness_router._recalculate_robustness_score(strategy_id)
+    score, passed = _score_fields(strategy_id)
+    assert passed == 3, "0-fold completed WFA must not displace the genuine PASS"
+    assert score == 100.0
+
+
+def test_recalc_all_nonresult_rows_writes_zero_not_stale(forven_db):
+    """When EVERY persisted row is a non-result (all timed out), the recalc must
+    overwrite any previously-written score with 0 - leaving a stale 100 standing
+    would let the brain keep reading robustness no surviving evidence supports."""
+    strategy_id = _create_strategy()
+    _set_required_tests(["walk_forward", "param_jitter", "cost_stress"])
+
+    with get_db() as conn:
+        conn.execute(
+            "UPDATE strategies SET metrics = ? WHERE id = ?",
+            (
+                json.dumps(
+                    {
+                        "sharpe": 1.0,
+                        "composite_robustness_score": 100.0,
+                        "robustness_tests_passed": 3,
+                    }
+                ),
+                strategy_id,
+            ),
+        )
+        conn.commit()
+
+    base = datetime(2026, 7, 11, 12, 0, 0, tzinfo=timezone.utc)
+    for i, rt in enumerate(("walk_forward", "param_jitter", "cost_stress")):
+        _insert_result(
+            strategy_id,
+            result_id=f"{rt}-timeout",
+            result_type=rt,
+            metrics={"status": "failed", "error": "Timed out after 600s"},
+            config={"status": "failed", "error": "Timed out after 600s"},
+            created_at=(base + timedelta(minutes=i)).isoformat(),
+        )
+
+    robustness_router._recalculate_robustness_score(strategy_id)
+    score, passed = _score_fields(strategy_id)
+    assert passed == 0
+    assert score == 0.0
+
+
+def test_collect_succeeded_types_ignores_newer_errored_row(forven_db):
+    """_collect_succeeded_validation_types feeds the auto-promotion reconcile: a
+    newer errored row must not CLAIM the type and hide the older genuine PASS."""
+    strategy_id = _create_strategy()
+    base = datetime(2026, 7, 11, 12, 0, 0, tzinfo=timezone.utc)
+    metrics, config = _PASS_ROWS["walk_forward"]
+    _insert_result(
+        strategy_id,
+        result_id="wfa-pass",
+        result_type="walk_forward",
+        metrics=metrics,
+        config=config,
+        created_at=base.isoformat(),
+    )
+    _insert_result(
+        strategy_id,
+        result_id="wfa-errored",
+        result_type="walk_forward",
+        metrics={"status": "failed", "error": "Timed out after 600s"},
+        config={"status": "failed", "error": "Timed out after 600s"},
+        created_at=(base + timedelta(hours=1)).isoformat(),
+    )
+
+    succeeded = robustness_router._collect_succeeded_validation_types(strategy_id)
+    assert "walk_forward" in succeeded

--- a/tests/test_robustness_score_skips_nonresult_rows.py
+++ b/tests/test_robustness_score_skips_nonresult_rows.py
@@ -1,0 +1,172 @@
+"""An errored/timed-out robustness row is a NON-RESULT and must not be counted as a
+failed test by _recalculate_robustness_score. Pre-fix, a param_jitter "Timed out
+after 600s" (or a cost_stress 92s timeout) row was fed to _validation_row_passed as
+passed=False, dragging composite_robustness_score / robustness_tests_passed — the
+merit signals the brain reads — and strategies were archived on infra failures
+(2026-07-11 fleet casualties). A genuinely MISSING required test must still pull the
+score down (fixed canonical denominator)."""
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import forven.routers.robustness as robustness_router
+from forven.db import create_strategy_container, get_db, init_db
+
+
+def _create_strategy() -> str:
+    init_db()
+    with get_db() as conn:
+        strategy_id, _display_id, _base_id = create_strategy_container(
+            conn=conn,
+            name="Nonresult Test Strategy",
+            type_="rsi_momentum",
+            symbol="BTC/USDT",
+            timeframe="1h",
+            params={"rsi_period": 14},
+            stage="gauntlet",
+        )
+    return strategy_id
+
+
+def _insert_result(
+    strategy_id: str,
+    *,
+    result_id: str,
+    result_type: str,
+    metrics: dict,
+    config: dict,
+    created_at: str,
+) -> None:
+    with get_db() as conn:
+        conn.execute(
+            """
+            INSERT INTO backtest_results
+                (result_id, strategy_id, result_type, symbol, timeframe,
+                 metrics_json, config_json, created_at)
+            VALUES (?, ?, ?, 'BTC/USDT', '1h', ?, ?, ?)
+            """,
+            (
+                result_id,
+                strategy_id,
+                result_type,
+                json.dumps(metrics),
+                json.dumps(config),
+                created_at,
+            ),
+        )
+        conn.commit()
+
+
+def _set_required_tests(tests: list[str]) -> None:
+    with get_db() as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO kv (key, value) VALUES (?, ?)",
+            (
+                "forven:pipeline_thresholds",
+                json.dumps({"gauntlet": {"required_tests": tests, "min_trades": 10}}),
+            ),
+        )
+        conn.commit()
+
+
+def _score_fields(strategy_id: str) -> tuple[float, int]:
+    with get_db() as conn:
+        row = conn.execute(
+            "SELECT metrics FROM strategies WHERE id = ?", (strategy_id,)
+        ).fetchone()
+    metrics = json.loads(row["metrics"] or "{}")
+    return (
+        float(metrics.get("composite_robustness_score") or 0.0),
+        int(metrics.get("robustness_tests_passed") or 0),
+    )
+
+
+_PASS_ROWS = {
+    "walk_forward": (
+        {
+            "verdict": "PASS",
+            "splits": [
+                {"out_of_sample": {"sharpe": 0.8}},
+                {"out_of_sample": {"sharpe": 0.9}},
+            ],
+        },
+        {"status": "succeeded"},
+    ),
+    "param_jitter": (
+        {"verdict": "PASS", "n_iterations": 50, "pct_positive_sharpe": 0.9},
+        {"status": "succeeded"},
+    ),
+    "cost_stress": (
+        {
+            "verdict": "PASS",
+            "original": {"sharpe": 0.9, "total_trades": 40},
+            "stressed": {"sharpe": 0.6, "total_trades": 40},
+            "degradation_pct": 20.0,
+            "stressed_sharpe": 0.6,
+        },
+        {"status": "succeeded"},
+    ),
+}
+
+
+def test_recalc_skips_errored_row_and_surfaces_older_pass(forven_db):
+    strategy_id = _create_strategy()
+    _set_required_tests(["walk_forward", "param_jitter", "cost_stress"])
+
+    base = datetime(2026, 7, 11, 12, 0, 0, tzinfo=timezone.utc)
+    for i, (rt, (metrics, config)) in enumerate(_PASS_ROWS.items()):
+        _insert_result(
+            strategy_id,
+            result_id=f"{rt}-pass",
+            result_type=rt,
+            metrics=metrics,
+            config=config,
+            created_at=(base + timedelta(minutes=i)).isoformat(),
+        )
+    # A NEWER timed-out walk_forward (0 trades, error text) — the S06885 shape.
+    _insert_result(
+        strategy_id,
+        result_id="walk_forward-timeout",
+        result_type="walk_forward",
+        metrics={"status": "failed", "error": "Timed out after 600s", "total_trades": 0},
+        config={"status": "failed", "error": "Timed out after 600s"},
+        created_at=(base + timedelta(hours=1)).isoformat(),
+    )
+
+    robustness_router._recalculate_robustness_score(strategy_id)
+    score, passed = _score_fields(strategy_id)
+    assert passed == 3, "errored latest row must not displace the older genuine PASS"
+    assert score == 100.0
+
+
+def test_recalc_missing_test_still_pulls_score_down(forven_db):
+    strategy_id = _create_strategy()
+    _set_required_tests(["walk_forward", "param_jitter", "cost_stress"])
+
+    base = datetime(2026, 7, 11, 12, 0, 0, tzinfo=timezone.utc)
+    for i, rt in enumerate(("walk_forward", "param_jitter")):
+        metrics, config = _PASS_ROWS[rt]
+        _insert_result(
+            strategy_id,
+            result_id=f"{rt}-pass",
+            result_type=rt,
+            metrics=metrics,
+            config=config,
+            created_at=(base + timedelta(minutes=i)).isoformat(),
+        )
+    # cost_stress exists ONLY as an errored row: it must read as unmeasured
+    # (not counted passed, not counted failed) — and the fixed canonical
+    # denominator still drags the score below 100.
+    _insert_result(
+        strategy_id,
+        result_id="cost_stress-timeout",
+        result_type="cost_stress",
+        metrics={"status": "failed", "error": "Backtest timed out after 92s"},
+        config={"status": "failed", "error": "Backtest timed out after 92s"},
+        created_at=(base + timedelta(minutes=30)).isoformat(),
+    )
+
+    robustness_router._recalculate_robustness_score(strategy_id)
+    score, passed = _score_fields(strategy_id)
+    assert passed == 2
+    assert score < 100.0

--- a/tests/test_sweep_prefers_declared_timeframe.py
+++ b/tests/test_sweep_prefers_declared_timeframe.py
@@ -54,15 +54,65 @@ def _insert_bt(
 
 def test_declared_tf_wins_over_negative_offtf_when_declared_row_degenerate(forven_db):
     """S06895 reconstruction: declared-4h row degenerate by one trade; every
-    surviving off-declared context is negative -> declared 4h must be returned."""
+    surviving off-declared context is negative -> the declared 4h comes back
+    UNMEASURED (no result id, no metrics) so the gate retries on the declared
+    context instead of judging a hijacked negative one — and the degenerate
+    lucky slice never reaches strategies.metrics."""
     sid = "S-SWPD1"
     _insert_strategy(sid, "4h")
     _insert_bt(sid, "bt-4h", "4h", trades=9, sharpe=2.996, total_return=6.0, is_trades=33)
     _insert_bt(sid, "bt-1h", "1h", trades=31, sharpe=-2.40, total_return=-9.2, is_trades=94)
     _insert_bt(sid, "bt-15m", "15m", trades=156, sharpe=-8.485, total_return=-33.9, is_trades=268)
 
-    tf, rid, _metrics = _best_sweep_result(sid, "4h")
+    tf, rid, metrics = _best_sweep_result(sid, "4h")
     assert tf == "4h", f"negative off-declared context must not be crowned (got {tf})"
+    assert rid is None, "a degeneracy-skipped declared slice must not be crowned either"
+    assert metrics == {}
+
+
+def test_declared_row_absent_negative_survivors_returns_declared_unmeasured(forven_db):
+    """When the declared timeframe has NO row at all and every survivor is
+    negative, the declared timeframe comes back unmeasured — a negative
+    off-declared context is never crowned just because the declared run is
+    missing (the last unclosed corner of the S06895 class)."""
+    sid = "S-SWPD6"
+    _insert_strategy(sid, "4h")
+    _insert_bt(sid, "bt-1h", "1h", trades=31, sharpe=-2.40, total_return=-9.2, is_trades=94)
+    _insert_bt(sid, "bt-15m", "15m", trades=156, sharpe=-8.485, total_return=-33.9, is_trades=268)
+
+    tf, rid, metrics = _best_sweep_result(sid, "4h")
+    assert tf == "4h"
+    assert rid is None
+    assert metrics == {}
+
+
+def test_declared_tf_read_from_immutable_params_over_hijacked_column(forven_db):
+    """After a prior crowning persisted timeframe='1h' onto the strategy row,
+    the author's declaration must still come from params._timeframe — otherwise
+    the bias defends the previously-crowned context instead of the author's."""
+    from forven.engine_provenance import BACKTEST_ENGINE_VERSION
+
+    sid = "S-SWPD7"
+    strategy_params = {"_timeframe": "4h", "kc_period": 10}
+    _insert_strategy(sid, "1h")  # column already hijacked to 1h
+    _insert_bt(sid, "bt-4h", "4h", trades=30, sharpe=1.5, total_return=6.0)
+    _insert_bt(sid, "bt-1h", "1h", trades=100, sharpe=0.8, total_return=3.0)
+    with get_db() as conn:
+        conn.execute(
+            "UPDATE backtest_results SET config_json = ? WHERE strategy_id = ?",
+            (
+                json.dumps(
+                    {"engine_version": BACKTEST_ENGINE_VERSION, "params": strategy_params}
+                ),
+                sid,
+            ),
+        )
+        conn.commit()
+
+    tf, rid, _metrics = _best_sweep_result(
+        sid, "1h", params=strategy_params, since=None, as_of=None
+    )
+    assert tf == "4h", "params._timeframe must define the declared context"
     assert rid == "bt-4h"
 
 

--- a/tests/test_sweep_prefers_declared_timeframe.py
+++ b/tests/test_sweep_prefers_declared_timeframe.py
@@ -1,0 +1,125 @@
+"""The timeframe sweep must never crown a NEGATIVE off-declared context over the
+author's declared timeframe. Live case S06895 (2026-07-11, declared 4h): the
+declared-4h sweep row (9 trades, Sharpe +3.0) missed the flat 10-trade degeneracy
+floor by ONE trade, its pre-existing positive 4h rows were as_of-excluded, and the
+crown fell to a 31-trade 1h context at Sharpe −2.40 — the strategy was then
+merit-archived at a timeframe it never declared. A genuinely BETTER positive
+off-declared timeframe must still win (the best-of-N enhancement stands)."""
+
+from __future__ import annotations
+
+import json
+
+from forven.db import get_db
+from forven.gauntlet.tasks import _best_sweep_result
+
+
+def _insert_strategy(sid: str, timeframe: str = "4h"):
+    with get_db() as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO strategies "
+            "(id, name, type, symbol, timeframe, params, metrics, status, owner, stage, "
+            " stage_changed_at, created_at, updated_at) "
+            "VALUES (?, ?, 'rsi_momentum', 'BTC', ?, '{}', '{}', 'quick_screen', 'brain', "
+            "'quick_screen', datetime('now'), datetime('now'), datetime('now'))",
+            (sid, sid, timeframe),
+        )
+
+
+def _insert_bt(
+    sid: str,
+    rid: str,
+    tf: str,
+    *,
+    trades: int,
+    sharpe: float,
+    total_return: float = 0.0,
+    is_trades: int | None = None,
+    created_at: str = "2026-07-11T16:20:00+00:00",
+):
+    metrics = {
+        "total_trades": trades,
+        "sharpe_ratio": sharpe,
+        "total_return_pct": total_return,
+        "in_sample": {"total_trades": is_trades if is_trades is not None else max(trades - 2, 1)},
+    }
+    with get_db() as conn:
+        conn.execute(
+            "INSERT INTO backtest_results "
+            "(result_id, strategy_id, result_type, symbol, timeframe, metrics_json, config_json, created_at) "
+            "VALUES (?, ?, 'backtest', 'BTC', ?, ?, '{}', ?)",
+            (rid, sid, tf, json.dumps(metrics), created_at),
+        )
+
+
+def test_declared_tf_wins_over_negative_offtf_when_declared_row_degenerate(forven_db):
+    """S06895 reconstruction: declared-4h row degenerate by one trade; every
+    surviving off-declared context is negative -> declared 4h must be returned."""
+    sid = "S-SWPD1"
+    _insert_strategy(sid, "4h")
+    _insert_bt(sid, "bt-4h", "4h", trades=9, sharpe=2.996, total_return=6.0, is_trades=33)
+    _insert_bt(sid, "bt-1h", "1h", trades=31, sharpe=-2.40, total_return=-9.2, is_trades=94)
+    _insert_bt(sid, "bt-15m", "15m", trades=156, sharpe=-8.485, total_return=-33.9, is_trades=268)
+
+    tf, rid, _metrics = _best_sweep_result(sid, "4h")
+    assert tf == "4h", f"negative off-declared context must not be crowned (got {tf})"
+    assert rid == "bt-4h"
+
+
+def test_positive_offtf_still_beats_positive_declared(forven_db):
+    sid = "S-SWPD2"
+    _insert_strategy(sid, "4h")
+    _insert_bt(sid, "bt-4h", "4h", trades=30, sharpe=1.0, total_return=4.0)
+    _insert_bt(sid, "bt-1h", "1h", trades=100, sharpe=2.0, total_return=12.0)
+
+    tf, rid, _metrics = _best_sweep_result(sid, "4h")
+    assert tf == "1h", "a genuinely better positive off-declared TF must still win"
+    assert rid == "bt-1h"
+
+
+def test_declared_positive_beats_weaker_offtf(forven_db):
+    sid = "S-SWPD3"
+    _insert_strategy(sid, "4h")
+    _insert_bt(sid, "bt-4h", "4h", trades=30, sharpe=1.5, total_return=6.0)
+    _insert_bt(sid, "bt-1h", "1h", trades=100, sharpe=0.8, total_return=3.0)
+
+    tf, rid, _metrics = _best_sweep_result(sid, "4h")
+    assert tf == "4h"
+    assert rid == "bt-4h"
+
+
+def test_negative_offtf_never_displaces_positive_declared(forven_db):
+    """Even when the off-declared score is numerically higher (less negative /
+    more trades), a non-positive-Sharpe context cannot displace the declared TF."""
+    sid = "S-SWPD4"
+    _insert_strategy(sid, "4h")
+    _insert_bt(sid, "bt-4h", "4h", trades=12, sharpe=0.05, total_return=0.2)
+    _insert_bt(sid, "bt-1h", "1h", trades=100, sharpe=-0.01, total_return=1.5)
+
+    tf, _rid, _metrics = _best_sweep_result(sid, "4h")
+    assert tf == "4h"
+
+
+def test_asof_pinned_excludes_unpinned_rows(forven_db):
+    """The as_of currency pin is NOT relaxed: an as_of=None pre-existing row stays
+    excluded when the sweep runs pinned, even if it is the declared timeframe."""
+    sid = "S-SWPD5"
+    _insert_strategy(sid, "4h")
+    # Pre-existing positive declared-TF row WITHOUT the pin (config as_of absent
+    # and params mismatch is avoided by passing params={} + config {}).
+    _insert_bt(sid, "bt-4h-unpinned", "4h", trades=40, sharpe=2.5, total_return=9.0)
+    with get_db() as conn:
+        conn.execute(
+            "UPDATE backtest_results SET config_json = ? WHERE result_id = 'bt-4h-unpinned'",
+            (json.dumps({"base_params": {}, "as_of": None}),),
+        )
+        conn.commit()
+
+    tf, rid, metrics = _best_sweep_result(
+        sid, "4h", params={}, since=None, as_of="2026-07-11T16:04:08+00:00"
+    )
+    # The unpinned row must not be selected; with no eligible rows at all the
+    # fallback timeframe comes back with empty metrics.
+    assert rid is None
+    assert metrics == {}
+    assert tf == "4h"

--- a/tests/test_walk_forward.py
+++ b/tests/test_walk_forward.py
@@ -210,3 +210,34 @@ def test_walk_forward_explicit_small_window_still_floored(monkeypatch, forven_db
     )
 
     assert "bars requested (need 420+)" in str(result.get("error") or "")
+
+
+def test_walk_forward_dated_1d_window_sized_by_span(monkeypatch, forven_db):
+    """The gauntlet's post-optimization WFA passes the optimizer's validation
+    window as start/end dates. The bar count must derive from the SPAN - the
+    stage-days fallback read a multi-year dated 1d span as '365 requested bars'
+    and errored before loading anything."""
+
+    def _candles(*_args, **_kwargs):
+        return _fake_daily_ohlcv(1100)
+
+    monkeypatch.setattr("forven.strategies.backtest.load_backtest_candles", _candles)
+    monkeypatch.setattr(
+        "forven.api_core.stage_backtest_duration_days", lambda *_a, **_k: 365
+    )
+
+    result = walk_forward(
+        strategy_id="wf-1d-dated",
+        asset="BTC",
+        strategy_type="rsi_momentum",
+        params={},
+        timeframe="1d",
+        start_date="2023-07-01T00:00:00+00:00",
+        end_date="2026-07-01T00:00:00+00:00",
+        n_splits=2,
+    )
+
+    err = str(result.get("error") or "")
+    assert "bars requested (need 420+)" not in err, (
+        f"dated 1d span must size by the dates, got: {err}"
+    )

--- a/tests/test_walk_forward.py
+++ b/tests/test_walk_forward.py
@@ -105,3 +105,108 @@ def test_walk_forward_gap_reduces_effective_oos(monkeypatch, forven_db):
 
     assert baseline["aggregate_oos"]["trades"] >= 0
     assert gapped["aggregate_oos"]["trades"] >= 0
+
+
+def _fake_daily_ohlcv(n: int) -> pd.DataFrame:
+    base = pd.date_range(datetime.now(timezone.utc), periods=n, freq="D")
+    np.random.seed(7)
+    close = 100 + np.cumsum(np.random.randn(n) * 0.5)
+    return pd.DataFrame(
+        {
+            "open": close + 0.1,
+            "high": close + 0.5,
+            "low": close - 0.5,
+            "close": close,
+            "volume": 1_000,
+        },
+        index=base,
+    )
+
+
+def test_walk_forward_1d_defaulted_window_reaches_sizing(monkeypatch, forven_db):
+    """D4 regression (2026-07-11): at 1d, bars == days, so a 365-day stage window
+    is 365 bars. The old code returned "need 420+" BEFORE the trade-frequency
+    window lift could size 1d to its multi-year window — every 1d strategy was
+    structurally un-promotable through walk_forward (all five persisted "365 bars
+    requested" failures were 1d). A DEFAULTED window must reach the sizing."""
+    captured: dict[str, object] = {}
+
+    def _candles(*_args, **kwargs):
+        captured["total_bars"] = kwargs.get("total_bars") or kwargs.get("bars")
+        return _fake_daily_ohlcv(2400)
+
+    monkeypatch.setattr("forven.strategies.backtest.load_backtest_candles", _candles)
+    monkeypatch.setattr(
+        "forven.api_core.stage_backtest_duration_days", lambda *_a, **_k: 365
+    )
+    monkeypatch.setattr(
+        "forven.wfa_window.recommended_wfa_window",
+        lambda *_a, **_k: {
+            "window_bars": 2400,
+            "est_trades_per_month": 3.0,
+            "trade_rate_source": "test-stub",
+        },
+    )
+
+    result = walk_forward(
+        strategy_id="wf-1d-default",
+        asset="BTC",
+        strategy_type="rsi_momentum",
+        params={},
+        timeframe="1d",
+        n_splits=2,
+    )
+
+    err = str(result.get("error") or "")
+    assert "bars requested (need 420+)" not in err, (
+        f"defaulted 1d window must be sized before the fold floor, got: {err}"
+    )
+
+
+def test_walk_forward_1d_belt_lift_when_recommender_fails(monkeypatch, forven_db):
+    """If the trade-frequency recommender fails open, a DEFAULTED window is still
+    lifted to the 420-bar fold floor instead of erroring."""
+
+    def _candles(*_args, **_kwargs):
+        return _fake_daily_ohlcv(600)
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("recommender unavailable")
+
+    monkeypatch.setattr("forven.strategies.backtest.load_backtest_candles", _candles)
+    monkeypatch.setattr(
+        "forven.api_core.stage_backtest_duration_days", lambda *_a, **_k: 365
+    )
+    monkeypatch.setattr("forven.wfa_window.recommended_wfa_window", _boom)
+
+    result = walk_forward(
+        strategy_id="wf-1d-belt",
+        asset="BTC",
+        strategy_type="rsi_momentum",
+        params={},
+        timeframe="1d",
+        n_splits=2,
+    )
+
+    err = str(result.get("error") or "")
+    assert "bars requested (need 420+)" not in err
+
+
+def test_walk_forward_explicit_small_window_still_floored(monkeypatch, forven_db):
+    """Explicit caller windows are untouched by the lift: a too-small explicit
+    total_bars must still fail the minimum-bars gate."""
+
+    def _candles(*_args, **_kwargs):
+        return _fake_ohlcv(300)
+
+    monkeypatch.setattr("forven.strategies.backtest.load_backtest_candles", _candles)
+
+    result = walk_forward(
+        strategy_id="wf-explicit-small",
+        asset="BTC",
+        strategy_type="rsi_momentum",
+        params={},
+        total_bars=300,
+    )
+
+    assert "bars requested (need 420+)" in str(result.get("error") or "")


### PR DESCRIPTION
Five verified defects from the 2026-07-11 fleet run, each killing or blocking candidates for infrastructure reasons rather than merit. One commit per defect, independently revertable; each carries a regression test that mirrors its live failure. Guiding principle: **make evaluation honest — never relax a gate.** No new settings knobs, no schema changes.

| Commit | Defect | Live casualty |
|---|---|---|
| `fix(D1)` | Dropzone strategies orphan on backtest/robustness paths (`type` vs `runtime_type` split-brain) | Entire dropzone fleet; S06890 chain |
| `fix(D3)` | Robustness timeouts/errors counted as merit FAILs; no-metrics terminal rejects | S06890 (rejected 41 min after registration, never ran) |
| `fix(D5)` | Ordering gate counts failed/restart-killed optimizations; 0-fold WFA re-run displaces a genuine pass | S06885 (promotion deadlock; genuine 5-fold pass overwritten) |
| `fix(D2)` | Timeframe sweep crowns a negative off-declared context when the declared slice is degeneracy-skipped | S06895 (positive at declared 4h, archived at Sharpe −2.40 on 1h) |
| `fix(D4)` | 1d structurally un-promotable: 420-bar floor evaluated before the window sizing (bars==days at 1d) | S06881 ×2 + three older 1d strategies |

## What changed
- **D1**: `resolve_execution_strategy_type(row)` prefers `runtime_type` when sandbox-only, at `post_backtesting_run`, `post_backtest_submit`, and robustness `_extract_strategy_info`; the registry active-registration sweep guards on `runtime_type` too (stops doomed `custom.dropzone_*` imports every `discover()`). Registration stamping untouched (`test_ai_dropzone_intake.py` unchanged).
- **D3**: shared `is_nonresult_validation_row()` (extracted from the S03523 gate guard) now also drives `_recalculate_robustness_score` — errored/pending rows are skipped without claiming their type, so older genuine verdicts surface and infra failures read as *not-yet-measured*, never failed-on-merit; missing required tests still drag the score. Ghost protection extended to the `rejected` terminal via `verify_evidence_before_reject` (evidence-only — no fitness-key demand, so genuine merit rejects with real metrics proceed; force bypass preserved).
- **D5a**: `_check_artifact_ordering` / `_check_validation_freshness` / `_check_confirmation_backtest` key on `_latest_genuine_optimization_time` — a failed/killed/running optimization no longer resets the baseline; a genuine newer optimization still trips ordering.
- **D5b**: verdict selection prefers rows stamped with the strategy's CURRENT `params_hash` (unstamped legacy rows stay eligible as fallback), and a COMPLETED walk_forward with an explicitly empty splits list + 0 OOS trades is a non-result. Deliberately narrow: real failing folds still displace an older pass; legacy verdict-only rows stay honored.
- **D2**: `_best_sweep_result` prefer-declared bias — an off-declared timeframe wins only if it beats the declared context's score AND carries positive Sharpe; declared-degenerate + all-negative-survivors returns the declared context. Best-of-N enhancement stands; as_of pin and all-degenerate fallback unchanged.
- **D4**: WFA window sizing (knobs + `recommended_wfa_window` lift + a 420-bar belt for defaulted windows) hoisted above the minimum-bars gate; explicit caller windows still fail the gate; `_WFA_MAX_BARS` cap unchanged.

## Tests
6 new test files + extensions, 214 passed across the 22 affected suites locally, including the suites pinned as must-stay-green (`test_ai_dropzone_intake`, `test_errored_validation_not_merit_fail`, `test_sweep_degenerate_slice`, `test_wfa_window`, `test_two_tier_gate`, `test_engine_provenance`).

Known pre-existing failure (NOT touched, fails on main): `test_data_provenance.py::test_verdict_reader_refuses_stale_data_rows` — fixture pins `engine_version=2` while the repo constant has moved (same class as the date-drift failures).

## After merge
Backend restart to activate, then targeted re-adjudication of the casualties (S06895 first: `transition_stage(..., "quick_screen", force=False)` + workflow reset per `requeue_stale_engine_artifacts` conventions — archived→quick_screen is in the allowed map). Deliberately NOT an engine-version bump: no engine math changed, so a bump would falsely stale-flag all current verdicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)