### PR TITLE
fix: data-availability precheck trusts registration for sandbox-only strategies

### DIFF
--- a/forven/strategies/data_availability.py
+++ b/forven/strategies/data_availability.py
@@ -406,6 +406,27 @@ def evaluate_data_availability(
 
             cls = _resolve_strategy_class(strategy_type)
         if cls is None:
+            from forven.strategies.sandbox_proxy import is_sandbox_only_type
+
+            if is_sandbox_only_type(strategy_type):
+                # A sandbox-only (imported/dropzone) class is NEVER resolvable in
+                # the trusted parent — by design its code loads only in the
+                # worker. Its availability was already certified WITH the real
+                # class at registration (intake passes strategy_cls; a blocked
+                # verdict parks the strategy research_only at birth), so a
+                # sandbox strategy that reached the active funnel has passed
+                # this probe. Hard-blocking here re-blocked every certified
+                # dropzone strategy at quick_screen ("Cannot verify data
+                # availability ... could not be resolved", the S06890/S06895
+                # chain, 2026-07-11). The backtest itself still fails loudly on
+                # genuinely missing data.
+                who = strategy_id or strategy_type or "strategy"
+                result.ok = True
+                result.warnings.append(
+                    f"{who}: sandbox-only runtime — data availability certified at "
+                    "registration; parent-side class introspection skipped."
+                )
+                return result
             who = strategy_id or strategy_type or "strategy"
             return DataAvailabilityResult(
                 ok=False,

--- a/tests/test_sandbox_data_availability.py
+++ b/tests/test_sandbox_data_availability.py
@@ -1,0 +1,40 @@
+"""The runtime data-availability precheck must not hard-block sandbox-only
+(imported/dropzone) strategies just because their class cannot be resolved in
+the trusted parent — that is true BY DESIGN (the class loads only in the
+worker), and their availability was already certified with the real class at
+registration (a blocked verdict parks the strategy research_only at birth).
+Pre-fix, every certified dropzone strategy re-blocked at quick_screen with
+"Cannot verify data availability ... strategy class could not be resolved"
+(the S06890 no-metrics chain; S06895's re-adjudication stall, 2026-07-11).
+Non-sandbox unresolvable types keep the fail-closed hard block."""
+
+from forven.strategies.data_availability import evaluate_data_availability
+
+
+def test_sandbox_only_type_proceeds_with_warning(forven_db, monkeypatch):
+    monkeypatch.setattr(
+        "forven.strategies.backtest._resolve_strategy_class", lambda *_a, **_k: None
+    )
+    result = evaluate_data_availability(
+        "imported__dropzone_btc_funding_trend_align_s63123_b1d5025a517a",
+        "BTC",
+        "4h",
+        strategy_id="S06895",
+    )
+    assert result.blocked is False
+    assert result.ok is True
+    assert any("sandbox-only" in w for w in result.warnings)
+
+
+def test_non_sandbox_unresolvable_type_still_blocks(forven_db, monkeypatch):
+    monkeypatch.setattr(
+        "forven.strategies.backtest._resolve_strategy_class", lambda *_a, **_k: None
+    )
+    result = evaluate_data_availability(
+        "some_unknown_family",
+        "BTC",
+        "1h",
+        strategy_id="S-UNKNOWN",
+    )
+    assert result.blocked is True
+    assert "could not be resolved" in str(result.error)


### PR DESCRIPTION
Follow-up to #77 — the sixth (and last known) reader that blocked imported/dropzone strategies: `evaluate_data_availability` hard-blocked whenever the class could not be resolved in the parent, which is always true for sandbox-only runtimes (worker-held class, by design). Registration already certifies availability with the real class in hand and parks blocked designs `research_only` at birth, so an active-funnel sandbox strategy has passed this probe; the runtime precheck now proceeds with a warning for sandbox types instead of re-blocking them at quick_screen. Non-sandbox unresolvable types keep the fail-closed block.

Live casualty: S06895's re-adjudication stalled `blocked_runtime` on exactly this message (attempt 2/3) after the #77 deploy; S06890's "no metrics" terminal chain started here too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)