### PR TITLE
fix: quick-screen gate judges the declared timeframe when the sweep returns it unmeasured

### DIFF
--- a/forven/gauntlet/tasks.py
+++ b/forven/gauntlet/tasks.py
@@ -435,6 +435,50 @@ def _quick_screen_defer_to_optimization() -> bool:
         return False
 
 
+def _declared_tf_metrics_for_judgment(
+    strategy_id: str,
+    timeframe: str,
+    *,
+    params: dict[str, Any] | None,
+    since: str | None,
+    as_of: str | None,
+) -> dict[str, Any]:
+    """Newest current-artifact backtest metrics at the DECLARED timeframe, for the
+    quick-screen gate to JUDGE (never persist) when the sweep selector returned the
+    declared context unmeasured. Degenerate rows are eligible here on purpose: a
+    sparse declared slice is judged on its own numbers by the gate (whose
+    testing_mode deferral and downstream full-history robustness do the real
+    vetting) instead of the strategy being judged on an off-declared context or on
+    stale stored metrics. Returns {} when no current row exists at that timeframe."""
+    from forven.db import get_db
+
+    with get_db() as conn:
+        rows = conn.execute(
+            """
+            SELECT result_id, timeframe, metrics_json, config_json, created_at
+            FROM backtest_results
+            WHERE strategy_id = ?
+              AND LOWER(TRIM(COALESCE(result_type, 'backtest'))) = 'backtest'
+              AND LOWER(TRIM(COALESCE(timeframe, ''))) = ?
+              AND (deleted_at IS NULL OR TRIM(COALESCE(deleted_at, '')) = '')
+            ORDER BY datetime(created_at) DESC
+            """,
+            (strategy_id, str(timeframe or "").strip().lower()),
+        ).fetchall()
+    for row in rows:
+        if params is not None and not _current_sweep_artifact(
+            row,
+            params=params,
+            since=since,
+            as_of=as_of,
+        ):
+            continue
+        metrics = _loads(row["metrics_json"], {})
+        if isinstance(metrics, dict) and metrics:
+            return metrics
+    return {}
+
+
 def run_quick_screen_gate(workflow: dict[str, Any], step: dict[str, Any]) -> dict[str, Any]:
     settings = _workflow_settings(workflow)
     quick_cfg = settings.get("quick_screen") if isinstance(settings.get("quick_screen"), dict) else {}
@@ -457,12 +501,14 @@ def run_quick_screen_gate(workflow: dict[str, Any], step: dict[str, Any]) -> dic
         row = _strategy_row(strategy_id)
         fallback_tf = str(row.get("timeframe") or "") if row else ""
         row_params = _loads((row or {}).get("params"), {})
+        since = str(workflow.get("created_at") or "").strip() or None
+        as_of = _workflow_as_of(workflow)
         best_tf, _best_result_id, best_metrics = _best_sweep_result(
             strategy_id,
             fallback_tf or "1h",
             params=row_params if isinstance(row_params, dict) else {},
-            since=str(workflow.get("created_at") or "").strip() or None,
-            as_of=_workflow_as_of(workflow),
+            since=since,
+            as_of=as_of,
         )
         if best_metrics:
             metrics = best_metrics
@@ -470,6 +516,53 @@ def run_quick_screen_gate(workflow: dict[str, Any], step: dict[str, Any]) -> dic
             # brain guardrails (which read strategies.metrics) judge the best timeframe,
             # and every downstream step (optimization/confirmation/paper) runs on it.
             _persist_quick_screen_winner(strategy_id, best_tf, best_metrics)
+        elif str(best_tf or "").strip().lower() != (fallback_tf or "1h").strip().lower():
+            # The selector returned the DECLARED timeframe UNMEASURED: its slice was
+            # degenerate/absent and every off-declared survivor was negative. Judging
+            # screen_metrics here (produced on the stored, off-declared timeframe)
+            # would recreate the off-declared merit-fail one layer above the selector
+            # that just refused it (S06895 re-adjudication, 2026-07-11: gate failed
+            # on the 1h screen run after the selector correctly refused to crown 1h).
+            declared_metrics = _declared_tf_metrics_for_judgment(
+                strategy_id,
+                str(best_tf),
+                params=row_params if isinstance(row_params, dict) else {},
+                since=since,
+                as_of=as_of,
+            )
+            if declared_metrics:
+                # Judge the declared slice WITHOUT persisting it: it missed the
+                # degeneracy floor, so it must not contaminate strategies.metrics.
+                # The gate's own checks (and the testing_mode deferral) decide, and
+                # the full-history robustness suite remains the real judge downstream.
+                metrics = declared_metrics
+            else:
+                submit_note = "resubmitted declared-timeframe backtest"
+                try:
+                    from forven.api_core import BacktestSubmitBody, stage_backtest_duration_days
+
+                    _submit_backtest(
+                        BacktestSubmitBody(
+                            strategy_id=str(row["id"]) if row else strategy_id,
+                            strategy_name=(row or {}).get("name"),
+                            symbol=(row or {}).get("symbol") or "BTC/USDT",
+                            timeframe=str(best_tf),
+                            params=row_params if isinstance(row_params, dict) else {},
+                            duration_days=stage_backtest_duration_days("timeframe_sweep"),
+                            as_of=as_of,
+                        ),
+                        skip_auto_trash=True,
+                    )
+                except Exception as submit_exc:  # noqa: BLE001 — retry loop handles it
+                    submit_note = f"declared-timeframe resubmission failed: {submit_exc}"
+                return {
+                    "status": "blocked_runtime",
+                    "message": (
+                        f"declared-timeframe ({best_tf}) evidence missing — declared slice "
+                        f"absent and all off-declared contexts negative; {submit_note}"
+                    ),
+                    "retryable": True,
+                }
     except Exception as exc:  # noqa: BLE001 - enhancement must never break the gate
         log.warning(
             "quick_screen_gate: best-of-N selection failed for %s, using quick_screen result: %s",

--- a/tests/test_quick_screen_gate_declared_tf.py
+++ b/tests/test_quick_screen_gate_declared_tf.py
@@ -1,0 +1,139 @@
+"""When the sweep selector returns the DECLARED timeframe unmeasured (declared
+slice degenerate/absent, every off-declared survivor negative), the quick-screen
+gate must not fall back to judging metrics produced on an off-declared timeframe
+— that recreates the off-declared merit-fail one layer above the selector that
+just refused it. Live case S06895 (2026-07-11 re-adjudication): the selector
+correctly refused to crown the negative 1h context, the strategy row read 4h,
+and the gate then failed it on the 1h screen run anyway.
+
+Fixed behavior: judge the declared-timeframe row when one exists (WITHOUT
+persisting its degenerate metrics onto strategies.metrics), else block
+retryably and resubmit the declared-timeframe backtest."""
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import forven.gauntlet.tasks as gauntlet_tasks
+from forven.db import get_db
+from forven.engine_provenance import BACKTEST_ENGINE_VERSION
+from forven.gauntlet.store import create_or_get_workflow
+from forven.gauntlet.tasks import run_quick_screen_gate
+
+_PARAMS = {"_timeframe": "4h", "kc_period": 10}
+
+
+def _insert_strategy(strategy_id: str, *, metrics: dict | None) -> None:
+    now = datetime.now(timezone.utc)
+    stage_changed = (now - timedelta(days=1)).isoformat()
+    with get_db() as conn:
+        conn.execute(
+            """
+            INSERT INTO strategies
+                (id, name, type, symbol, timeframe, params, metrics, status, owner,
+                 stage, stage_changed_at, canonical, created_at, updated_at)
+            VALUES (?, ?, 'rsi_momentum', 'BTC', '1h', ?, ?, 'quick_screen', 'brain',
+                    'quick_screen', ?, 0, ?, ?)
+            """,
+            (
+                strategy_id,
+                strategy_id,
+                json.dumps(_PARAMS),
+                json.dumps(metrics) if metrics is not None else None,
+                stage_changed,
+                stage_changed,
+                stage_changed,
+            ),
+        )
+        conn.commit()
+
+
+def _insert_bt(
+    strategy_id: str,
+    rid: str,
+    tf: str,
+    *,
+    trades: int,
+    sharpe: float,
+    total_return: float,
+    is_trades: int = 20,
+    as_of: str | None = None,
+) -> None:
+    metrics = {
+        "total_trades": trades,
+        "sharpe_ratio": sharpe,
+        "total_return_pct": total_return,
+        "in_sample": {"total_trades": is_trades},
+    }
+    config = {"engine_version": BACKTEST_ENGINE_VERSION, "params": _PARAMS}
+    if as_of:
+        config["as_of"] = as_of
+    created = (datetime.now(timezone.utc) + timedelta(minutes=1)).isoformat()
+    with get_db() as conn:
+        conn.execute(
+            "INSERT INTO backtest_results "
+            "(result_id, strategy_id, result_type, symbol, timeframe, metrics_json, config_json, created_at) "
+            "VALUES (?, ?, 'backtest', 'BTC', ?, ?, ?, ?)",
+            (rid, strategy_id, tf, json.dumps(metrics), json.dumps(config), created),
+        )
+        conn.commit()
+
+
+def _gate_step(workflow_id: str) -> dict:
+    with get_db() as conn:
+        rows = conn.execute(
+            "SELECT * FROM gauntlet_steps WHERE workflow_id = ? ORDER BY order_index",
+            (workflow_id,),
+        ).fetchall()
+    return next(dict(r) for r in rows if r["step_key"] == "quick_screen_gate")
+
+
+def test_gate_judges_declared_row_not_offdeclared_screen(forven_db):
+    """Declared-4h row exists but is degenerate (below the 10-trade floor) and the
+    only survivor (1h) is negative: the gate must judge the DECLARED row's numbers.
+    Here the 4h slice is negative too, so the gate fails — but on the 4h numbers,
+    and without persisting the degenerate slice onto strategies.metrics."""
+    sid = "S-QSGDT1"
+    stored_metrics = {"sharpe": -2.40, "total_return_pct": -9.16, "total_trades": 31}
+    _insert_strategy(sid, metrics=stored_metrics)
+    workflow = create_or_get_workflow(strategy_id=sid, created_by="pytest")
+    wf_as_of = gauntlet_tasks._workflow_as_of(workflow)
+    _insert_bt(sid, "bt-1h", "1h", trades=31, sharpe=-2.40, total_return=-9.16, as_of=wf_as_of)
+    _insert_bt(sid, "bt-4h", "4h", trades=9, sharpe=-0.50, total_return=-1.0, as_of=wf_as_of)
+
+    outcome = run_quick_screen_gate(workflow, _gate_step(workflow["id"]))
+
+    assert outcome["status"] == "failed_gate"
+    msg = str(outcome.get("message") or "")
+    assert "-2.40" not in msg and "-9.16" not in msg, (
+        f"gate judged the off-declared 1h context: {msg}"
+    )
+    assert "-0.50" in msg or "-1.0" in msg, f"gate should cite the 4h numbers: {msg}"
+    with get_db() as conn:
+        row = conn.execute("SELECT metrics FROM strategies WHERE id = ?", (sid,)).fetchone()
+    persisted = json.loads(row["metrics"] or "{}")
+    assert persisted.get("total_trades") != 9, (
+        "degenerate declared metrics must not be persisted onto strategies.metrics"
+    )
+
+
+def test_gate_blocks_and_resubmits_when_declared_row_absent(forven_db, monkeypatch):
+    sid = "S-QSGDT2"
+    _insert_strategy(sid, metrics={"sharpe": -2.40, "total_return_pct": -9.16})
+    workflow = create_or_get_workflow(strategy_id=sid, created_by="pytest")
+    wf_as_of = gauntlet_tasks._workflow_as_of(workflow)
+    _insert_bt(sid, "bt-1h", "1h", trades=31, sharpe=-2.40, total_return=-9.16, as_of=wf_as_of)
+
+    submitted: list[str] = []
+
+    def _capture_submit(body, **_kwargs):
+        submitted.append(str(getattr(body, "timeframe", "")))
+        return {"ok": True}
+
+    monkeypatch.setattr(gauntlet_tasks, "_submit_backtest", _capture_submit)
+
+    outcome = run_quick_screen_gate(workflow, _gate_step(workflow["id"]))
+
+    assert outcome["status"] == "blocked_runtime", f"got: {outcome}"
+    assert "declared-timeframe" in str(outcome.get("message") or "")
+    assert outcome.get("retryable") is True
+    assert submitted == ["4h"], "the declared-timeframe backtest must be resubmitted"


### PR DESCRIPTION
Completes the D2 sweep-fairness fix from #77. The selector correctly refuses to crown a negative off-declared context, but the gate then judged `screen_metrics` (produced on the stored, off-declared timeframe) — observed live on S06895's re-adjudication: 4h crowned, gate failed on the 1h screen numbers anyway.

- Declared-TF row exists (even if degeneracy-floor-skipped): the gate judges ITS numbers, without persisting them onto `strategies.metrics` (no lucky-slice contamination); testing_mode deferral and the full-history robustness suite stay the real vetting.
- Declared-TF row absent: `blocked_runtime` (retryable) + the declared-timeframe backtest is resubmitted — never a merit verdict on off-declared or stale numbers.

Regression tests reconstruct both S06895 shapes; 42 green across the gate/sweep/lifecycle suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)