### PR TITLE
fix: optimizer runs sandbox-only strategies on the degenerate space instead of orphan-erroring

### DIFF
--- a/forven/strategies/optimizer.py
+++ b/forven/strategies/optimizer.py
@@ -720,32 +720,45 @@ def optimize_strategy(
     if resolved_param_space is None:
         resolved_param_space = _get_param_space(strategy_id, strategy_type, base_params)
     if not resolved_param_space:
-        # Distinguish the two failure modes so the user gets an actionable error:
-        #   (a) the strategy type is an orphan — no class, no param family →
-        #       the entire strategy is broken, not just the Robustness tab.
-        #   (b) the class exists but doesn't expose `parameter_space()` and the
-        #       type isn't in the hardcoded `defaults` dict → missing param space.
-        from forven.strategies.params import is_known_runtime_type
+        from forven.strategies.sandbox_proxy import is_sandbox_only_type
 
-        if not is_known_runtime_type(strategy_type):
+        if is_sandbox_only_type(strategy_type):
+            # Sandbox-only strategy with no worker-captured _parameter_space:
+            # _get_param_space's documented fallback is the DEGENERATE space — a
+            # single grid evaluation of the author's stored params through the
+            # worker (math.prod over zero axes is 1). The orphan error below is
+            # for types the parent SHOULD be able to resolve; an imported class
+            # is worker-held BY DESIGN, and erroring here blocked every such
+            # strategy's validation_optimization step until retries exhausted
+            # and the workflow failed (S06895, 2026-07-12).
+            resolved_param_space = {}
+        else:
+            # Distinguish the two failure modes so the user gets an actionable error:
+            #   (a) the strategy type is an orphan — no class, no param family →
+            #       the entire strategy is broken, not just the Robustness tab.
+            #   (b) the class exists but doesn't expose `parameter_space()` and the
+            #       type isn't in the hardcoded `defaults` dict → missing param space.
+            from forven.strategies.params import is_known_runtime_type
+
+            if not is_known_runtime_type(strategy_type):
+                return {
+                    "error": (
+                        f"Strategy type '{strategy_type}' has no registered runtime class "
+                        "and is not a known param family. This strategy is an orphan: "
+                        "it cannot be optimized, overlaid on charts, or promoted to live. "
+                        "Either register a class for this TYPE_NAME under "
+                        "forven/strategies/custom/, or archive the strategy."
+                    )
+                }
             return {
                 "error": (
-                    f"Strategy type '{strategy_type}' has no registered runtime class "
-                    "and is not a known param family. This strategy is an orphan: "
-                    "it cannot be optimized, overlaid on charts, or promoted to live. "
-                    "Either register a class for this TYPE_NAME under "
-                    "forven/strategies/custom/, or archive the strategy."
+                    f"No parameter space defined for '{strategy_type}'. The runtime class "
+                    "exists but does not expose a `parameter_space()` method, and there is "
+                    "no entry in the optimizer defaults. Add a `parameter_space()` method "
+                    "to the strategy class (recommended) or an entry to "
+                    "forven/strategies/optimizer.py:_get_param_space defaults."
                 )
             }
-        return {
-            "error": (
-                f"No parameter space defined for '{strategy_type}'. The runtime class "
-                "exists but does not expose a `parameter_space()` method, and there is "
-                "no entry in the optimizer defaults. Add a `parameter_space()` method "
-                "to the strategy class (recommended) or an entry to "
-                "forven/strategies/optimizer.py:_get_param_space defaults."
-            )
-        }
 
     log.info("Optimizing %s (%s on %s)", strategy_id, strategy_type, asset)
 

--- a/tests/test_optimizer_sandbox_types.py
+++ b/tests/test_optimizer_sandbox_types.py
@@ -1,0 +1,104 @@
+"""optimize_strategy must never orphan-error a sandbox-only (imported/dropzone)
+strategy: the class is worker-held BY DESIGN, so the parent-side orphan check is
+always false for them. A sandbox strategy with no worker-captured
+_parameter_space uses the documented degenerate space (single grid evaluation
+of the stored params through the worker) instead of erroring. Pre-fix, every
+such strategy's validation_optimization step retried into exhaustion and the
+workflow failed (S06895, 2026-07-12)."""
+
+import forven.strategies.optimizer as optimizer_mod
+from forven.strategies.optimizer import optimize_strategy
+
+_SANDBOX_TYPE = "imported__dropzone_btc_funding_trend_align_s63123_b1d5025a517a"
+
+
+def test_sandbox_type_without_stored_space_uses_degenerate_grid(forven_db, monkeypatch):
+    captured: dict = {}
+
+    def _fake_grid_search(strategy_id, asset, strategy_type, param_space, **kwargs):
+        captured["param_space"] = param_space
+        captured["strategy_type"] = strategy_type
+        return [
+            {
+                "params": {"fz_win": 180},
+                "metrics": {"sharpe_ratio": 1.0, "total_trades": 20},
+                "objective_value": 1.0,
+                "fitness": 1.0,
+            }
+        ]
+
+    def _fake_walk_forward(*_a, **_k):
+        return {
+            "verdict": "PASS",
+            "splits": [],
+            "aggregate_oos": {"sharpe": 1.0, "total_trades": 20},
+        }
+
+    monkeypatch.setattr(optimizer_mod, "grid_search", _fake_grid_search)
+    monkeypatch.setattr(optimizer_mod, "walk_forward", _fake_walk_forward)
+
+    result = optimize_strategy(
+        "S-OPT-SBX",
+        asset="BTC",
+        strategy_type=_SANDBOX_TYPE,
+        bars=500,
+        base_params={"fz_win": 180, "_timeframe": "4h"},
+        timeframe="4h",
+    )
+
+    assert "orphan" not in str(result.get("error") or ""), f"got: {result.get('error')}"
+    assert captured.get("param_space") == {}, (
+        "sandbox type without _parameter_space must run the degenerate grid"
+    )
+    assert captured.get("strategy_type") == _SANDBOX_TYPE
+
+
+def test_sandbox_type_with_stored_space_uses_it(forven_db, monkeypatch):
+    captured: dict = {}
+
+    def _fake_grid_search(strategy_id, asset, strategy_type, param_space, **kwargs):
+        captured["param_space"] = param_space
+        return [
+            {
+                "params": {"fz_win": 200},
+                "metrics": {"sharpe_ratio": 1.1, "total_trades": 22},
+                "objective_value": 1.1,
+                "fitness": 1.1,
+            }
+        ]
+
+    monkeypatch.setattr(optimizer_mod, "grid_search", _fake_grid_search)
+    monkeypatch.setattr(
+        optimizer_mod,
+        "walk_forward",
+        lambda *_a, **_k: {
+            "verdict": "PASS",
+            "splits": [],
+            "aggregate_oos": {"sharpe": 1.0, "total_trades": 20},
+        },
+    )
+
+    stored_space = {"fz_win": [120, 240, 40]}
+    result = optimize_strategy(
+        "S-OPT-SBX2",
+        asset="BTC",
+        strategy_type=_SANDBOX_TYPE,
+        bars=500,
+        base_params={"fz_win": 180, "_parameter_space": stored_space},
+        timeframe="4h",
+    )
+
+    assert "orphan" not in str(result.get("error") or "")
+    assert captured.get("param_space") == stored_space
+
+
+def test_non_sandbox_orphan_still_errors(forven_db):
+    result = optimize_strategy(
+        "S-OPT-ORPHAN",
+        asset="BTC",
+        strategy_type="totally_unknown_family_xyz",
+        bars=500,
+        base_params={},
+        timeframe="1h",
+    )
+    assert "orphan" in str(result.get("error") or "")


### PR DESCRIPTION
The seventh (and per exhaustive grep, final) parent-side reader that dead-ended imported/dropzone strategies. The submit path was fixed in #77; the execution path's empty-space guard still fired the orphan error for sandbox types with no worker-captured `_parameter_space`, even though `_get_param_space` documents the degenerate-space fallback (single evaluation of stored params — `grid_search` handles zero axes natively).

Live casualty: S06895 passed the (fixed) quick_screen gate at its declared 4h, then `validation_optimization` retried 8× overnight into exhaustion and the workflow failed — correctly labeled non-merit by the #77 semantics, but still a dead end. Non-sandbox orphan/missing-space errors unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)