### PR TITLE
fix: degenerate grid reports the evaluated full params as best_params

### DIFF
--- a/forven/strategies/optimizer.py
+++ b/forven/strategies/optimizer.py
@@ -906,7 +906,14 @@ def optimize_strategy(
         "strategy_id": strategy_id,
         "asset": asset,
         "strategy_type": strategy_type,
-        "best_params": best["params"],
+        # A degenerate grid (zero axes — e.g. a sandbox-only strategy with no
+        # captured _parameter_space) records no per-axis overrides, so
+        # best["params"] is {}. Report the evaluated FULL params as best then:
+        # "no better params found; best = the author's stored params". An empty
+        # best_params here left the persisted row unreadable to the gauntlet's
+        # _best_params_from_optimization_payload, which resubmitted the
+        # optimization forever (S06895's third run, 2026-07-12).
+        "best_params": best["params"] or dict(best_full_params or {}),
         "best_full_params": best_full_params,
         "best_execution_controls": best.get("execution_controls") or {},
         "best_execution_profile": best_execution_controls,

--- a/tests/test_optimizer_sandbox_types.py
+++ b/tests/test_optimizer_sandbox_types.py
@@ -102,3 +102,47 @@ def test_non_sandbox_orphan_still_errors(forven_db):
         timeframe="1h",
     )
     assert "orphan" in str(result.get("error") or "")
+
+
+def test_degenerate_grid_reports_full_params_as_best(forven_db, monkeypatch):
+    """A zero-axis grid records no per-axis overrides (params={}), which left the
+    persisted optimization row unreadable to the gauntlet's best-params extractor
+    and made run_validation_optimization resubmit forever. The degenerate result
+    must report the evaluated FULL params as best."""
+    base = {"fz_win": 180, "ema_fast": 21, "_timeframe": "4h"}
+
+    def _fake_grid_search(strategy_id, asset, strategy_type, param_space, **kwargs):
+        return [
+            {
+                "params": {},  # zero-axis combo: no overrides
+                "full_params": dict(base),
+                "metrics": {"sharpe_ratio": 1.0, "total_trades": 20},
+                "objective_value": 1.0,
+                "fitness": 1.0,
+            }
+        ]
+
+    monkeypatch.setattr(optimizer_mod, "grid_search", _fake_grid_search)
+    monkeypatch.setattr(
+        optimizer_mod,
+        "walk_forward",
+        lambda *_a, **_k: {
+            "verdict": "PASS",
+            "splits": [],
+            "aggregate_oos": {"sharpe": 1.0, "total_trades": 20},
+        },
+    )
+
+    result = optimize_strategy(
+        "S-OPT-SBX3",
+        asset="BTC",
+        strategy_type=_SANDBOX_TYPE,
+        bars=500,
+        base_params=dict(base),
+        timeframe="4h",
+    )
+
+    assert not result.get("error"), result.get("error")
+    assert result.get("best_params") == base, (
+        "degenerate grid must report the evaluated full params as best_params"
+    )


### PR DESCRIPTION
Companion to #80. The degenerate (zero-axis) optimization now completes AND is consumable: its single trial recorded `params: {}` (per-axis overrides only), leaving the persisted row unreadable to `_best_params_from_optimization_payload` — so `run_validation_optimization` hit the succeeded-but-no-best-params fall-through and resubmitted the optimization every tick, forever (S06895's third run: three opt rows in three minutes, step "running" for hours).

Degenerate results now report the evaluated full params as `best_params` ("no better params found; best = the author's stored params"). Normal grids keep override-only semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)