### PR TITLE
fix: persisted walk-forward drops an undersized optimizer validation window

### DIFF
--- a/forven/gauntlet/tasks.py
+++ b/forven/gauntlet/tasks.py
@@ -1490,6 +1490,27 @@ def _robustness_outcome(
     }
 
 
+def _window_supports_wfa_folds(start: str, end: str, timeframe: str) -> bool:
+    """True when a dated window spans >= 420 bars at ``timeframe`` — the
+    walk-forward fold floor. The optimizer's validation window is an anti-leak
+    HOLDOUT sized for its own internal WFA (often ~30% of a short stage window);
+    forwarding one smaller than the floor to the persisted FULL-HISTORY
+    walk-forward can only ever error ('109 bars requested (need 420+)',
+    S06895's fourth run, 2026-07-12)."""
+    from datetime import datetime
+
+    from forven.api_core import _timeframe_to_minutes
+
+    try:
+        s = datetime.fromisoformat(str(start).replace("Z", "+00:00"))
+        e = datetime.fromisoformat(str(end).replace("Z", "+00:00"))
+        minutes_per_bar = max(_timeframe_to_minutes(str(timeframe or "1h")), 1)
+        span_bars = (e - s).total_seconds() / 60.0 / minutes_per_bar
+        return span_bars >= 420
+    except Exception:  # noqa: BLE001 — unparseable window: let the runner decide
+        return True
+
+
 def run_walk_forward(workflow: dict[str, Any], step: dict[str, Any]) -> dict[str, Any]:
     row = _strategy_row(str(workflow.get("strategy_id") or ""))
     if not row:
@@ -1497,6 +1518,22 @@ def run_walk_forward(workflow: dict[str, Any], step: dict[str, Any]) -> dict[str
     settings = _workflow_settings(workflow)
     wf_cfg = settings.get("walk_forward") if isinstance(settings.get("walk_forward"), dict) else {}
     _selection_window, validation_window = _workflow_optimization_windows(workflow)
+    tf = str(row.get("timeframe") or "1h")
+    start_date = str(validation_window.get("start") or "").strip() or None
+    end_date = str(validation_window.get("end") or "").strip() or None
+    if start_date and end_date and not _window_supports_wfa_folds(start_date, end_date, tf):
+        # The persisted walk-forward is the FULL-HISTORY edge-existence test; the
+        # anti-leak validation on the optimizer's holdout already ran inside the
+        # optimizer itself. Fall back to the windowless trade-frequency-sized
+        # window (the path every successful WFA has used) rather than submitting
+        # a window that structurally cannot produce the fold floor.
+        log.info(
+            "walk_forward %s: optimizer validation window too small for folds at %s — "
+            "running full-history windowless WFA instead",
+            row["id"], tf,
+        )
+        start_date = None
+        end_date = None
     try:
         from forven.routers.robustness import WalkForwardBody
 
@@ -1504,11 +1541,11 @@ def run_walk_forward(workflow: dict[str, Any], step: dict[str, Any]) -> dict[str
             WalkForwardBody(
                 strategy_id=str(row["id"]),
                 symbol=str(row.get("symbol") or "BTC/USDT"),
-                timeframe=str(row.get("timeframe") or "1h"),
+                timeframe=tf,
                 n_splits=int(wf_cfg.get("n_folds") or 5),
                 train_ratio=float(wf_cfg.get("in_sample_pct") or 0.7),
-                start_date=str(validation_window.get("start") or "").strip() or None,
-                end_date=str(validation_window.get("end") or "").strip() or None,
+                start_date=start_date,
+                end_date=end_date,
                 as_of=_workflow_as_of(workflow),
             )
         )

--- a/tests/test_gauntlet_workflow_tasks.py
+++ b/tests/test_gauntlet_workflow_tasks.py
@@ -523,3 +523,69 @@ def test_paper_promotion_gate_uses_unified_status_and_transition(forven_db, monk
     assert outcome["status"] == "passed"
     assert seen["strategy_id"] == strategy_id
     assert seen["target_stage"] == "paper"
+
+
+def test_run_walk_forward_drops_undersized_validation_window(forven_db, monkeypatch):
+    """The optimizer's validation window is an anti-leak holdout sized for its own
+    internal WFA; when it spans fewer than the 420-bar fold floor at the strategy's
+    timeframe, run_walk_forward must fall back to the windowless full-history path
+    instead of submitting a window that structurally cannot fold ('109 bars
+    requested (need 420+)', S06895's fourth run, 2026-07-12)."""
+    from datetime import datetime, timedelta, timezone
+
+    from forven.db import get_db
+    from forven.gauntlet import tasks as gtasks
+
+    sid = "S-WFWIN1"
+    now = datetime.now(timezone.utc)
+    with get_db() as conn:
+        conn.execute(
+            "INSERT INTO strategies (id, name, type, symbol, timeframe, params, metrics, "
+            "status, owner, stage, stage_changed_at, created_at, updated_at) "
+            "VALUES (?, ?, 'rsi_momentum', 'BTC/USDT', '4h', '{}', '{}', 'gauntlet', 'brain', "
+            "'gauntlet', ?, ?, ?)",
+            (sid, sid, now.isoformat(), now.isoformat(), now.isoformat()),
+        )
+        conn.commit()
+
+    captured: dict = {}
+
+    def _fake_run_wf(body):
+        captured["start"] = body.start_date
+        captured["end"] = body.end_date
+        return {
+            "verdict": "PASS",
+            "splits": [
+                {"out_of_sample": {"sharpe": 1.0, "total_trades": 12}} for _ in range(5)
+            ],
+            "aggregate_oos": {"sharpe": 0.9, "total_trades": 60},
+        }
+
+    monkeypatch.setattr(gtasks, "_run_walk_forward", _fake_run_wf)
+    # ~18 days at 4h = ~109 bars — far below the 420-bar fold floor.
+    small_window = {
+        "start": (now - timedelta(days=18)).isoformat(),
+        "end": now.isoformat(),
+    }
+    monkeypatch.setattr(
+        gtasks, "_workflow_optimization_windows", lambda _wf: ({}, small_window)
+    )
+
+    workflow = {"id": "gw-test-wfwin", "strategy_id": sid, "settings_snapshot_json": "{}"}
+    outcome = gtasks.run_walk_forward(workflow, {"step_key": "walk_forward"})
+
+    assert captured.get("start") is None and captured.get("end") is None, (
+        f"undersized window must be dropped, got {captured}"
+    )
+    assert outcome["status"] == "passed"
+
+    # A window that DOES support folds is forwarded untouched.
+    big_window = {
+        "start": (now - timedelta(days=200)).isoformat(),
+        "end": now.isoformat(),
+    }
+    monkeypatch.setattr(
+        gtasks, "_workflow_optimization_windows", lambda _wf: ({}, big_window)
+    )
+    gtasks.run_walk_forward(workflow, {"step_key": "walk_forward"})
+    assert captured.get("start") == big_window["start"]


### PR DESCRIPTION
D4b follow-up (deferred in #77's plan, now hit live): `run_walk_forward` forwarded the optimizer's anti-leak holdout to the full-history persisted WFA; a holdout under the 420-bar fold floor at the strategy's timeframe structurally cannot fold (S06895 run four: "109 bars requested (need 420+)"). Undersized windows now fall back to the windowless trade-frequency-sized path — the same one every successful persisted WFA (e.g. S06898's 2022→2026 pass) has used; adequately-sized windows are forwarded unchanged. The anti-leak concern is already handled by the optimizer's internal WFA on that holdout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)