### PR TITLE
fix: walk-forward worker builds the sandbox proxy for imported types

### DIFF
--- a/forven/strategies/backtest.py
+++ b/forven/strategies/backtest.py
@@ -476,17 +476,29 @@ def _isolated_walk_forward_worker(
     """
     strategy_obj = None
     checker = SIGNAL_CHECKERS.get(family_strategy_type)
-    # Load only the registry slice this walk-forward needs: built-in strategies skip
-    # the ~12s custom-module import+AST-scan that full discover() pays on every spawn.
-    cls = _resolve_worker_strategy_class(original_strategy_type, family_strategy_type)
-    if cls:
-        try:
-            strategy_obj = cls(strategy_id, params)
-        except Exception as e:
-            return {"error": f"Failed to instantiate strategy: {e}"}
+    from forven.strategies.sandbox_proxy import SandboxOnlyStrategy, is_sandbox_only_type
 
-    if strategy_obj is None and not checker and family_strategy_type not in _VECTORIZABLE_TYPES:
-        return {"error": f"Unknown strategy type: {original_strategy_type}"}
+    if is_sandbox_only_type(original_strategy_type):
+        # Untrusted-origin (imported) strategy: NEVER resolve/instantiate its real
+        # class in this process. Build the non-executing proxy — run_strategy_execution
+        # force-routes its signal generation to the locked-down sandbox worker. Same
+        # branch as _isolated_backtest_worker; its absence here made every sandbox
+        # strategy's persisted walk-forward error "Unknown strategy type" once the
+        # robustness path resolved the namespaced runtime_type (S06895, 2026-07-12).
+        strategy_obj = SandboxOnlyStrategy(strategy_id, params, runtime_type=original_strategy_type)
+        checker = None
+    else:
+        # Load only the registry slice this walk-forward needs: built-in strategies skip
+        # the ~12s custom-module import+AST-scan that full discover() pays on every spawn.
+        cls = _resolve_worker_strategy_class(original_strategy_type, family_strategy_type)
+        if cls:
+            try:
+                strategy_obj = cls(strategy_id, params)
+            except Exception as e:
+                return {"error": f"Failed to instantiate strategy: {e}"}
+
+        if strategy_obj is None and not checker and family_strategy_type not in _VECTORIZABLE_TYPES:
+            return {"error": f"Unknown strategy type: {original_strategy_type}"}
 
     splits = []
     all_oos_trades = []

--- a/tests/test_sandbox_data_availability.py
+++ b/tests/test_sandbox_data_availability.py
@@ -38,3 +38,49 @@ def test_non_sandbox_unresolvable_type_still_blocks(forven_db, monkeypatch):
     )
     assert result.blocked is True
     assert "could not be resolved" in str(result.error)
+
+
+def test_walk_forward_worker_builds_sandbox_proxy(forven_db, monkeypatch):
+    """The isolated walk-forward worker must build the SandboxOnlyStrategy proxy
+    for imported types — same branch as the IS/OOS backtest worker. Its absence
+    errored every sandbox strategy's persisted walk-forward with 'Unknown
+    strategy type' once robustness resolved the namespaced runtime_type."""
+    import numpy as np
+    import pandas as pd
+
+    from forven.strategies import backtest as bt
+
+    n = 500
+    idx = pd.date_range("2025-01-01", periods=n, freq="4h")
+    close = 100 + np.cumsum(np.random.default_rng(3).normal(0, 0.5, n))
+    df = pd.DataFrame(
+        {"open": close, "high": close + 0.5, "low": close - 0.5, "close": close, "volume": 1000},
+        index=idx,
+    )
+
+    captured: dict = {}
+
+    def _fake_execution(strategy_obj, frame, **_kwargs):
+        captured["runtime_type"] = getattr(strategy_obj, "runtime_type", None)
+        empty = pd.Series(False, index=frame.index, dtype=bool)
+        return empty, empty
+
+    monkeypatch.setattr(bt, "run_strategy_execution", _fake_execution)
+
+    result = bt._isolated_walk_forward_worker(
+        strategy_id="S-WFSBX",
+        original_strategy_type="imported__dropzone_x_deadbeef",
+        family_strategy_type="x",
+        params={"_timeframe": "4h"},
+        df=df,
+        leverage=1.0,
+        fee_bps=4.5,
+        slippage_bps=2.0,
+        regime_gate=False,
+        warmup=50,
+        resolved_timeframe="4h",
+        resolved_n_splits=2,
+        resolved_in_sample_pct=0.7,
+    )
+
+    assert "Unknown strategy type" not in str(result.get("error") or ""), result.get("error")


### PR DESCRIPTION
The isolated walk-forward worker was the one execution worker without the sandbox branch — it resolved classes in-process and errored `Unknown strategy type: imported__...` for sandbox-only strategies, so every persisted walk-forward for a dropzone strategy retried into exhaustion (S06895 run five; correctly labeled non-merit by the #77 semantics). Mirrors the exact branch `_isolated_backtest_worker` has always had: build `SandboxOnlyStrategy` and let `run_strategy_execution` route fold signals through the locked-down worker.

With #78–#82, this completes the sandbox-runtime path audit: register → backtest → availability → sweep → gate → optimize → apply → confirm → walk-forward all proven or covered by the same routing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)