### PR TITLE
fix: confirmation backtest backfills canonical metrics when the strategy blob has none

### DIFF
--- a/forven/gauntlet/tasks.py
+++ b/forven/gauntlet/tasks.py
@@ -1258,10 +1258,48 @@ def run_confirmation_backtest(workflow: dict[str, Any], step: dict[str, Any]) ->
         return _classify_exception(exc)
     if not isinstance(response, dict):
         return {"status": "blocked_runtime", "message": "confirmation backtest returned invalid response", "retryable": True}
+    confirmation_metrics = (
+        response.get("metrics")
+        if isinstance(response.get("metrics"), dict)
+        else _load_result_metrics(response.get("result_id"))
+    )
+    # When the strategy row carries NO performance metrics — the quick-screen gate
+    # deliberately does not persist a degeneracy-skipped declared-TF slice — promote
+    # this confirmation run's metrics as the canonical blob: it is the
+    # POST-optimization run at the declared timeframe over the full IS+OOS window,
+    # exactly the sample the paper (capital) gate needs to judge. Without it the
+    # gate fails closed with "no trade-count metric" despite eleven green steps
+    # (S06895, 2026-07-12). Rows that already carry performance metrics (the normal
+    # sweep-winner path) are left untouched.
+    try:
+        if isinstance(confirmation_metrics, dict) and confirmation_metrics:
+            from forven.policy import _resolve_full_sample_trade_count
+
+            current_blob = _loads(
+                (_strategy_row(str(row["id"])) or {}).get("metrics"), {}
+            )
+            if not isinstance(current_blob, dict):
+                current_blob = {}
+            if _resolve_full_sample_trade_count(current_blob) is None:
+                # Overlay the existing blob (robustness score fields written by
+                # _recalculate_robustness_score) so the backfill adds performance
+                # metrics without erasing the validation bookkeeping.
+                merged = dict(confirmation_metrics)
+                merged.update(current_blob)
+                _persist_quick_screen_winner(
+                    str(row["id"]),
+                    str(row.get("timeframe") or "1h"),
+                    merged,
+                )
+    except Exception as exc:  # noqa: BLE001 — canonical-metrics backfill is best-effort
+        log.warning(
+            "confirmation_backtest: canonical-metrics backfill failed for %s: %s",
+            row.get("id"), exc,
+        )
     return {
         "status": "passed",
         "result_id": response.get("result_id"),
-        "metrics": response.get("metrics") if isinstance(response.get("metrics"), dict) else _load_result_metrics(response.get("result_id")),
+        "metrics": confirmation_metrics,
         "execution_profile_selection": profile_selection,
     }
 

--- a/tests/test_gauntlet_workflow_tasks.py
+++ b/tests/test_gauntlet_workflow_tasks.py
@@ -589,3 +589,77 @@ def test_run_walk_forward_drops_undersized_validation_window(forven_db, monkeypa
     )
     gtasks.run_walk_forward(workflow, {"step_key": "walk_forward"})
     assert captured.get("start") == big_window["start"]
+
+
+def test_confirmation_backfills_canonical_metrics_when_blob_lacks_trade_count(forven_db, monkeypatch):
+    """When the strategy blob carries no performance metrics (the quick-screen
+    gate deliberately skips persisting a degeneracy-skipped declared-TF slice),
+    the confirmation backtest must promote its post-optimization metrics as the
+    canonical blob — otherwise the paper gate fails closed with 'no trade-count
+    metric' despite a fully green pipeline (S06895, 2026-07-12). Robustness
+    bookkeeping already on the blob survives; rows with existing performance
+    metrics are untouched."""
+    import json as _j
+    from datetime import datetime, timezone
+
+    from forven.db import get_db
+    from forven.gauntlet import tasks as gtasks
+
+    now = datetime.now(timezone.utc).isoformat()
+    sid = "S-CONFBF1"
+    rob_only = {"composite_robustness_score": 95.85, "robustness_tests_passed": 5}
+    with get_db() as conn:
+        conn.execute(
+            "INSERT INTO strategies (id, name, type, symbol, timeframe, params, metrics, "
+            "status, owner, stage, stage_changed_at, created_at, updated_at) "
+            "VALUES (?, ?, 'rsi_momentum', 'BTC/USDT', '4h', '{}', ?, 'gauntlet', 'brain', "
+            "'gauntlet', ?, ?, ?)",
+            (sid, sid, _j.dumps(rob_only), now, now, now),
+        )
+        conn.commit()
+
+    conf_metrics = {
+        "total_trades": 42,
+        "sharpe": 1.2,
+        "total_return_pct": 8.0,
+        "in_sample": {"total_trades": 33},
+        "out_of_sample": {"total_trades": 9},
+    }
+    monkeypatch.setattr(
+        gtasks, "_submit_backtest",
+        lambda body, **_k: {"result_id": "bt-conf-1", "metrics": conf_metrics},
+    )
+    monkeypatch.setattr(gtasks, "_latest_step_output", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        gtasks, "_workflow_optimization_windows", lambda _wf: ({}, {})
+    )
+
+    workflow = {"id": "gw-confbf", "strategy_id": sid, "settings_snapshot_json": "{}"}
+    outcome = gtasks.run_confirmation_backtest(workflow, {"step_key": "confirmation_backtest"})
+    assert outcome["status"] == "passed"
+
+    with get_db() as conn:
+        row = conn.execute("SELECT metrics FROM strategies WHERE id = ?", (sid,)).fetchone()
+    blob = _j.loads(row["metrics"] or "{}")
+    assert blob.get("total_trades") == 42, "confirmation metrics must be backfilled"
+    assert blob.get("composite_robustness_score") == 95.85, (
+        "robustness bookkeeping must survive the backfill"
+    )
+
+    # A row that already has performance metrics is untouched.
+    sid2 = "S-CONFBF2"
+    existing = {"total_trades": 77, "sharpe": 0.5}
+    with get_db() as conn:
+        conn.execute(
+            "INSERT INTO strategies (id, name, type, symbol, timeframe, params, metrics, "
+            "status, owner, stage, stage_changed_at, created_at, updated_at) "
+            "VALUES (?, ?, 'rsi_momentum', 'BTC/USDT', '4h', '{}', ?, 'gauntlet', 'brain', "
+            "'gauntlet', ?, ?, ?)",
+            (sid2, sid2, _j.dumps(existing), now, now, now),
+        )
+        conn.commit()
+    workflow2 = {"id": "gw-confbf2", "strategy_id": sid2, "settings_snapshot_json": "{}"}
+    gtasks.run_confirmation_backtest(workflow2, {"step_key": "confirmation_backtest"})
+    with get_db() as conn:
+        row2 = conn.execute("SELECT metrics FROM strategies WHERE id = ?", (sid2,)).fetchone()
+    assert _j.loads(row2["metrics"])["total_trades"] == 77


### PR DESCRIPTION
Completes the #79 design: the no-persist rule for degeneracy-skipped declared-TF slices protects `strategies.metrics` from lucky-slice contamination, but left that path's strategies metric-less at the paper gate — which correctly fails closed on "no trade-count metric" (S06895: eleven green steps, robustness 95.85, DSR 0.81, no sample to verify). The confirmation backtest — post-optimization, declared timeframe, full IS+OOS window — now backfills the canonical blob when (and only when) no performance metrics exist, merged beneath the robustness bookkeeping. Normal sweep-winner flows unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)