### PR TITLE
fix: fitness auto-assign never moves the timeframe off params._timeframe

### DIFF
--- a/forven/db.py
+++ b/forven/db.py
@@ -7021,7 +7021,7 @@ def auto_assign_best_symbol_timeframe(strategy_id: str) -> tuple[str, str] | Non
 
     with get_db() as conn:
         row = conn.execute(
-            "SELECT symbol, timeframe, name, type FROM strategies WHERE id = ?",
+            "SELECT symbol, timeframe, name, type, params FROM strategies WHERE id = ?",
             (strategy_id,),
         ).fetchone()
         if not row:
@@ -7031,6 +7031,33 @@ def auto_assign_best_symbol_timeframe(strategy_id: str) -> tuple[str, str] | Non
         old_timeframe = str(row["timeframe"] or "").strip().lower() or "1h"
         if old_symbol == best_symbol and old_timeframe == best_timeframe:
             return best_symbol, best_timeframe
+
+        # The author's declared timeframe (params._timeframe) is a contract. This
+        # reassigner scores rows from EVERY timeframe, so a dense off-declared
+        # history re-homes the strategy onto a context the sweep's prefer-declared
+        # bias just refused — S06895 run seven: gate passed at the declared 4h,
+        # this fired minutes later on old 1h rows, and the persisted walk-forward
+        # then ran (and merit-archived) at 1h. Timeframe changes for declared
+        # strategies belong to the sweep's quality-barred selection, not fitness
+        # shopping across contexts.
+        declared_tf = ""
+        try:
+            params_blob = json.loads(row["params"]) if row["params"] else {}
+            if isinstance(params_blob, dict):
+                declared_tf = str(params_blob.get("_timeframe") or "").strip().lower()
+        except Exception:
+            declared_tf = ""
+        if declared_tf and str(best_timeframe or "").strip().lower() != declared_tf:
+            log_activity(
+                "info",
+                "db.auto_assign_context",
+                (
+                    f"Auto-assign for {strategy_id} kept declared timeframe "
+                    f"{declared_tf} (fitness winner was {best_symbol} {best_timeframe})"
+                ),
+                {"strategy_id": strategy_id, "declared_timeframe": declared_tf},
+            )
+            return old_symbol, old_timeframe
 
         # Traded-asset freeze: never re-home a running paper/live strategy onto a
         # higher-scoring cross-asset sweep result — keep its promoted asset.

--- a/tests/test_capital_adjacent_symbol_freeze.py
+++ b/tests/test_capital_adjacent_symbol_freeze.py
@@ -194,3 +194,49 @@ def test_scanner_allows_matching_asset_open(forven_db, monkeypatch):
         )
     except ValueError as e:
         assert "cross-asset open blocked" not in str(e)
+
+
+def test_auto_assign_never_moves_timeframe_off_declaration(forven_db):
+    """The fitness reassigner scores rows from every timeframe; with a dense
+    off-declared history it re-homed strategies onto contexts the sweep's
+    prefer-declared bias had just refused (S06895 run seven: gate passed at the
+    declared 4h, this flipped the column to 1h, the persisted walk-forward ran
+    at 1h and merit-archived the strategy). params._timeframe pins it."""
+    import json
+    from datetime import datetime, timezone
+
+    from forven.db import auto_assign_best_symbol_timeframe, get_db
+
+    now = datetime.now(timezone.utc).isoformat()
+    sid = "S-TFPIN1"
+    with get_db() as conn:
+        conn.execute(
+            "INSERT INTO strategies (id, name, type, symbol, timeframe, params, metrics, "
+            "status, owner, stage, stage_changed_at, created_at, updated_at) "
+            "VALUES (?, ?, 'rsi_momentum', 'BTC', '4h', ?, '{}', 'gauntlet', 'brain', "
+            "'gauntlet', ?, ?, ?)",
+            (sid, sid, json.dumps({"_timeframe": "4h", "kc_period": 10}), now, now, now),
+        )
+        # A high-fitness 1h row that would win the cross-timeframe fitness contest.
+        conn.execute(
+            "INSERT INTO backtest_results (result_id, strategy_id, result_type, symbol, "
+            "timeframe, metrics_json, config_json, created_at) "
+            "VALUES ('bt-tfpin-1h', ?, 'backtest', 'BTC', '1h', ?, '{}', ?)",
+            (
+                sid,
+                json.dumps({
+                    "sharpe": 2.5, "sharpe_ratio": 2.5, "total_trades": 60,
+                    "total_return_pct": 20.0, "max_drawdown_pct": 0.05, "win_rate": 0.6,
+                }),
+                now,
+            ),
+        )
+        conn.commit()
+
+    auto_assign_best_symbol_timeframe(sid)
+
+    with get_db() as conn:
+        row = conn.execute("SELECT timeframe FROM strategies WHERE id = ?", (sid,)).fetchone()
+    assert str(row["timeframe"]).lower() == "4h", (
+        "auto-assign must never move the timeframe away from params._timeframe"
+    )


### PR DESCRIPTION
The fifth (and last) writer of `strategies.timeframe` from the #77 investigation, now caught in the act: `auto_assign_best_symbol_timeframe` fitness-scores rows across ALL timeframes, so S06895's dense 1h history re-homed it to 1h minutes after the quick-screen gate passed it at the declared 4h — the persisted walk-forward then ran at 1h and merit-archived it on the timeframe it never declared (run seven, 19:03–19:06). With `params._timeframe` declared, the timeframe is pinned; timeframe selection belongs exclusively to the sweep's quality-barred prefer-declared logic (#77/#79). Symbol freeze behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)