### PR TITLE
fix(forge): unstick the gauntlet — staleness-first catch-up, symbol validation, unfillable strike-out, zombie sweeps

### DIFF
--- a/forven/dataeng/catchup.py
+++ b/forven/dataeng/catchup.py
@@ -40,7 +40,14 @@ class CatchUpPlanner:
 
     def plan(self, *, now: datetime | None = None) -> list[CatchUpTask]:
         now_ts = _as_utc(now or datetime.now(timezone.utc))
-        tasks: list[CatchUpTask] = []
+        # (hours_behind, task) — sorted most-stale-first before returning. The plan
+        # used to ride the catalog's alphabetical order, which head-of-line blocked
+        # the bounded drain batch: the first few symbols' sub-hour series re-stale
+        # every couple of minutes and refilled the whole batch on every run, so a
+        # series past the alphabetical horizon could stay frozen for weeks while
+        # every run reported green. Staleness-descending is an aging queue: any
+        # series left unserved only rises in priority, so nothing starves.
+        prioritized: list[tuple[float, CatchUpTask]] = []
         covered: set[tuple[str, str]] = set()
         for row in self.catalog.list_coverage():
             stream = str(row.get("stream") or "")
@@ -60,11 +67,23 @@ class CatchUpPlanner:
             # Only closed bars are catch-up candidates.
             latest_closed_start = _floor_to_timeframe(now_ts, tf_delta) - tf_delta
             if start_ts <= latest_closed_start:
-                tasks.append(_task_from_row(row, start_ts, latest_closed_start, reason="stale"))
+                hours_behind = max(0.0, (now_ts - start_ts).total_seconds() / 3600.0)
+                prioritized.append(
+                    (hours_behind, _task_from_row(row, start_ts, latest_closed_start, reason="stale"))
+                )
                 continue
             # Current at the tail — but is it gap-complete inside its span?
+            # Interior-gap repair re-downloads the whole span (expensive) and no
+            # quality gate is waiting on it the way end-staleness gates scoring,
+            # so it queues behind end-staleness work at priority 0 and drains
+            # whenever the tail is healthy.
             if _completeness(row, tf_delta) < COMPLETENESS_THRESHOLD:
-                tasks.append(_task_from_row(row, _as_utc(row.get("start_ts") or end_ts), end_ts, reason="gaps"))
+                prioritized.append(
+                    (0.0, _task_from_row(row, _as_utc(row.get("start_ts") or end_ts), end_ts, reason="gaps"))
+                )
+
+        prioritized.sort(key=lambda pair: pair[0], reverse=True)
+        tasks: list[CatchUpTask] = [task for _, task in prioritized]
 
         # Symbol-inventory pre-stage: an active symbol that is in the trading
         # universe but has NO catalog row produces zero rows above and is never

--- a/forven/dataeng/coverage.py
+++ b/forven/dataeng/coverage.py
@@ -71,6 +71,181 @@ def canonical_market_symbol(symbol: str) -> str:
     return f"{s}/USDT"
 
 
+# SYMBOL-VALID-1: strategies were minted with fabricated market symbols
+# (``MULTI/USDT``, ``BASKET/USDT``), inverted pairs (``BTC/ETH``), and dataset
+# context-names leaked into the symbol column (``ETH/USDT-8H``, ``BTC-USDT-1D``).
+# Each one wedged its gauntlet workflow in an eternal blocked_data backfill loop
+# and hammered the exchange with requests for markets that don't exist. Validate
+# at mint instead: repair the repairable (timeframe-suffix leak), reject the
+# fabricated, and let anything plausibly real through (the ensure_coverage
+# strike-out is the backstop for plausible-but-unlisted).
+_TIMEFRAME_SUFFIX_RE = None  # compiled lazily; module import must stay light
+_PLAUSIBLE_QUOTES = ("USDT", "USDC", "USD", "BUSD", "BTC", "ETH")
+
+
+def _strip_timeframe_suffix(symbol: str) -> str:
+    """``ETH/USDT-8H`` → ``ETH/USDT``; ``BTC-USDT-1D`` → ``BTC-USDT``.
+
+    Only strips a TRAILING ``-<timeframe>`` token — never touches the base."""
+    global _TIMEFRAME_SUFFIX_RE
+    if _TIMEFRAME_SUFFIX_RE is None:
+        import re
+
+        _TIMEFRAME_SUFFIX_RE = re.compile(
+            r"[-_/](?:1|3|5|15|30)M$|[-_/](?:1|2|4|6|8|12)H$|[-_/](?:1|3)D$|[-_/]1W$",
+            re.IGNORECASE,
+        )
+    return _TIMEFRAME_SUFFIX_RE.sub("", str(symbol or "").strip())
+
+
+def _series_is_known(canonical: str) -> bool:
+    """True when the lake already stores this series or the perp registry lists
+    it (active OR delisted — delisted history is real, tradable-at-T data)."""
+    from forven.data import DATA_DIR, symbol_to_fs
+
+    fs = symbol_to_fs(canonical)
+    if not fs:
+        return False
+    try:
+        sym_dir = DATA_DIR / fs
+        if sym_dir.is_dir() and any(sym_dir.glob("*.parquet")):
+            return True
+    except Exception:
+        pass
+    try:
+        from forven.dataeng.universe import get_symbol_registry
+
+        return any(str(row.get("symbol")) == fs for row in get_symbol_registry())
+    except Exception:
+        return False
+
+
+def _base_is_known(base: str) -> bool:
+    """A base asset counts as known when any lake dir or registry row trades it."""
+    from forven.data import DATA_DIR
+
+    b = str(base or "").strip().upper()
+    if not b:
+        return False
+    try:
+        if DATA_DIR.exists() and any(
+            d.name.upper().split("-")[0] == b for d in DATA_DIR.iterdir() if d.is_dir()
+        ):
+            return True
+    except Exception:
+        pass
+    try:
+        from forven.dataeng.universe import get_symbol_registry
+
+        return any(
+            str(row.get("symbol") or "").upper().split("-")[0] == b
+            for row in get_symbol_registry()
+        )
+    except Exception:
+        return False
+
+
+def known_base_asset(base: str) -> bool:
+    """Whether ``base`` is an asset the system has ANY evidence of (lake dir or
+    registry row). Fails open when there is no evidence base to judge against
+    (fresh install / isolated test home). Used by the funding collector to skip
+    fabricated assets (MULTI, BASKET) instead of hammering the venue for them."""
+    try:
+        if not _validation_evidence_available():
+            return True
+        return _base_is_known(base)
+    except Exception:
+        return True
+
+
+def _validation_evidence_available() -> bool:
+    """Whether the lake or the registry holds ANY markets to validate against."""
+    from forven.data import DATA_DIR
+
+    try:
+        if DATA_DIR.exists() and any(d.is_dir() and not d.name.startswith(".") for d in DATA_DIR.iterdir()):
+            return True
+    except Exception:
+        pass
+    try:
+        from forven.dataeng.universe import get_symbol_registry
+
+        return bool(get_symbol_registry())
+    except Exception:
+        return False
+
+
+def validate_strategy_symbol(symbol: str) -> dict[str, Any]:
+    """Mint-time market-symbol validation.
+
+    Returns ``{"ok": bool, "symbol": str, "repaired": bool, "reason": str | None}``
+    where ``symbol`` is the canonical (possibly repaired) form to store. Fail-open
+    on infrastructure errors — a registry/lake hiccup must never block a mint
+    (the ensure_coverage strike-out catches anything that slips through)."""
+    raw = str(symbol or "").strip()
+    if not raw:
+        return {"ok": False, "symbol": "", "repaired": False, "reason": "empty symbol"}
+    try:
+        canon = canonical_market_symbol(raw)
+
+        if _series_is_known(canon):
+            return {"ok": True, "symbol": canon, "repaired": False, "reason": None}
+
+        # Repairable: a dataset-context name leaked into the symbol column
+        # (``ETH/USDT-8H``). Strip the trailing timeframe token and re-check.
+        # This must run BEFORE the asset-class carve-out below: the classifier
+        # buckets unrecognized shapes like "ETH/USDT-8H" as "stock", which would
+        # otherwise wave the leak through unrepaired.
+        stripped = _strip_timeframe_suffix(raw)
+        if stripped and stripped != raw:
+            canon_stripped = canonical_market_symbol(stripped)
+            if _series_is_known(canon_stripped):
+                return {
+                    "ok": True,
+                    "symbol": canon_stripped,
+                    "repaired": True,
+                    "reason": f"stripped timeframe suffix from {raw!r}",
+                }
+
+        # Non-crypto tickers (stocks/ETFs/forex) are outside the crypto registry —
+        # never invent a rejection for them.
+        try:
+            from forven.data import classify_dataset_asset_class
+
+            if classify_dataset_asset_class(canon) in _NON_CRYPTO_ASSET_CLASSES:
+                return {"ok": True, "symbol": canon, "repaired": False, "reason": None}
+        except Exception:
+            pass
+
+        # Plausibly real but uncollected: a known base against a standard quote
+        # (new listing, spot cross). Let it through — the coverage strike-out
+        # terminates it cleanly if the venue doesn't actually list it.
+        base, _, quote = canon.partition("/")
+        if quote in _PLAUSIBLE_QUOTES and _base_is_known(base):
+            return {"ok": True, "symbol": canon, "repaired": False, "reason": None}
+
+        # No evidence base to judge against (fresh install / isolated test home:
+        # empty lake AND empty registry) → fail open. Rejection is only meaningful
+        # when the system actually knows what markets exist.
+        if not _validation_evidence_available():
+            return {"ok": True, "symbol": canon, "repaired": False, "reason": None}
+
+        return {
+            "ok": False,
+            "symbol": canon,
+            "repaired": False,
+            "reason": (
+                f"unknown market symbol {raw!r}: not in the data lake, not in the "
+                "symbol registry, and its base asset is not traded anywhere in "
+                "either. Placeholder names (MULTI, BASKET) are not real markets — "
+                "use a concrete listed pair like BTC/USDT."
+            ),
+        }
+    except Exception as exc:  # noqa: BLE001 — fail-open: never block a mint on infra
+        log.warning("validate_strategy_symbol: validation errored for %r: %s", raw, exc)
+        return {"ok": True, "symbol": canonical_market_symbol(raw) or raw, "repaired": False, "reason": None}
+
+
 def coverage_days(symbol: str, timeframe: str) -> float:
     """Days of stored OHLCV history for (symbol, timeframe), read from the parquet
     FOOTER only (no full column load). 0.0 when missing/empty/unreadable."""
@@ -125,6 +300,85 @@ def _latest_ingestion_run(symbol_canonical: str, timeframe: str) -> dict | None:
     return best
 
 
+# Strike-out for series whose downloads can never succeed (fabricated / unlisted
+# symbols like ``MULTI/USDT`` or context-name leaks like ``ETH/USDT-8H``). Without
+# it, ensure_coverage resubmits a fresh backfill on every tick forever — the
+# workflow stays blocked_data eternally and the exchange gets hammered with
+# requests for symbols it does not list (observed: 33 failed runs for MULTI/USDT,
+# all 429/BadSymbol). Two triggers:
+#   * the venue said the symbol does not exist (deterministic — 2 strikes), or
+#   * repeated failures with ZERO bars ever stored (5 strikes — loose enough that
+#     a transient network outage on a real series keeps its retry path).
+_UNFILLABLE_ERROR_TOKENS = (
+    "does not have market symbol",
+    "badsymbol",
+    "symbol not found",
+    "invalid symbol",
+)
+_UNFILLABLE_DETERMINISTIC_STREAK = 2
+_UNFILLABLE_ZERO_COVERAGE_STREAK = 5
+
+
+def _failed_ingestion_streak(symbol_canonical: str, timeframe: str) -> tuple[int, str]:
+    """Consecutive most-recent FAILED ingestion runs for this series.
+
+    Returns ``(streak, most_recent_error)``. A completed run breaks the streak
+    (the source can serve this series); in-flight runs are skipped — they have
+    not confirmed anything yet."""
+    from forven.data import get_active_ingestion_runs, symbol_to_fs
+
+    target_fs = symbol_to_fs(symbol_canonical)
+    series_runs: list[dict] = []
+    for run in get_active_ingestion_runs():
+        try:
+            if symbol_to_fs(run.get("symbol")) != target_fs:
+                continue
+            if str(run.get("timeframe")) != str(timeframe):
+                continue
+        except Exception:
+            continue
+        series_runs.append(run)
+    series_runs.sort(key=lambda run: str(run.get("started_at") or ""), reverse=True)
+
+    streak = 0
+    last_error = ""
+    for run in series_runs:
+        status = str(run.get("status") or "")
+        if status in {"pending", "running"}:
+            continue
+        if status != "failed":
+            break
+        streak += 1
+        if not last_error:
+            last_error = str(run.get("error") or "")
+    return streak, last_error
+
+
+def _unfillable_verdict(symbol_canonical: str, timeframe: str, cov: float) -> dict[str, Any] | None:
+    """The ``unfillable`` result when this series has struck out, else None."""
+    streak, last_error = _failed_ingestion_streak(symbol_canonical, timeframe)
+    if streak <= 0:
+        return None
+    lowered = last_error.lower()
+    deterministic = any(token in lowered for token in _UNFILLABLE_ERROR_TOKENS)
+    if (deterministic and streak >= _UNFILLABLE_DETERMINISTIC_STREAK) or (
+        cov <= 0 and streak >= _UNFILLABLE_ZERO_COVERAGE_STREAK
+    ):
+        log.warning(
+            "ensure_coverage: %s %s struck out as UNFILLABLE after %d consecutive "
+            "failed downloads (last error: %s) — no further backfills will be submitted",
+            symbol_canonical, timeframe, streak, last_error or "unknown",
+        )
+        return {
+            "status": "unfillable",
+            "symbol": symbol_canonical,
+            "coverage_days": cov,
+            "failed_attempts": streak,
+            "last_error": last_error,
+        }
+    return None
+
+
 def ensure_coverage(
     symbol: str,
     timeframe: str,
@@ -138,6 +392,9 @@ def ensure_coverage(
       * ``"ready"``       — enough history exists (or the source has no more); proceed.
       * ``"backfilling"`` — an async backfill is in flight; the caller should defer
         (``blocked_data`` / ``awaiting_data_backfill``) and retry on a later tick.
+      * ``"unfillable"``  — downloads for this series deterministically fail (bad /
+        unlisted symbol) or keep failing with zero bars ever stored; the caller
+        should treat this as TERMINAL for the strategy, not retry.
 
     Never blocks on the network — the download runs asynchronously via
     ``data.submit_ingestion``. ``symbol`` in the result is the canonical form the
@@ -177,7 +434,10 @@ def ensure_coverage(
                 "symbol": canon,
                 "max_available": True,
             }
-        # status == "failed" → fall through and (re)submit a fresh backfill.
+        # status == "failed" → strike-out check, then (re)submit a fresh backfill.
+        struck_out = _unfillable_verdict(canon, timeframe, cov)
+        if struck_out is not None:
+            return struck_out
 
     since_ms = int(time.time() * 1000) - need * _DAY_MS
     try:

--- a/forven/db.py
+++ b/forven/db.py
@@ -4962,6 +4962,32 @@ def create_strategy_container(
         params = lift_unambiguous_risk_params(params)
     except Exception:
         pass
+    # SYMBOL-VALID-1: fabricated symbols (MULTI/USDT, BASKET/USDT), inverted
+    # pairs, and dataset-context leaks (ETH/USDT-8H) wedge the gauntlet in an
+    # eternal blocked_data backfill loop and hammer the exchange with requests
+    # for markets that don't exist. Repair the repairable, reject the fabricated
+    # — loudly, at the mint chokepoint, so the author sees WHY instead of the
+    # strategy silently rotting in the Forge. Unlike the class-introspection
+    # guards above, this runs for sandbox_only registrations too (the dropzone
+    # import path is where several fake-symbol strategies came from) — symbol
+    # validity is independent of the strategy class. The validator fails OPEN on
+    # infra errors, so a registry/lake hiccup can never block a legitimate mint.
+    # An OMITTED symbol keeps the legacy default-fill behavior — only a symbol the
+    # caller actually provided is validated.
+    if str(symbol or "").strip():
+        from forven.dataeng.coverage import validate_strategy_symbol
+
+        _symbol_verdict = validate_strategy_symbol(symbol)
+        if not _symbol_verdict.get("ok"):
+            raise ValueError(
+                f"cannot create strategy on symbol {symbol!r}: {_symbol_verdict.get('reason')}"
+            )
+        if _symbol_verdict.get("repaired"):
+            log.warning(
+                "create_strategy_container: repaired market symbol %r -> %r (%s)",
+                symbol, _symbol_verdict.get("symbol"), _symbol_verdict.get("reason"),
+            )
+        symbol = str(_symbol_verdict.get("symbol") or symbol)
     normalized_parent = str(parent_strategy_id or "").strip() or None
     if normalized_parent:
         parent_row = conn.execute(

--- a/forven/gauntlet/engine.py
+++ b/forven/gauntlet/engine.py
@@ -1057,6 +1057,55 @@ def cancel_param_locked_workflows(*, limit: int = 50) -> int:
     return cancelled
 
 
+def cancel_orphaned_terminal_workflows(*, limit: int = 50) -> int:
+    """Cancel any non-terminal gauntlet workflow whose strategy is already at a
+    TERMINAL stage (archived/rejected/trash).
+
+    Archiving a strategy (evolution sweeps, operator action, brain transitions)
+    never touched its workflow, so 'pending' workflows for long-dead strategies
+    accumulated as permanent Forge clutter (8 such zombies dated back to June)
+    and could even be re-armed by stale-step recovery. Mirror of
+    :func:`cancel_param_locked_workflows` for the terminal stages. Idempotent.
+    """
+    from forven.db import get_db
+
+    with get_db() as conn:
+        init_gauntlet_schema(conn)
+        placeholders = ",".join("?" for _ in _TERMINAL_WORKFLOW_STATUSES)
+        rows = conn.execute(
+            f"""
+            SELECT w.id
+            FROM gauntlet_workflows w
+            JOIN strategies s ON s.id = w.strategy_id
+            WHERE w.status NOT IN ({placeholders})
+              AND LOWER(TRIM(COALESCE(s.stage, s.status, ''))) IN
+                  ('archived', 'rejected', 'trash', 'backtest_failed')
+            ORDER BY w.id
+            LIMIT ?
+            """,
+            (*_TERMINAL_WORKFLOW_STATUSES, int(max(int(limit), 1))),
+        ).fetchall()
+    workflow_ids = [str(row["id"]) for row in rows]
+
+    cancelled = 0
+    for workflow_id in workflow_ids:
+        try:
+            cancel_workflow(
+                workflow_id,
+                actor="gauntlet_sweep",
+                reason="strategy already at a terminal stage; zombie workflow cancelled",
+            )
+            cancelled += 1
+        except Exception:
+            log.exception("Gauntlet: failed to cancel orphaned terminal workflow %s", workflow_id)
+    if cancelled:
+        log.info(
+            "Gauntlet: cancelled %d zombie workflow(s) for terminal-stage strategies",
+            cancelled,
+        )
+    return cancelled
+
+
 # --- Engine-version re-baselining ---------------------------------------------------
 # Validation verdict result_types whose LATEST row decides whether a strategy's
 # evidence is current. Mirrors the IN-list of gauntlet/status._latest_robustness_results.
@@ -1636,6 +1685,10 @@ def tick_active_gauntlet_workflows(
     # (paper/live) so they are not re-armed by stale-step recovery and churn the
     # frozen strategy.
     cancelled_param_locked = cancel_param_locked_workflows(limit=max_workflows)
+    # And workflows whose strategy is already dead (archived/rejected) — zombie
+    # rows that otherwise clutter the Forge forever and can be re-armed by
+    # stale-step recovery.
+    cancelled_orphaned = cancel_orphaned_terminal_workflows(limit=max_workflows)
     workflow_ids = list_active_workflow_ids(max_workflows=max_workflows)
     summary: dict[str, Any] = {
         "ok": True,
@@ -1646,6 +1699,7 @@ def tick_active_gauntlet_workflows(
         "drained_exhausted": drained,
         "demoted_failed_gate": demoted,
         "cancelled_param_locked": cancelled_param_locked,
+        "cancelled_orphaned_terminal": cancelled_orphaned,
         "advanced": 0,
         "no_progress": 0,
         "errors": [],

--- a/forven/gauntlet/tasks.py
+++ b/forven/gauntlet/tasks.py
@@ -381,6 +381,21 @@ def run_quick_screen(workflow: dict[str, Any], step: dict[str, Any]) -> dict[str
                 "retryable": True,
                 "reason_code": "awaiting_data_backfill",
             }
+        if coverage.get("status") == "unfillable":
+            # Downloads for this series deterministically fail (fabricated / unlisted
+            # symbol, e.g. MULTI/USDT or a context-name leak like ETH/USDT-8H). This
+            # can never self-heal, so it is a terminal config failure — NOT a
+            # retryable data wait (which previously looped the workflow forever).
+            return {
+                "status": "failed_gate",
+                "message": (
+                    f"market data for {coverage.get('symbol')} {timeframe} is unobtainable "
+                    f"({int(coverage.get('failed_attempts') or 0)} consecutive failed downloads; "
+                    f"last error: {coverage.get('last_error') or 'unknown'}). The symbol is "
+                    "likely invalid or unlisted — fix the strategy's symbol and re-register."
+                ),
+                "retryable": False,
+            }
         symbol = str(coverage.get("symbol") or raw_symbol)
         if symbol != raw_symbol:
             _persist_strategy_symbol(str(row["id"]), symbol)
@@ -1824,6 +1839,56 @@ def _select_and_persist_execution_profile(workflow: dict[str, Any], strategy_id:
     return {"skipped": False, "selection": marker}
 
 
+def _requeue_walk_forward_for_window_rerun(workflow: dict[str, Any]) -> bool:
+    """Re-arm this workflow's completed walk_forward step so the WFA actually
+    re-runs on the trade-frequency-aware window.
+
+    The gate's ``wfa_window_insufficient`` block promises "re-run WFA on the
+    trade-frequency-aware window" and is exempt from the drain (correct — it is
+    absence of evidence, not merit), but nothing re-queued the already-passed
+    walk_forward step, so the gate retried forever against the same insufficient
+    artifact. Bounded: the step's own attempt budget is NOT reset, so the claim
+    increment caps re-runs at max_attempts; an in-flight step is left alone.
+    Best-effort — a store hiccup leaves the block to retry on its normal cadence.
+    """
+    workflow_id = str(workflow.get("id") or "").strip()
+    if not workflow_id:
+        return False
+    try:
+        from datetime import datetime, timezone
+
+        from forven.db import get_db
+
+        now = datetime.now(timezone.utc).isoformat()
+        with get_db() as conn:
+            row = conn.execute(
+                """SELECT id, status, attempt_count, max_attempts FROM gauntlet_steps
+                   WHERE workflow_id = ? AND step_key = 'walk_forward'""",
+                (workflow_id,),
+            ).fetchone()
+            if not row:
+                return False
+            if str(row["status"] or "") in {"queued", "pending", "running"}:
+                return True  # a re-run is already on its way
+            if int(row["attempt_count"] or 0) >= int(row["max_attempts"] or 3):
+                return False  # re-run budget spent; leave the block to the hygiene backstop
+            conn.execute(
+                """UPDATE gauntlet_steps
+                   SET status = 'queued', error_json = NULL, completed_at = NULL, updated_at = ?
+                   WHERE id = ?""",
+                (now, row["id"]),
+            )
+        log.info(
+            "paper gate: re-queued walk_forward for %s (workflow %s) — window "
+            "insufficient, re-running WFA on the trade-frequency-aware window",
+            workflow.get("strategy_id"), workflow_id,
+        )
+        return True
+    except Exception:
+        log.exception("paper gate: failed to re-queue walk_forward for workflow %s", workflow_id)
+        return False
+
+
 def run_paper_promotion_gate(workflow: dict[str, Any], step: dict[str, Any]) -> dict[str, Any]:
     from forven.gauntlet.status import get_strategy_gauntlet_status
 
@@ -1953,6 +2018,15 @@ def run_paper_promotion_gate(workflow: dict[str, Any], step: dict[str, Any]) -> 
         # archived genuinely-unjudged strategies via the workflow path.
         or "window insufficient" in _blocked_text
     ):
+        if "window insufficient" in _blocked_text:
+            # This block's whole premise is "the re-run produces judgeable folds"
+            # — but nothing ever re-armed the (already-passed) walk_forward step,
+            # so the gate retried forever against the SAME insufficient artifact
+            # (5 candidates with composite 94-100 sat here for days). Actually
+            # trigger the re-run, bounded by the step's own attempt budget so a
+            # strategy that can't produce judgeable folds even on the sized
+            # window doesn't ping-pong indefinitely.
+            _requeue_walk_forward_for_window_rerun(workflow)
         # PENDING RE-VALIDATION, not a merit failure. The gauntlet gate's artifact-
         # ordering / freshness check fails when a validation (walk_forward) is older
         # than the latest optimization — i.e. it ran in the transient window after

--- a/forven/market_data_collector.py
+++ b/forven/market_data_collector.py
@@ -396,10 +396,31 @@ def ensure_funding_history(
     - ``"exhausted"``  — the exchange has no data older than what is stored
     - ``"cooldown"``   — a recent attempt already failed to extend coverage
     - ``"error"``      — the backfill attempt itself failed
+    - ``"skipped_unknown_asset"`` — the asset exists nowhere in the lake or the
+      symbol registry (a fabricated symbol like MULTI/BASKET leaked in from a
+      strategy row); the venue is not asked at all
     """
     normalized_asset = str(asset or "").strip().upper()
     if not normalized_asset:
         return {"action": "error", "error": "empty asset"}
+
+    # SYMBOL-VALID-1 companion: assets are enumerated from strategy symbols, so a
+    # fabricated symbol (MULTI/USDT, BASKET/USDT) used to reach this backfill and
+    # hammer the venue every cooldown lapse (observed: repeated 429/500 pages,
+    # every 6h, forever). An asset with no lake dir and no registry row cannot
+    # have funding history — skip without a network call. Fails open when the
+    # system has no lake/registry evidence at all (fresh install).
+    try:
+        from forven.dataeng.coverage import known_base_asset
+
+        if not known_base_asset(normalized_asset):
+            log.info(
+                "Funding backfill skipped for %s: unknown asset (no lake data, "
+                "no registry row)", normalized_asset,
+            )
+            return {"action": "skipped_unknown_asset", "asset": normalized_asset}
+    except Exception:
+        pass
     start_ms = int(start_ms)
     now = datetime.now(timezone.utc)
 

--- a/tests/test_forge_stuck_pipeline_fixes.py
+++ b/tests/test_forge_stuck_pipeline_fixes.py
@@ -248,7 +248,6 @@ def test_validate_symbol_fails_open_without_evidence(monkeypatch, tmp_path):
 
 
 def test_create_strategy_container_rejects_bad_symbol(forven_db, monkeypatch):
-    from forven import db as db_mod
     from forven.db import create_strategy_container, get_db
     from forven.dataeng import coverage
 

--- a/tests/test_forge_stuck_pipeline_fixes.py
+++ b/tests/test_forge_stuck_pipeline_fixes.py
@@ -1,0 +1,406 @@
+"""Fixes for the Forge stuck-strategy clusters (2026-07-16).
+
+Covers:
+  * catch-up plan ordered by staleness (head-of-line starvation fix)
+  * ensure_coverage strike-out for unfillable series (fake symbols)
+  * SYMBOL-VALID-1 mint-time symbol validation / repair
+  * funding-collector skip for unknown assets
+  * zombie-workflow cancellation for terminal-stage strategies
+  * paper-gate wfa_window_insufficient actually re-queues walk_forward
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Catch-up plan ordering
+# ---------------------------------------------------------------------------
+
+
+class _FakeCatalog:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def list_coverage(self):
+        return list(self._rows)
+
+
+def _coverage_row(symbol: str, timeframe: str, end_ts: datetime, *, row_count: int = 100000) -> dict:
+    start = end_ts - timedelta(days=400)
+    return {
+        "source": "binance",
+        "market": "spot",
+        "symbol": symbol,
+        "timeframe": timeframe,
+        "stream": "candles",
+        "path": f"{symbol}/{timeframe}.parquet",
+        "start_ts": start.isoformat(),
+        "end_ts": end_ts.isoformat(),
+        "row_count": row_count,
+    }
+
+
+def test_catchup_plan_orders_by_staleness_not_alphabet():
+    from forven.dataeng.catchup import CatchUpPlanner
+
+    now = datetime(2026, 7, 16, 12, 0, tzinfo=timezone.utc)
+    rows = [
+        # Alphabetically first, barely stale (20 minutes behind on 5m bars).
+        _coverage_row("AAA-USDT", "5m", now - timedelta(minutes=20)),
+        # Alphabetically last, frozen for two weeks.
+        _coverage_row("ZZZ-USDT", "1h", now - timedelta(days=14)),
+        # Middle staleness.
+        _coverage_row("MMM-USDT", "4h", now - timedelta(days=2)),
+    ]
+    planner = CatchUpPlanner(catalog=_FakeCatalog(rows))
+    planner._bootstrap_tasks = lambda now_ts, covered: []  # isolate gap-fill ordering
+
+    plan = planner.plan(now=now)
+    symbols = [t.symbol for t in plan]
+
+    assert symbols == ["ZZZ-USDT", "MMM-USDT", "AAA-USDT"], (
+        "plan must serve the most-stale series first, not alphabetical order: "
+        f"{symbols}"
+    )
+
+
+def test_catchup_plan_appends_bootstraps_after_gap_fills():
+    from forven.dataeng.catchup import CatchUpPlanner, CatchUpTask
+
+    now = datetime(2026, 7, 16, 12, 0, tzinfo=timezone.utc)
+    rows = [_coverage_row("AAA-USDT", "1h", now - timedelta(days=3))]
+    planner = CatchUpPlanner(catalog=_FakeCatalog(rows))
+    bootstrap = CatchUpTask(
+        source="binance", market="spot", symbol="NEW-USDT", timeframe="1h",
+        stream="candles", start_ts=now.isoformat(), end_ts=now.isoformat(),
+        reason="bootstrap",
+    )
+    planner._bootstrap_tasks = lambda now_ts, covered: [bootstrap]
+
+    plan = planner.plan(now=now)
+
+    assert [t.symbol for t in plan] == ["AAA-USDT", "NEW-USDT"]
+    assert plan[-1].reason == "bootstrap"
+
+
+# ---------------------------------------------------------------------------
+# ensure_coverage strike-out
+# ---------------------------------------------------------------------------
+
+
+def _failed_run(symbol: str, timeframe: str, error: str, started_at: str) -> dict:
+    return {
+        "id": f"run-{started_at}",
+        "symbol": symbol,
+        "timeframe": timeframe,
+        "status": "failed",
+        "error": error,
+        "started_at": started_at,
+    }
+
+
+def test_ensure_coverage_strikes_out_deterministic_bad_symbol(monkeypatch):
+    from forven.dataeng import coverage
+
+    monkeypatch.setenv("FORVEN_DATA_AUTOBACKFILL", "1")
+    monkeypatch.setattr(coverage, "coverage_days", lambda symbol, tf: 0.0)
+    runs = [
+        _failed_run("MULTI/USDT", "1h", "binance does not have market symbol MULTI/USDT", "2026-07-16T01:00:00"),
+        _failed_run("MULTI/USDT", "1h", "binance does not have market symbol MULTI/USDT", "2026-07-16T02:00:00"),
+    ]
+    monkeypatch.setattr("forven.data.get_active_ingestion_runs", lambda: list(runs))
+
+    submitted = []
+    monkeypatch.setattr(
+        "forven.data.submit_ingestion",
+        lambda **kwargs: submitted.append(kwargs) or {"id": "run-new", "status": "pending"},
+    )
+
+    res = coverage.ensure_coverage("MULTI/USDT", "1h", 365)
+
+    assert res["status"] == "unfillable"
+    assert res["failed_attempts"] == 2
+    assert "does not have market symbol" in res["last_error"]
+    assert submitted == [], "a struck-out series must not resubmit a backfill"
+
+
+def test_ensure_coverage_generic_failures_strike_out_only_at_five(monkeypatch):
+    from forven.dataeng import coverage
+
+    monkeypatch.setenv("FORVEN_DATA_AUTOBACKFILL", "1")
+    monkeypatch.setattr(coverage, "coverage_days", lambda symbol, tf: 0.0)
+
+    def _runs(n):
+        return [
+            _failed_run("BASKET/USDT", "1h", "candle source binance circuit is open", f"2026-07-16T0{i}:00:00")
+            for i in range(n)
+        ]
+
+    monkeypatch.setattr("forven.data.get_active_ingestion_runs", lambda: _runs(4))
+    monkeypatch.setattr(
+        "forven.data.submit_ingestion",
+        lambda **kwargs: {"id": "run-new", "status": "pending"},
+    )
+    res = coverage.ensure_coverage("BASKET/USDT", "1h", 365)
+    assert res["status"] == "backfilling", "4 generic failures keep the retry path"
+
+    monkeypatch.setattr("forven.data.get_active_ingestion_runs", lambda: _runs(5))
+    res = coverage.ensure_coverage("BASKET/USDT", "1h", 365)
+    assert res["status"] == "unfillable"
+
+
+def test_ensure_coverage_completed_run_breaks_streak(monkeypatch):
+    from forven.dataeng import coverage
+
+    monkeypatch.setenv("FORVEN_DATA_AUTOBACKFILL", "1")
+    monkeypatch.setattr(coverage, "coverage_days", lambda symbol, tf: 0.0)
+    runs = [
+        _failed_run("ETH/USDT", "1h", "binance does not have market symbol", "2026-07-16T01:00:00"),
+        {
+            "id": "run-ok", "symbol": "ETH/USDT", "timeframe": "1h",
+            "status": "completed", "error": None, "started_at": "2026-07-16T02:00:00",
+        },
+    ]
+    monkeypatch.setattr("forven.data.get_active_ingestion_runs", lambda: list(runs))
+
+    streak, _err = coverage._failed_ingestion_streak("ETH/USDT", "1h")
+    assert streak == 0, "a completed run must break the failure streak"
+
+
+# ---------------------------------------------------------------------------
+# SYMBOL-VALID-1: mint-time validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _symbol_evidence(monkeypatch, tmp_path):
+    """A lake with BTC-USDT + ETH-BTC data and a registry listing ETH-USDT."""
+    import forven.data as data_mod
+    from forven.dataeng import universe
+
+    for fs in ("BTC-USDT", "ETH-BTC", "SOL-USDT"):
+        d = tmp_path / fs
+        d.mkdir()
+        (d / "1h.parquet").write_bytes(b"")
+    monkeypatch.setattr(data_mod, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(
+        universe, "get_symbol_registry",
+        lambda catalog=None: [{"symbol": "ETH-USDT", "status": "active"}],
+    )
+    return tmp_path
+
+
+def test_validate_symbol_accepts_lake_and_registry_series(_symbol_evidence):
+    from forven.dataeng.coverage import validate_strategy_symbol
+
+    assert validate_strategy_symbol("BTC/USDT")["ok"] is True
+    assert validate_strategy_symbol("ETH/BTC")["ok"] is True  # lake-backed spot cross
+    assert validate_strategy_symbol("ETH/USDT")["ok"] is True  # registry-backed
+
+
+def test_validate_symbol_rejects_fabricated_symbols(_symbol_evidence):
+    from forven.dataeng.coverage import validate_strategy_symbol
+
+    for fake in ("MULTI/USDT", "BASKET/USDT"):
+        verdict = validate_strategy_symbol(fake)
+        assert verdict["ok"] is False, f"{fake} must be rejected"
+        assert verdict["reason"]
+
+
+def test_validate_symbol_repairs_timeframe_suffix_leak(_symbol_evidence):
+    from forven.dataeng.coverage import validate_strategy_symbol
+
+    verdict = validate_strategy_symbol("ETH/USDT-8H")
+    assert verdict["ok"] is True
+    assert verdict["repaired"] is True
+    assert verdict["symbol"] == "ETH/USDT"
+
+    verdict = validate_strategy_symbol("BTC-USDT-1D")
+    assert verdict["ok"] is True
+    assert verdict["symbol"] == "BTC/USDT"
+
+
+def test_validate_symbol_allows_plausible_new_pair(_symbol_evidence):
+    from forven.dataeng.coverage import validate_strategy_symbol
+
+    # SOL has lake evidence (SOL-USDT); SOL/BTC is a plausible uncollected cross —
+    # allowed through; the ensure_coverage strike-out is the backstop.
+    assert validate_strategy_symbol("SOL/BTC")["ok"] is True
+    # Same rule admits an inverted-but-plausible cross like BTC/ETH (both assets
+    # known): mint can't know the venue's market list without a network call, so
+    # it defers to the strike-out, which terminates it after 2 BadSymbol failures.
+    assert validate_strategy_symbol("BTC/ETH")["ok"] is True
+
+
+def test_validate_symbol_fails_open_without_evidence(monkeypatch, tmp_path):
+    import forven.data as data_mod
+    from forven.dataeng import universe
+    from forven.dataeng.coverage import validate_strategy_symbol
+
+    monkeypatch.setattr(data_mod, "DATA_DIR", tmp_path / "empty")
+    monkeypatch.setattr(universe, "get_symbol_registry", lambda catalog=None: [])
+
+    assert validate_strategy_symbol("MULTI/USDT")["ok"] is True
+
+
+def test_create_strategy_container_rejects_bad_symbol(forven_db, monkeypatch):
+    from forven import db as db_mod
+    from forven.db import create_strategy_container, get_db
+    from forven.dataeng import coverage
+
+    monkeypatch.setattr(
+        coverage, "validate_strategy_symbol",
+        lambda symbol: {"ok": False, "symbol": symbol, "repaired": False, "reason": "unknown market"},
+    )
+    with get_db() as conn:
+        with pytest.raises(ValueError, match="unknown market"):
+            create_strategy_container(
+                conn=conn, name="Bad Symbol", type_="rsi_momentum",
+                symbol="MULTI/USDT", timeframe="1h", params={}, stage="quick_screen",
+            )
+
+
+def test_create_strategy_container_persists_repaired_symbol(forven_db, monkeypatch):
+    from forven.db import create_strategy_container, get_db
+    from forven.dataeng import coverage
+
+    monkeypatch.setattr(
+        coverage, "validate_strategy_symbol",
+        lambda symbol: {"ok": True, "symbol": "ETH/USDT", "repaired": True, "reason": "stripped suffix"},
+    )
+    with get_db() as conn:
+        strategy_id, _display, _base = create_strategy_container(
+            conn=conn, name="Repaired Symbol", type_="rsi_momentum",
+            symbol="ETH/USDT-8H", timeframe="8h", params={}, stage="quick_screen",
+        )
+        row = conn.execute("SELECT symbol FROM strategies WHERE id = ?", (strategy_id,)).fetchone()
+    assert row["symbol"] == "ETH/USDT"
+
+
+# ---------------------------------------------------------------------------
+# Funding collector guard
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_funding_history_skips_unknown_asset(forven_db, monkeypatch):
+    from forven.dataeng import coverage
+    from forven.market_data_collector import ensure_funding_history
+
+    monkeypatch.setattr(coverage, "known_base_asset", lambda base: False)
+
+    res = ensure_funding_history("MULTI", 1_700_000_000_000)
+
+    assert res["action"] == "skipped_unknown_asset"
+
+
+def test_ensure_funding_history_known_asset_proceeds(forven_db, monkeypatch):
+    from forven.dataeng import coverage
+    from forven.market_data_collector import ensure_funding_history
+
+    monkeypatch.setattr(coverage, "known_base_asset", lambda base: True)
+    monkeypatch.setattr(
+        "forven.market_data_collector.get_funding_coverage_bounds",
+        lambda asset: (None, None),
+    )
+    calls = []
+    monkeypatch.setattr(
+        "forven.market_data_collector.backfill_funding_history",
+        lambda asset, days_back: calls.append(asset) or {"stored": 0},
+    )
+
+    res = ensure_funding_history("BTC", 1_700_000_000_000)
+
+    assert res["action"] in {"backfilled", "exhausted"}
+    assert calls == ["BTC"]
+
+
+# ---------------------------------------------------------------------------
+# Zombie workflows + WFA re-run re-queue
+# ---------------------------------------------------------------------------
+
+
+def _mint_with_workflow(stage: str = "quick_screen"):
+    from forven.db import create_strategy_container, get_db
+    from forven.gauntlet.store import create_or_get_workflow
+
+    with get_db() as conn:
+        strategy_id, _display, _base = create_strategy_container(
+            conn=conn, name="Zombie Test", type_="rsi_momentum",
+            symbol="BTC/USDT", timeframe="1h", params={"rsi_period": 14}, stage=stage,
+        )
+    workflow = create_or_get_workflow(
+        strategy_id=strategy_id, created_by="pytest", settings_snapshot={},
+    )
+    return strategy_id, workflow
+
+
+def test_cancel_orphaned_terminal_workflows(forven_db):
+    from forven.db import get_db
+    from forven.gauntlet.engine import cancel_orphaned_terminal_workflows
+
+    live_id, live_wf = _mint_with_workflow()
+    dead_id, dead_wf = _mint_with_workflow()
+    with get_db() as conn:
+        conn.execute("UPDATE strategies SET stage = 'archived' WHERE id = ?", (dead_id,))
+
+    cancelled = cancel_orphaned_terminal_workflows()
+
+    assert cancelled == 1
+    with get_db() as conn:
+        dead_status = conn.execute(
+            "SELECT status FROM gauntlet_workflows WHERE id = ?", (dead_wf["id"],)
+        ).fetchone()["status"]
+        live_status = conn.execute(
+            "SELECT status FROM gauntlet_workflows WHERE id = ?", (live_wf["id"],)
+        ).fetchone()["status"]
+    assert dead_status == "cancelled"
+    assert live_status != "cancelled"
+
+
+def test_requeue_walk_forward_for_window_rerun(forven_db):
+    from forven.db import get_db
+    from forven.gauntlet.tasks import _requeue_walk_forward_for_window_rerun
+
+    _sid, workflow = _mint_with_workflow()
+    with get_db() as conn:
+        conn.execute(
+            """UPDATE gauntlet_steps SET status = 'passed', attempt_count = 1
+               WHERE workflow_id = ? AND step_key = 'walk_forward'""",
+            (workflow["id"],),
+        )
+
+    assert _requeue_walk_forward_for_window_rerun(workflow) is True
+    with get_db() as conn:
+        row = conn.execute(
+            """SELECT status, attempt_count FROM gauntlet_steps
+               WHERE workflow_id = ? AND step_key = 'walk_forward'""",
+            (workflow["id"],),
+        ).fetchone()
+    assert row["status"] == "queued"
+    assert row["attempt_count"] == 1, "re-queue must NOT reset the attempt budget"
+
+
+def test_requeue_walk_forward_respects_attempt_budget(forven_db):
+    from forven.db import get_db
+    from forven.gauntlet.tasks import _requeue_walk_forward_for_window_rerun
+
+    _sid, workflow = _mint_with_workflow()
+    with get_db() as conn:
+        conn.execute(
+            """UPDATE gauntlet_steps SET status = 'passed', attempt_count = 3, max_attempts = 3
+               WHERE workflow_id = ? AND step_key = 'walk_forward'""",
+            (workflow["id"],),
+        )
+
+    assert _requeue_walk_forward_for_window_rerun(workflow) is False
+    with get_db() as conn:
+        row = conn.execute(
+            """SELECT status FROM gauntlet_steps
+               WHERE workflow_id = ? AND step_key = 'walk_forward'""",
+            (workflow["id"],),
+        ).fetchone()
+    assert row["status"] == "passed", "budget-exhausted step must be left alone"


### PR DESCRIPTION
## Why

The Forge investigation (2026-07-16) found 31 non-terminal gauntlet workflows stuck, and behind them **342 of 350 lake series stale** (bulk frozen since ~07-02). Four distinct mechanisms, four fixes.

## What

1. **DATA-STARVE-1 — staleness-first catch-up plan** (`dataeng/catchup.py`). The 12-task/30-min drain consumed its whole batch on the alphabetically-first symbols' sub-hour series (which re-stale every few minutes), so everything past the alphabetical horizon stayed frozen for weeks: ETH/BTC (4 strategies blocked), HYPE (3), PERP. The plan is now ordered most-stale-first — an aging queue where nothing starves. Interior-gap repairs queue at priority 0 behind end-staleness work; bootstraps still append last.

2. **SYMBOL-VALID-1 — mint-time symbol validation** (`dataeng/coverage.py`, `db.py`). Strategies were minted on fabricated symbols (`MULTI/USDT`, `BASKET/USDT`), inverted pairs, and dataset-context leaks (`ETH/USDT-8H`, `BTC-USDT-1D`). Now: repairable leaks are repaired (strip trailing timeframe token), fabricated symbols are rejected loudly at `create_strategy_container` (all creation paths incl. sandbox/dropzone). Fails open on infra errors, empty-evidence installs, and omitted symbols (legacy default-fill preserved).

3. **UNFILLABLE-1 — backfill strike-out** (`dataeng/coverage.py`, `gauntlet/tasks.py`, `market_data_collector.py`). `ensure_coverage` resubmitted a failed backfill every tick forever (33 failed runs observed for MULTI/USDT). Now a series strikes out after 2 deterministic venue does-not-have-symbol failures (or 5 consecutive zero-progress failures), quick_screen converts that to a terminal `failed_gate` with a self-documenting message, and the funding collector skips unknown assets instead of hammering fundingHistory into 429s every 6h — the same HL rate budget the book-equity reads depend on.

4. **WFA-RERUN-1 + ZOMBIE-WF-1 — advancer fixes** (`gauntlet/tasks.py`, `gauntlet/engine.py`). The paper gate's `wfa_window_insufficient` block promises "re-run WFA on the trade-frequency-aware window" and is (correctly) drain-exempt — but nothing ever re-armed the already-passed walk_forward step, so 5 candidates with composite scores 94–100 sat blocked for days retrying against the same insufficient artifact. The gate now re-queues walk_forward, bounded by the step's own attempt budget. A new sweep cancels non-terminal workflows for archived/rejected strategies (8 zombies dated to June).

## Impact on currently-stuck strategies (after deploy + restart)

- 7 data-stale strategies unblock as the lake heals (ETH/BTC ~15 days behind will take a few drain cycles)
- 6 fake-symbol strategies terminate cleanly with an actionable error instead of looping
- 5 WFA-blocked candidates (the best in the pipeline: DSR 0.66, composite 94–100) get their re-run and a real verdict
- 8 zombie workflows disappear from the Forge

## Tests

`tests/test_forge_stuck_pipeline_fixes.py` — 17 tests covering plan ordering, strike-out streak logic, symbol validation/repair/fail-open, mint rejection + repaired-symbol persistence, funding-collector skip, zombie sweep, and the WFA re-queue (incl. attempt-budget bound). Targeted sweep: **596 passed**; the 8 remaining failures are the known pre-existing environmental baseline, verified identical on clean main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)