### PR TITLE
fix(runtime): kill the zombie-backend death spiral

### DIFF
--- a/forven/api.py
+++ b/forven/api.py
@@ -185,6 +185,48 @@ def _spawn_supervised_runtime_thread(
     return thread
 
 
+_zombie_reaper_started = False
+
+
+def _spawn_zombie_reaper() -> None:
+    """Force-exit the process if interpreter teardown wedges after the main thread dies.
+
+    When uvicorn's main thread exits (signal, crash, console event) a non-daemon
+    thread can block ``threading._shutdown`` forever. The process then lives on as
+    a zombie: no listener, executors poisoned ("cannot schedule new futures after
+    interpreter shutdown"), but still holding the runtime-worker and daemon file
+    locks — so the supervisor's replacement backend boots with NO background
+    loops. The 2026-07-18..20 outage was days of exactly this. A healthy shutdown
+    finishes well inside the grace window; if we are still alive after it, nothing
+    useful can ever run again, so hard-exit and let the supervisor restart clean.
+    """
+    global _zombie_reaper_started
+    if _zombie_reaper_started:
+        return
+    grace = _env_float("FORVEN_ZOMBIE_REAPER_GRACE_SECONDS", 45.0, minimum=0.0, maximum=600.0)
+    if grace <= 0:
+        log.info("Zombie reaper disabled (FORVEN_ZOMBIE_REAPER_GRACE_SECONDS<=0)")
+        return
+    main_thread = threading.main_thread()
+
+    def _watch() -> None:
+        main_thread.join()
+        threading.Event().wait(grace)
+        try:
+            log.critical(
+                "Main thread exited %.0fs ago but the process is still alive; "
+                "forcing exit so the supervisor can restart a working backend.",
+                grace,
+            )
+            logging.shutdown()
+        except Exception:
+            pass
+        os._exit(86)
+
+    threading.Thread(target=_watch, name="forven-zombie-reaper", daemon=True).start()
+    _zombie_reaper_started = True
+
+
 # Windows Proactor loop can intermittently reset accepted sockets under mixed
 # HTTP/WebSocket load. Use selector policy for API stability on Windows.
 if sys.platform.startswith("win"):
@@ -236,6 +278,8 @@ async def lifespan(_app: FastAPI):
     # Configure logging FIRST so every subsequent startup step, the scheduler
     # loop, and the agent workers emit observable log lines under any launcher.
     _configure_runtime_logging()
+
+    _spawn_zombie_reaper()
 
     # Surface missing/incompatible DECLARED dependencies at boot, under ANY
     # launcher. The shell launchers preflight before starting, but a direct
@@ -426,6 +470,139 @@ async def lifespan(_app: FastAPI):
     # pure control plane — used by the Playwright e2e harness to get a
     # deterministic, network-quiet backend. Never set this on a real install:
     # without a separate `forven daemon start` nothing trades or ticks.
+    def _start_runtime_workers() -> None:
+        # Caller must already hold the runtime worker lock. Factored out of the
+        # startup branch so the deferred-acquisition retry thread below can start
+        # the identical stack when the lock frees late.
+        nonlocal _scheduler_task, _agent_worker_task, _brain_worker_task, _daemon_task
+        from forven.scheduler import reset_scheduler_job_locks, run_scheduler_loop
+
+        recovered_job_locks = reset_scheduler_job_locks()
+        if recovered_job_locks:
+            log.info("API runtime worker cleared %d inherited scheduler job lock(s) at startup", recovered_job_locks)
+
+        agent_concurrency = _env_int("FORVEN_HEADLESS_AGENT_CONCURRENCY", 3, minimum=1, maximum=8)
+        brain_limit = _env_int("FORVEN_HEADLESS_BRAIN_LIMIT", 2, minimum=1, maximum=8)
+        runtime_thread_mode = _env_bool("FORVEN_API_RUNTIME_THREAD_MODE", True)
+        runtime_start_delay = _env_float("FORVEN_API_RUNTIME_START_DELAY_SECONDS", 5.0, minimum=0.0, maximum=60.0)
+        # BOOT-1: close the startup-recovery gate BEFORE the scheduler/scanner thread
+        # can run a live execution scan, so a stale recovery_active=False persisted by
+        # a cleanly-exited prior run can't let a live entry through during the boot
+        # window before the daemon's boot reconcile re-verifies the exchange.
+        try:
+            from forven.daemon import mark_boot_recovery_pending
+            mark_boot_recovery_pending()
+        except Exception:
+            log.warning("Could not stamp boot recovery gate", exc_info=True)
+        if runtime_thread_mode:
+            _runtime_threads.extend(
+                [
+                    _spawn_supervised_runtime_thread(
+                        "scheduler-loop",
+                        lambda: run_scheduler_loop(interval_seconds=30),
+                        initial_delay_seconds=runtime_start_delay,
+                    ),
+                    _spawn_supervised_runtime_thread(
+                        "headless-agent-loop",
+                        lambda: run_headless_agent_loop(poll_seconds=5.0, concurrency=agent_concurrency),
+                        initial_delay_seconds=runtime_start_delay,
+                    ),
+                    _spawn_supervised_runtime_thread(
+                        "headless-brain-loop",
+                        lambda: run_headless_brain_loop(poll_seconds=20.0, limit=brain_limit),
+                        initial_delay_seconds=runtime_start_delay,
+                    ),
+                ]
+            )
+        else:
+            _scheduler_task = _spawn_supervised_loop(
+                "scheduler-loop",
+                lambda: run_scheduler_loop(interval_seconds=30),
+            )
+            _agent_worker_task = _spawn_supervised_loop(
+                "headless-agent-loop",
+                lambda: run_headless_agent_loop(poll_seconds=5.0, concurrency=agent_concurrency),
+            )
+            _brain_worker_task = _spawn_supervised_loop(
+                "headless-brain-loop",
+                lambda: run_headless_brain_loop(poll_seconds=20.0, limit=brain_limit),
+            )
+
+        # Host the data/risk daemon in-process so a Discord-less install
+        # (Tauri shell only spawns `python -m forven.api`) still drives the
+        # market feed, price ticks, and daemon_state heartbeat. The daemon
+        # holds its own file lock so an external `forven daemon start` wins
+        # if it's already running.
+        try:
+            from forven.daemon import run_in_loop as run_daemon_in_loop
+            if runtime_thread_mode:
+                _runtime_threads.append(
+                    _spawn_supervised_runtime_thread(
+                        "daemon-loop",
+                        run_daemon_in_loop,
+                        initial_delay_seconds=runtime_start_delay,
+                    )
+                )
+            else:
+                _daemon_task = spawn(run_daemon_in_loop(), name="daemon-loop")
+            log.info(
+                "API runtime worker started: scheduler + headless agent loop "
+                "(concurrency=%d) + headless brain loop (limit=%d) + data/risk daemon "
+                "(thread_mode=%s, start_delay=%.1fs)",
+                agent_concurrency,
+                brain_limit,
+                runtime_thread_mode,
+                runtime_start_delay,
+            )
+        except Exception:
+            log.exception("Failed to start in-process daemon loop.")
+            # BOOT-1: no daemon will run its boot reconcile in this process, so
+            # release the startup-recovery gate we stamped above (else paper trading
+            # is wedged forever). Live still fails closed on missing real equity.
+            try:
+                from forven.daemon import clear_boot_recovery_pending
+                clear_boot_recovery_pending("daemon_unavailable")
+            except Exception:
+                log.warning("Could not release boot recovery gate after daemon-start failure", exc_info=True)
+            log.info(
+                "API runtime worker started: scheduler + headless agent loop "
+                "(concurrency=%d) + headless brain loop (limit=%d) (daemon unavailable, thread_mode=%s, start_delay=%.1fs)",
+                agent_concurrency,
+                brain_limit,
+                runtime_thread_mode,
+                runtime_start_delay,
+            )
+
+    _runtime_lock_retry_stop = threading.Event()
+
+    def _spawn_runtime_lock_retry_thread() -> None:
+        # The lock holder may be a zombie backend stuck in interpreter teardown
+        # (see _spawn_zombie_reaper): its listener is gone but its file locks are
+        # not. Once the reaper or the supervisor kills it the lock frees — but
+        # startup has already passed, and without this retry the replacement
+        # backend would serve a healthy-looking API forever with NO background
+        # loops (no scheduler, no gauntlet advancer, no data/risk daemon).
+        def _retry() -> None:
+            nonlocal _api_runtime_lock_held
+            while not _runtime_lock_retry_stop.wait(30.0):
+                if not acquire_runtime_worker_lock():
+                    continue
+                if _runtime_lock_retry_stop.is_set():
+                    release_runtime_worker_lock()
+                    return
+                _api_runtime_lock_held = True
+                try:
+                    _start_runtime_workers()
+                    log.warning(
+                        "Runtime worker lock acquired after startup; background "
+                        "loops are now running in this process."
+                    )
+                except Exception:
+                    log.exception("Deferred runtime worker start failed.")
+                return
+
+        threading.Thread(target=_retry, name="forven-runtime-lock-retry", daemon=True).start()
+
     try:
         if _env_bool("FORVEN_API_CONTROL_PLANE_ONLY", False):
             log.info(
@@ -434,105 +611,15 @@ async def lifespan(_app: FastAPI):
             )
         elif acquire_runtime_worker_lock():
             _api_runtime_lock_held = True
-            from forven.scheduler import reset_scheduler_job_locks, run_scheduler_loop
-
-            recovered_job_locks = reset_scheduler_job_locks()
-            if recovered_job_locks:
-                log.info("API runtime worker cleared %d inherited scheduler job lock(s) at startup", recovered_job_locks)
-
-            agent_concurrency = _env_int("FORVEN_HEADLESS_AGENT_CONCURRENCY", 3, minimum=1, maximum=8)
-            brain_limit = _env_int("FORVEN_HEADLESS_BRAIN_LIMIT", 2, minimum=1, maximum=8)
-            runtime_thread_mode = _env_bool("FORVEN_API_RUNTIME_THREAD_MODE", True)
-            runtime_start_delay = _env_float("FORVEN_API_RUNTIME_START_DELAY_SECONDS", 5.0, minimum=0.0, maximum=60.0)
-            # BOOT-1: close the startup-recovery gate BEFORE the scheduler/scanner thread
-            # can run a live execution scan, so a stale recovery_active=False persisted by
-            # a cleanly-exited prior run can't let a live entry through during the boot
-            # window before the daemon's boot reconcile re-verifies the exchange.
-            try:
-                from forven.daemon import mark_boot_recovery_pending
-                mark_boot_recovery_pending()
-            except Exception:
-                log.warning("Could not stamp boot recovery gate", exc_info=True)
-            if runtime_thread_mode:
-                _runtime_threads.extend(
-                    [
-                        _spawn_supervised_runtime_thread(
-                            "scheduler-loop",
-                            lambda: run_scheduler_loop(interval_seconds=30),
-                            initial_delay_seconds=runtime_start_delay,
-                        ),
-                        _spawn_supervised_runtime_thread(
-                            "headless-agent-loop",
-                            lambda: run_headless_agent_loop(poll_seconds=5.0, concurrency=agent_concurrency),
-                            initial_delay_seconds=runtime_start_delay,
-                        ),
-                        _spawn_supervised_runtime_thread(
-                            "headless-brain-loop",
-                            lambda: run_headless_brain_loop(poll_seconds=20.0, limit=brain_limit),
-                            initial_delay_seconds=runtime_start_delay,
-                        ),
-                    ]
-                )
-            else:
-                _scheduler_task = _spawn_supervised_loop(
-                    "scheduler-loop",
-                    lambda: run_scheduler_loop(interval_seconds=30),
-                )
-                _agent_worker_task = _spawn_supervised_loop(
-                    "headless-agent-loop",
-                    lambda: run_headless_agent_loop(poll_seconds=5.0, concurrency=agent_concurrency),
-                )
-                _brain_worker_task = _spawn_supervised_loop(
-                    "headless-brain-loop",
-                    lambda: run_headless_brain_loop(poll_seconds=20.0, limit=brain_limit),
-                )
-
-            # Host the data/risk daemon in-process so a Discord-less install
-            # (Tauri shell only spawns `python -m forven.api`) still drives the
-            # market feed, price ticks, and daemon_state heartbeat. The daemon
-            # holds its own file lock so an external `forven daemon start` wins
-            # if it's already running.
-            try:
-                from forven.daemon import run_in_loop as run_daemon_in_loop
-                if runtime_thread_mode:
-                    _runtime_threads.append(
-                        _spawn_supervised_runtime_thread(
-                            "daemon-loop",
-                            run_daemon_in_loop,
-                            initial_delay_seconds=runtime_start_delay,
-                        )
-                    )
-                else:
-                    _daemon_task = spawn(run_daemon_in_loop(), name="daemon-loop")
-                log.info(
-                    "API runtime worker started: scheduler + headless agent loop "
-                    "(concurrency=%d) + headless brain loop (limit=%d) + data/risk daemon "
-                    "(thread_mode=%s, start_delay=%.1fs)",
-                    agent_concurrency,
-                    brain_limit,
-                    runtime_thread_mode,
-                    runtime_start_delay,
-                )
-            except Exception:
-                log.exception("Failed to start in-process daemon loop.")
-                # BOOT-1: no daemon will run its boot reconcile in this process, so
-                # release the startup-recovery gate we stamped above (else paper trading
-                # is wedged forever). Live still fails closed on missing real equity.
-                try:
-                    from forven.daemon import clear_boot_recovery_pending
-                    clear_boot_recovery_pending("daemon_unavailable")
-                except Exception:
-                    log.warning("Could not release boot recovery gate after daemon-start failure", exc_info=True)
-                log.info(
-                    "API runtime worker started: scheduler + headless agent loop "
-                    "(concurrency=%d) + headless brain loop (limit=%d) (daemon unavailable, thread_mode=%s, start_delay=%.1fs)",
-                    agent_concurrency,
-                    brain_limit,
-                    runtime_thread_mode,
-                    runtime_start_delay,
-                )
+            _start_runtime_workers()
         else:
-            log.info("API runtime worker lock not acquired; another process owns background loops")
+            log.info(
+                "API runtime worker lock not acquired; another process owns "
+                "background loops — retrying every 30s in case the owner is a "
+                "dying process."
+            )
+            if _env_bool("FORVEN_API_RUNTIME_THREAD_MODE", True):
+                _spawn_runtime_lock_retry_thread()
     except Exception:
         log.exception("Failed to start API runtime worker.")
 
@@ -561,6 +648,10 @@ async def lifespan(_app: FastAPI):
             pass
 
     yield
+
+    # Stop the deferred runtime-lock retry so it can't grab the lock while
+    # we are tearing down.
+    _runtime_lock_retry_stop.set()
 
     # Signal the in-process daemon loop to exit so _price_consumer /
     # async_market_loop break out of their `while not shutdown.is_set()` waits

--- a/forven/gauntlet/tasks.py
+++ b/forven/gauntlet/tasks.py
@@ -262,10 +262,25 @@ _DETERMINISTIC_ERROR_TOKENS = (
     "does not support trade_mode",
 )
 
+# Process-teardown signatures checked BEFORE the deterministic tokens: a run that
+# died because the hosting interpreter/executor was shutting down mid-flight says
+# nothing about the strategy, but its message often EMBEDS a deterministic token
+# (e.g. "Indicator execution failed during in-sample: failed to serialize input
+# frame: cannot schedule new futures after interpreter shutdown") and would be
+# scored failed_gate -> archived. The 2026-07-19/20 zombie-backend incident
+# archived S05073/S07583/S07595/S07537/S07519 exactly this way.
+_INFRA_ERROR_TOKENS = (
+    "cannot schedule new futures",
+    "interpreter shutdown",
+    "event loop is closed",
+)
+
 
 def _classify_exception(exc: Exception) -> dict[str, Any]:
     detail = str(getattr(exc, "detail", exc))
     lowered = detail.lower()
+    if any(token in lowered for token in _INFRA_ERROR_TOKENS):
+        return {"status": "blocked_runtime", "message": detail, "retryable": True}
     if isinstance(exc, (NameError, AttributeError, TypeError, KeyError)) or any(
         token in lowered for token in _DETERMINISTIC_ERROR_TOKENS
     ):

--- a/start_all.ps1
+++ b/start_all.ps1
@@ -331,6 +331,47 @@ function Stop-ExistingBotProcesses {
     }
 }
 
+function Get-BackendProcessIds {
+    # Every backend uvicorn process for THIS repo, listener or not. A backend
+    # whose main thread died closes its listener but can survive as a zombie
+    # (background threads wedge interpreter teardown) while still holding the
+    # runtime-worker and daemon file locks - reaping only the port listeners
+    # leaves it alive and the replacement backend then boots with no background
+    # loops.
+    $escapedRepoRoot = [Regex]::Escape($script:RepoRoot)
+    try {
+        return @(
+            Get-CimInstance Win32_Process -Filter "Name = 'python.exe'" -ErrorAction Stop |
+                Where-Object {
+                    $cmd = [string]$_.CommandLine
+                    $cmd -match $escapedRepoRoot -and $cmd -match 'uvicorn' -and $cmd -match 'forven\.api'
+                } |
+                Select-Object -ExpandProperty ProcessId -Unique
+        )
+    } catch {
+        Write-WarnMessage "Backend process discovery failed: $($_.Exception.Message)"
+        return @()
+    }
+}
+
+function Stop-ZombieBackendProcesses {
+    param([int[]]$KeepProcessIds = @())
+
+    $keep = @($KeepProcessIds | Where-Object { $_ -and $_ -gt 0 })
+    $zombiePids = @(Get-BackendProcessIds | Where-Object { $keep -notcontains $_ })
+    if ($zombiePids.Count -eq 0) { return }
+    Write-WarnMessage "Reaping non-listening backend process(es): $($zombiePids -join ', ')"
+    foreach ($procId in $zombiePids) {
+        try {
+            Stop-Process -Id ([int]$procId) -Force -ErrorAction Stop
+        } catch {
+            if (Get-Process -Id ([int]$procId) -ErrorAction SilentlyContinue) {
+                Write-WarnMessage "Backend zombie PID $procId could not be stopped: $($_.Exception.Message)"
+            }
+        }
+    }
+}
+
 function Get-DaemonProcessIds {
     $escapedRepoRoot = [Regex]::Escape($script:RepoRoot)
     try {
@@ -707,10 +748,14 @@ function Start-BackendService {
     if (-not $portFreed) {
         if (Test-HttpHealthy -Url $backendHealth) {
             Write-Info "Port $backendPort still occupied but backend is healthy - reusing existing service."
+            Stop-ZombieBackendProcesses -KeepProcessIds @(Get-ListeningProcessIds -Port $backendPort)
             return $null
         }
         Throw-StartAllError "Port $backendPort occupied by unkillable process and service is not healthy."
     }
+    # Port is free; any backend process still alive is a zombie holding the
+    # runtime-worker/daemon locks the fresh backend needs.
+    Stop-ZombieBackendProcesses
     Write-Info "Starting backend on ${backendHost}:$backendPort ..."
     $proc = Start-LoggedProcess -FilePath $python -CommandArgs @("-m","uvicorn","--app-dir",$script:RepoRoot,"forven.api:app","--host",$backendHost,"--port",$backendPort.ToString(),"--workers",$backendWorkers.ToString()) `
         -WorkingDirectory $script:RepoRoot -StdOutPath $backendLog -StdErrPath $backendErr

--- a/tests/test_gauntlet_workflow_tasks.py
+++ b/tests/test_gauntlet_workflow_tasks.py
@@ -78,6 +78,34 @@ def test_trade_mode_unsupported_is_terminal_not_retryable():
     assert transient["retryable"] is True
 
 
+def test_interpreter_shutdown_is_infra_not_merit_failure():
+    """A run that died because the hosting process was tearing down says nothing
+    about the strategy. Its message often embeds a deterministic token (the
+    2026-07-19/20 zombie-backend incident produced 'Indicator execution failed
+    during in-sample: ... cannot schedule new futures after interpreter shutdown'
+    and archived five strategies as failed_gate) — the infra signature must win."""
+    from forven.gauntlet.tasks import _classify_exception
+
+    for msg in (
+        "Indicator execution failed during in-sample: failed to serialize input "
+        "frame: cannot schedule new futures after interpreter shutdown",
+        "cannot schedule new futures after shutdown",
+        "Event loop is closed",
+    ):
+        # RuntimeError and TypeError both occur in the wild; the infra signature
+        # must also beat the deterministic isinstance(TypeError) branch.
+        for exc in (RuntimeError(msg), TypeError(msg)):
+            verdict = _classify_exception(exc)
+            assert verdict["status"] == "blocked_runtime", msg
+            assert verdict["retryable"] is True, msg
+
+    # Control: a plain indicator failure without an infra signature is still a
+    # terminal strategy defect.
+    verdict = _classify_exception(ValueError("Indicator execution failed during in-sample: division by zero"))
+    assert verdict["status"] == "failed_gate"
+    assert verdict["retryable"] is False
+
+
 def test_quick_screen_pass_advances_to_gate(forven_db, monkeypatch):
     kv_set("forven:pipeline:settings", {"gauntlet_auto_quick_screen_enabled": True})
     created = create_lifecycle_strategy(

--- a/watchdog.ps1
+++ b/watchdog.ps1
@@ -61,6 +61,42 @@ function Get-ListeningPids {
     return $result
 }
 
+function Get-BackendProcessIds {
+    # Every backend process for THIS repo, listener or not. A backend whose main
+    # thread died closes its listener but can survive as a zombie (background
+    # threads wedge interpreter teardown) while still holding the runtime-worker
+    # and daemon file locks - killing only the listening PIDs leaves it alive and
+    # the replacement backend then boots with no background loops.
+    $result = @()
+    try {
+        $procs = Get-CimInstance Win32_Process -Filter "Name like 'python%'" -ErrorAction SilentlyContinue |
+            Where-Object {
+                $cmd = [string]$_.CommandLine
+                $cmd -match "uvicorn" -and $cmd -match "forven\.api" -and $cmd.ToLowerInvariant().Contains($RepoRoot.ToLowerInvariant())
+            }
+        foreach ($proc in @($procs)) {
+            if ($proc -and $proc.ProcessId) { $result += [int]$proc.ProcessId }
+        }
+    } catch {}
+    return @($result | Select-Object -Unique)
+}
+
+function Stop-BackendProcesses {
+    param([int[]]$ListenerPids)
+
+    $targets = @((@($ListenerPids) + @(Get-BackendProcessIds)) | Where-Object { $_ -and $_ -gt 0 } | Select-Object -Unique)
+    foreach ($procId in $targets) {
+        try {
+            Stop-Process -Id $procId -Force -ErrorAction Stop
+            Write-Log ("Stopped backend PID " + $procId)
+        } catch {
+            if (Get-Process -Id $procId -ErrorAction SilentlyContinue) {
+                Write-Log ("WARN: Could not stop backend PID " + $procId + ": " + $_.Exception.Message)
+            }
+        }
+    }
+}
+
 function Find-Python {
     $venvPy = Join-Path (Join-Path $RepoRoot ".venv") "Scripts\python.exe"
     if (Test-Path $venvPy) { return $venvPy }
@@ -335,15 +371,31 @@ try {
     }
     $watchdogOwnerLockHeld = $true
 
+    # --- Restart sentinel (self-update / operator-requested bounce) ---
+    # start_all's supervisor loop honors .tmp/restart.request; honor it here too
+    # so a restart requested while only the scheduled-task watchdog is running
+    # (no start_all console) still lands.
+    $restartSentinel = Join-Path (Join-Path $RepoRoot ".tmp") "restart.request"
+    $backendRestartForced = $false
+    if (Test-Path $restartSentinel) {
+        Write-Log "Restart sentinel found - bouncing backend to load new code."
+        try { Remove-Item -Path $restartSentinel -Force -ErrorAction Stop } catch {
+            Write-Log ("WARN: Could not remove restart sentinel: " + $_.Exception.Message)
+        }
+        $backendRestartForced = $true
+    }
+
     # --- Check Backend ---
     [array]$backendListeners = @(Get-ListeningPids -Port $BackendPort)
     $backendHealthy = Test-HttpHealthy -Url $HealthUrl
-    if ($backendListeners.Count -eq 0 -or -not $backendHealthy) {
-        $msg = "Backend DOWN (listeners=" + $backendListeners.Count + ", healthy=" + $backendHealthy + ") - restarting"
-        Write-Log $msg
-        foreach ($pid in $backendListeners) {
-            try { Stop-Process -Id $pid -Force -ErrorAction SilentlyContinue } catch {}
+    if ($backendRestartForced -or $backendListeners.Count -eq 0 -or -not $backendHealthy) {
+        $msg = if ($backendRestartForced) {
+            "Backend restart requested via sentinel - restarting"
+        } else {
+            "Backend DOWN (listeners=" + $backendListeners.Count + ", healthy=" + $backendHealthy + ") - restarting"
         }
+        Write-Log $msg
+        Stop-BackendProcesses -ListenerPids $backendListeners
         $backendLog = Join-Path $logRoot "unified_backend.log"
         $backendErr = Join-Path $logRoot "unified_backend.err.log"
         $proc = Start-Process -FilePath $python `
@@ -448,6 +500,19 @@ if (-not $daemonAlive) {
             Where-Object { $_.CommandLine -match "forven.*daemon" }
         if ($daemonProcs) { $daemonAlive = $true }
     } catch {}
+}
+if (-not $daemonAlive -and (Test-Path $daemonLockFile)) {
+    # The backend hosts the daemon in-process (thread_mode): no standalone daemon
+    # process exists, but the live daemon keeps an open handle on the lock file.
+    # If we cannot open it exclusively, a daemon is alive somewhere. Without this
+    # probe the watchdog spawned a doomed duplicate daemon every cycle ("Another
+    # daemon instance is already running").
+    try {
+        $probe = [System.IO.File]::Open($daemonLockFile, [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+        $probe.Dispose()
+    } catch {
+        $daemonAlive = $true
+    }
 }
 if (-not $daemonAlive) {
     if (Test-Path $daemonLockFile) { Remove-Item $daemonLockFile -Force -ErrorAction SilentlyContinue }


### PR DESCRIPTION
## The illness (2026-07-18..20 outage)

uvicorn's main thread dies (signal/console event/crash) but a non-daemon thread wedges `threading._shutdown`, leaving a **zombie backend**: listener closed, executors poisoned (`cannot schedule new futures after interpreter shutdown` — 71,348 hits in api.log.1), still holding `api_runtime_worker.lock` + `daemon.lock`. The watchdog only killed PIDs still *listening* on 8003, so the zombie survived every restart; the replacement backend logged "API runtime worker lock not acquired" (one-shot, no retry) and served the API with **no background loops**. Gauntlet runs dying inside the zombie were scored as gate failures and archived (S05073, S07583, S07595, S07537, S07519).

## Four independent breakers

1. **Zombie reaper** (`forven/api.py`): daemon thread joins the main thread; if the process survives `FORVEN_ZOMBIE_REAPER_GRACE_SECONDS` (45s, 0 disables) past main-thread exit, teardown is wedged → CRITICAL log + `os._exit(86)` so the supervisor restarts something that works.
2. **Runtime-lock retry** (`forven/api.py`): "another process owns background loops" now retries every 30s (thread mode) and starts the identical worker stack when the dying owner releases the lock. Startup body factored into `_start_runtime_workers()` shared by both paths; retry stops cleanly at lifespan shutdown.
3. **Supervisor zombie reap** (`watchdog.ps1`, `start_all.ps1`): backend restarts kill **all** `uvicorn …forven.api` processes for this repo (command-line match incl. the venv-redirector parent), not just port listeners. `watchdog.ps1` additionally honors the `.tmp/restart.request` sentinel (previously start_all-only — a restart requested while only the scheduled task ran never landed) and probes `daemon.lock` with an exclusive open so the in-process daemon thread counts as alive, ending the doomed-duplicate-daemon spawn every 2 minutes.
4. **Infra-error classification** (`forven/gauntlet/tasks.py`): process-teardown signatures (`cannot schedule new futures` / `interpreter shutdown` / `event loop is closed`) classify as retryable `blocked_runtime` **before** the deterministic `failed_gate` tokens — an infra death can never archive a strategy again.

## Verification

- `tests/test_gauntlet_workflow_tasks.py` — new `test_interpreter_shutdown_is_infra_not_merit_failure` (infra signature beats both the embedded deterministic token and the `isinstance(TypeError)` branch; control case still fails terminal); all 16 tests in the file pass.
- Both `.ps1` scripts parse clean (`Language.Parser`); `forven.api` imports and compiles; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)