### PR TITLE
fix(runtime): unblock imported dropzone strategies from paper execution

### DIFF
--- a/forven/scanner.py
+++ b/forven/scanner.py
@@ -5427,7 +5427,17 @@ def _load_deployed_strategies() -> dict:
                 load_diagnostics[sid] = diagnostic
                 continue
 
-            if stype not in SIGNAL_CHECKERS and resolved_runtime_type not in _TYPE_MAP:
+            # Untrusted-origin (imported__*) types are executable by design via
+            # the sandbox worker proxy and NEVER appear in the parent _TYPE_MAP —
+            # blocking them here silently quarantined every dropzone import from
+            # paper execution (S06898/S07678/S07689, 2026-07-21). Exempt them iff
+            # the module file really exists (fabricated names still block).
+            from forven.strategies.registry import imported_module_exists as _imported_exists
+            if (
+                stype not in SIGNAL_CHECKERS
+                and resolved_runtime_type not in _TYPE_MAP
+                and not _imported_exists(resolved_runtime_type)
+            ):
                 diagnostic["blocked_reason"] = f"runtime type '{resolved_runtime_type}' is not registered"
                 diagnostic["last_runtime_error"] = diagnostic["blocked_reason"]
                 diagnostic["execution_decision"] = "blocked"

--- a/forven/strategies/params.py
+++ b/forven/strategies/params.py
@@ -935,6 +935,19 @@ def is_known_runtime_type(
     """
     if not strategy_type:
         return False
+    try:
+        # Untrusted-origin (imported__*) types have a CONCRETE runtime — the
+        # sandbox worker proxy — but by design never appear in the parent's
+        # _TYPE_MAP (the class only exists in the worker). Certify them iff the
+        # module file actually exists so a fabricated imported__* name (the
+        # PHANTOM-1 class) still fails closed. Lazy import: registry imports params.
+        from forven.strategies.registry import IMPORTED_TYPE_PREFIX, imported_module_exists
+
+        if str(strategy_type).strip().startswith(IMPORTED_TYPE_PREFIX):
+            return imported_module_exists(strategy_type)
+    except Exception:
+        if require_runtime_class:
+            return False
     if not require_runtime_class and is_known_strategy_family(strategy_type):
         return True
     try:

--- a/forven/strategies/registry.py
+++ b/forven/strategies/registry.py
@@ -415,6 +415,26 @@ def discover(include_custom: bool = True):
     _discovered = _builtin_discovered and _custom_discovered
 
 
+def imported_module_exists(runtime_type: object) -> bool:
+    """Parent-safe existence probe for an untrusted-origin (imported) type.
+
+    True iff the namespaced type maps to a real module file under
+    ``forven/strategies/imported/``. Pure filesystem check — the module is NEVER
+    imported here (author-controlled code must only execute in the sandbox
+    worker). Used by the certification gate and the scanner load gate so a
+    genuinely imported strategy is executable via the worker proxy while a
+    fabricated ``imported__*`` name (the PHANTOM-1 class) still fails closed.
+    """
+    name = str(runtime_type or "").strip()
+    if not name.startswith(IMPORTED_TYPE_PREFIX):
+        return False
+    module = name[len(IMPORTED_TYPE_PREFIX):]
+    # Module names are generated slugs; refuse anything path-traversal-shaped.
+    if not module or not all(ch.isalnum() or ch == "_" for ch in module):
+        return False
+    return (Path(__file__).resolve().parent / "imported" / f"{module}.py").is_file()
+
+
 def imported_runtime_type(module_name: str) -> str:
     """The namespaced runtime-type key for an untrusted-origin (imported) strategy.
 

--- a/tests/test_imported_runtime_gates.py
+++ b/tests/test_imported_runtime_gates.py
@@ -1,0 +1,52 @@
+"""Untrusted-origin (imported__*) strategies and the parent-side gates.
+
+The registry deliberately resolves imported types to themselves and executes
+them via the sandbox worker proxy — but the scanner load gate and the
+PHANTOM-1 certification gate only accepted `_TYPE_MAP` classes, silently
+quarantining every dropzone import from paper execution (S06898 / S07678 /
+S07689, found 2026-07-21). These tests pin the fix: an imported type whose
+module file exists certifies and loads; a fabricated imported name still
+fails closed.
+"""
+
+from pathlib import Path
+
+from forven.strategies import registry
+from forven.strategies.certification import certify_execution_strategy
+from forven.strategies.params import is_known_runtime_type
+
+
+def _imported_dir() -> Path:
+    return Path(registry.__file__).resolve().parent / "imported"
+
+
+def test_imported_type_with_module_file_certifies():
+    name = "test_imported_gate_probe_c4f2a"
+    probe = _imported_dir() / f"{name}.py"
+    probe.write_text("# gate-probe artifact; never imported by the parent\n", encoding="utf-8")
+    try:
+        rt = f"imported__{name}"
+        assert registry.imported_module_exists(rt) is True
+        # Certification mode (PHANTOM-1 gate) must accept it: its concrete
+        # runtime is the sandbox worker proxy.
+        assert is_known_runtime_type(rt, require_runtime_class=True) is True
+        cert = certify_execution_strategy(rt, {})
+        assert cert.unregistered_runtime_type is False
+    finally:
+        probe.unlink()
+
+
+def test_fabricated_imported_type_still_fails_closed():
+    rt = "imported__no_such_module_phantom_guard"
+    assert registry.imported_module_exists(rt) is False
+    assert is_known_runtime_type(rt, require_runtime_class=True) is False
+    cert = certify_execution_strategy(rt, {})
+    assert cert.unregistered_runtime_type is True
+    assert cert.certified is False
+
+
+def test_traversal_shaped_imported_names_are_refused():
+    assert registry.imported_module_exists("imported__../evil") is False
+    assert registry.imported_module_exists("imported__a.b") is False
+    assert registry.imported_module_exists("imported__") is False
+    assert registry.imported_module_exists("not_imported_at_all") is False


### PR DESCRIPTION
Found while verifying the live-candidate slate: the scanner logs `blocked 3: runtime type 'imported__dropzone_...' is not registered` on **every scan** — and the blocked three are S06898 (live slate) and S07678/S07689 (slot-5 heirs). Their zero paper trades were never selectivity: they were quarantined at load.

**Root cause:** the registry deliberately resolves `imported__*` types to themselves and executes them via the sandbox worker proxy (registry.py: "resolve early so the parent never treats them as *not registered*") — but two parent-side gates never got that exemption:
1. the scanner load gate (`resolved_runtime_type not in _TYPE_MAP` → blocked), and
2. the PHANTOM-1 certification gate (`require_runtime_class=True` only accepts `_TYPE_MAP` classes → paper quarantine "outside the certified subset").

**Fix:** both gates now exempt imported types **iff the module file actually exists** under `forven/strategies/imported/` (new parent-safe `imported_module_exists()` probe — pure filesystem check, the module is never imported in the trusted parent, traversal-shaped names refused). A fabricated `imported__*` name still fails closed, preserving the PHANTOM-1 guard.

**Tests:** new `tests/test_imported_runtime_gates.py` — real-module certifies, fabricated/traversal names fail closed; param-canonicalization, create-fail-closed, scanner, and live-risk-clamp suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)