### PR TITLE
fix(runtime): serve on SelectorEventLoop — uvicorn's factory hard-codes Proactor on Windows

### DIFF
--- a/forven/api.py
+++ b/forven/api.py
@@ -931,4 +931,35 @@ if __name__ == "__main__":
     bind_host = resolved_bind_host()
     # Fail closed: never expose an unauthenticated API beyond loopback.
     assert_safe_bind_host(bind_host)
-    uvicorn.run(app, host=bind_host, port=port, workers=1)
+
+    # LOOP-1: run the server on a loop WE create. uvicorn's loop factory
+    # hard-codes ProactorEventLoop on win32 (uvicorn>=0.49 asyncio_loop_factory),
+    # silently defeating the WindowsSelectorEventLoopPolicy this module sets for
+    # WS stability — the Proactor _call_connection_lost socket.shutdown race
+    # (ConnectionResetError WinError 10054 in a loop callback) can kill the serve
+    # loop under WebSocket churn, observed as the 2026-07-21 backend restart
+    # storm. asyncio.run() honors the policy, so the serve loop is a
+    # SelectorEventLoop here. Crashes are logged to the rotating api.log BEFORE
+    # the process dies — per-boot stderr truncation destroyed every prior
+    # traceback of this class.
+    if sys.platform.startswith("win"):
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    _config = uvicorn.Config(app, host=bind_host, port=port, workers=1)
+    _server = uvicorn.Server(_config)
+
+    async def _serve() -> None:
+        log.info(
+            "uvicorn serve loop: %s", type(asyncio.get_running_loop()).__name__
+        )
+        await _server.serve()
+
+    try:
+        asyncio.run(_serve())
+    except (KeyboardInterrupt, SystemExit):
+        raise
+    except BaseException:
+        log.critical(
+            "uvicorn serve loop crashed; exiting so the supervisor restarts a "
+            "working backend.", exc_info=True,
+        )
+        raise

--- a/start_all.ps1
+++ b/start_all.ps1
@@ -344,7 +344,7 @@ function Get-BackendProcessIds {
             Get-CimInstance Win32_Process -Filter "Name = 'python.exe'" -ErrorAction Stop |
                 Where-Object {
                     $cmd = [string]$_.CommandLine
-                    $cmd -match $escapedRepoRoot -and $cmd -match 'uvicorn' -and $cmd -match 'forven\.api'
+                    $cmd -match $escapedRepoRoot -and $cmd -match 'forven\.api'
                 } |
                 Select-Object -ExpandProperty ProcessId -Unique
         )
@@ -757,7 +757,11 @@ function Start-BackendService {
     # runtime-worker/daemon locks the fresh backend needs.
     Stop-ZombieBackendProcesses
     Write-Info "Starting backend on ${backendHost}:$backendPort ..."
-    $proc = Start-LoggedProcess -FilePath $python -CommandArgs @("-m","uvicorn","--app-dir",$script:RepoRoot,"forven.api:app","--host",$backendHost,"--port",$backendPort.ToString(),"--workers",$backendWorkers.ToString()) `
+    # LOOP-1: launch via the module entry so the serve loop is a SelectorEventLoop
+    # (see forven/api.py __main__) — `-m uvicorn` hard-codes Proactor on Windows.
+    # Host comes from FORVEN_BIND_HOST/FORVEN_HOST (resolved_bind_host mirrors the
+    # same precedence as $backendHost above).
+    $proc = Start-LoggedProcess -FilePath $python -CommandArgs @("-m","forven.api","--port",$backendPort.ToString()) `
         -WorkingDirectory $script:RepoRoot -StdOutPath $backendLog -StdErrPath $backendErr
     if (-not (Wait-ForHttp -Url $backendHealth -Label "Backend")) {
         if (Test-Path $backendErr) { Get-Content $backendErr -Tail 120 }

--- a/watchdog.ps1
+++ b/watchdog.ps1
@@ -72,7 +72,7 @@ function Get-BackendProcessIds {
         $procs = Get-CimInstance Win32_Process -Filter "Name like 'python%'" -ErrorAction SilentlyContinue |
             Where-Object {
                 $cmd = [string]$_.CommandLine
-                $cmd -match "uvicorn" -and $cmd -match "forven\.api" -and $cmd.ToLowerInvariant().Contains($RepoRoot.ToLowerInvariant())
+                $cmd -match "forven\.api" -and $cmd.ToLowerInvariant().Contains($RepoRoot.ToLowerInvariant())
             }
         foreach ($proc in @($procs)) {
             if ($proc -and $proc.ProcessId) { $result += [int]$proc.ProcessId }
@@ -429,7 +429,7 @@ try {
         $backendLog = Join-Path $logRoot "unified_backend.log"
         $backendErr = Join-Path $logRoot "unified_backend.err.log"
         $proc = Start-Process -FilePath $python `
-            -ArgumentList @("-m","uvicorn","--app-dir",$RepoRoot,"forven.api:app","--host",$BackendHost,"--port",$BackendPort.ToString(),"--workers","1") `
+            -ArgumentList @("-m","forven.api","--port",$BackendPort.ToString()) `
             -WorkingDirectory $RepoRoot -RedirectStandardOutput $backendLog -RedirectStandardError $backendErr `
             -WindowStyle Hidden -PassThru
         Write-Log ("Backend started as PID " + $proc.Id)


### PR DESCRIPTION
Root cause of the recurring "Internal Server Error" panels and today's backend restart storm (crashes at 08:55, 09:42, 09:43, 09:48 — roughly every 5 minutes under load).

**The bug:** uvicorn ≥0.49's `asyncio_loop_factory` returns `ProactorEventLoop` on win32 unconditionally. The `WindowsSelectorEventLoopPolicy` that `forven/api.py` sets for exactly this reason (its comment: "Windows Proactor loop can intermittently reset accepted sockets under mixed HTTP/WebSocket load") is **silently ignored** for the serve loop — uvicorn builds the loop from its factory before the app is imported. The serve loop has been Proactor all along.

**The failure chain (evidenced in api.log):** GIL-stall → WS disconnects → Proactor's `_call_connection_lost` → `socket.shutdown` race → `ConnectionResetError [WinError 10054]` → serve loop dies → main thread exits *without lifespan shutdown* (no shutdown markers in any log) → wedged corpse reaped by the PR #90 zombie reaper 45s later (observed firing 09:48:51) → supervisor restarts → boot sweeps stall the loop → repeat. Crash tracebacks were destroyed each cycle by per-boot stderr truncation.

**The fix:**
- `python -m forven.api` builds the loop itself via `asyncio.run` (which honors the Selector policy) and runs uvicorn programmatically (`Server.serve()`).
- Boot logs the loop class — smoke-verified: `uvicorn serve loop: _WindowsSelectorEventLoop`.
- Any future serve-loop crash logs a full traceback to the rotating api.log **before** the process dies, ending the evidence destruction.
- `watchdog.ps1` / `start_all.ps1` launch via `-m forven.api --port N` (host resolves from the same `FORVEN_BIND_HOST`/`FORVEN_HOST` precedence via `resolved_bind_host`, built to mirror the launchers); backend-process matchers relaxed so zombie reaping covers both launch styles. `start_all.sh` untouched — the pathology is Windows-only.

Both PowerShell scripts parse clean; `forven/api.py` compiles and passes ruff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)