### PR TITLE
Fix strategy page timeout crash

### DIFF
--- a/forven/strategies/catalog.py
+++ b/forven/strategies/catalog.py
@@ -15,11 +15,14 @@ def get_prebuilt_catalog() -> list[dict]:
     """Build the prebuilt strategy template catalog from the type registry."""
     from forven.strategies.registry import _TYPE_MAP, discover
 
-    discover()
+    # This endpoint backs the Strategy Creator's built-in template selector.
+    # Loading every custom strategy made it instantiate thousands of generated
+    # classes on each request and return multi-megabyte payloads.
+    discover(include_custom=False)
 
     catalog: list[dict] = []
     for type_name, cls in sorted(_TYPE_MAP.items()):
-        if type_name in _SKIP_TYPES:
+        if type_name in _SKIP_TYPES or not cls.__module__.startswith("forven.strategies.builtin."):
             continue
         try:
             instance = cls(f"_catalog_{type_name}", {})
@@ -58,7 +61,10 @@ def get_prebuilt_catalog() -> list[dict]:
                 "parameters": parameters,
                 "source": "prebuilt",
             })
-        except Exception as exc:
+        # Strategy classes are extension code.  A broken constructor must not be
+        # able to terminate the API process while this informational catalog is
+        # being built (``SystemExit`` is not an ``Exception`` in Python).
+        except (Exception, SystemExit) as exc:
             log.debug("Skipping catalog entry for %s: %s", type_name, exc)
             continue
 

--- a/forven/strategies/custom_catalog.py
+++ b/forven/strategies/custom_catalog.py
@@ -19,7 +19,10 @@ def include_archived_custom_strategies() -> bool:
 
 def custom_strategy_status(module_name: str) -> str:
     normalized = str(module_name or "").strip()
-    if not normalized or normalized == "__init__":
+    # Leading-underscore modules are private helpers/probes, not discoverable
+    # strategies.  Treating them as entries allowed a leftover diagnostic probe
+    # with ``raise SystemExit`` in its constructor to enter the live registry.
+    if not normalized or normalized.startswith("_"):
         return "ignored"
     for pattern in _ARCHIVED_NAME_PATTERNS:
         if pattern.match(normalized):

--- a/forven/strategies/intake.py
+++ b/forven/strategies/intake.py
@@ -215,8 +215,12 @@ def scan_custom_strategies(*, register: bool = False) -> dict:
         if not modname or modname == "__init__":
             continue
 
+        module_status = custom_strategy_status(modname)
+        if module_status == "ignored":
+            continue
+
         report.scanned += 1
-        if custom_strategy_status(modname) == "archived" and not include_archived:
+        if module_status == "archived" and not include_archived:
             report.already_known += 1
             continue
 

--- a/forven/strategies/registry.py
+++ b/forven/strategies/registry.py
@@ -365,17 +365,22 @@ def discover(include_custom: bool = True):
         include_archived = include_archived_custom_strategies()
         loaded_custom = 0
         skipped_archived = 0
+        skipped_ignored = 0
         skipped_errors = 0
         skipped_known_broken = 0
         for _importer, modname, _ispkg in pkgutil.iter_modules(custom.__path__):
             if not modname or modname == "__init__":
+                continue
+            module_status = custom_strategy_status(modname)
+            if module_status == "ignored":
+                skipped_ignored += 1
                 continue
             # Already known to fail import this process — skip silently so a
             # broken module isn't re-imported (and re-warned) on every discover.
             if modname in _FAILED_CUSTOM_MODULES:
                 skipped_known_broken += 1
                 continue
-            if custom_strategy_status(modname) == "archived":
+            if module_status == "archived":
                 _ARCHIVED_CUSTOM_MODULES[modname.lower()] = modname
                 if not include_archived:
                     skipped_archived += 1
@@ -383,7 +388,7 @@ def discover(include_custom: bool = True):
             try:
                 _load_custom_strategy_module(modname)
                 loaded_custom += 1
-            except Exception as e:
+            except (Exception, SystemExit) as e:
                 _FAILED_CUSTOM_MODULES.add(modname)
                 # Warn once per module per process; stay quiet on later discovers.
                 if modname not in _FAILED_CUSTOM_LOGGED:
@@ -391,9 +396,10 @@ def discover(include_custom: bool = True):
                     log.warning("Skipping custom strategy module %s: %s", modname, e)
                 skipped_errors += 1
         log.info(
-            "Custom strategies loaded: %d module(s), %d archived skipped, %d errors skipped, "
-            "%d known-broken skipped, %d total types now",
+            "Custom strategies loaded: %d module(s), %d private ignored, %d archived skipped, "
+            "%d errors skipped, %d known-broken skipped, %d total types now",
             loaded_custom,
+            skipped_ignored,
             skipped_archived,
             skipped_errors,
             skipped_known_broken,
@@ -474,7 +480,7 @@ def _discover_imported_modules() -> None:
             if errors:
                 raise RegistryTypeError("; ".join(errors))
             _TYPE_MAP[imported_runtime_type(modname)] = cls
-        except Exception as e:
+        except (Exception, SystemExit) as e:
             if modname not in _FAILED_CUSTOM_LOGGED:
                 _FAILED_CUSTOM_LOGGED.add(modname)
                 log.warning("Skipping imported strategy module %s: %s", modname, e)
@@ -552,7 +558,7 @@ def _ensure_active_db_strategy_modules() -> None:
         try:
             _load_custom_strategy_module(modname)
             loaded += 1
-        except Exception as exc:  # noqa: BLE001 - quarantine a broken module, warn once
+        except (Exception, SystemExit) as exc:  # noqa: BLE001 - quarantine broken extension code
             _FAILED_CUSTOM_MODULES.add(modname)
             if modname not in _FAILED_CUSTOM_LOGGED:
                 _FAILED_CUSTOM_LOGGED.add(modname)
@@ -736,7 +742,7 @@ def _load_archived_custom_runtime_type(runtime_name: str) -> bool:
         return False
     try:
         _load_custom_strategy_module(module_name)
-    except (RegistryTypeError, ImportError):
+    except (RegistryTypeError, ImportError, SystemExit):
         # Broken/guard-rejected archived module — don't let the error escape the
         # runtime-type resolver (the type simply stays unresolved), and remember
         # the failure so every later hydrate doesn't re-read and re-execute the
@@ -847,7 +853,7 @@ def _load_db_strategies(target: dict):
                     )
                     _inject_regime_metadata(strategy, compatible_regimes, is_all_rounder)
                     target[sid] = strategy
-                except Exception as row_exc:
+                except (Exception, SystemExit) as row_exc:
                     dedupe_key = (sid, str(row_exc))
                     if dedupe_key in _BAD_ROW_LOGGED:
                         log.debug("Skipping bad strategy row %s: %s", sid, row_exc)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -265,6 +265,72 @@ def test_custom_catalog_marks_versioned_modules_archived():
     assert custom_strategy_status("rsi_momentum") == "active"
     assert custom_strategy_status("rsi_momentum_s00293") == "archived"
     assert custom_strategy_status("S00224_bollinger") == "archived"
+    assert custom_strategy_status("_probe_signal_fields") == "ignored"
+
+
+def test_discover_ignores_private_custom_modules(monkeypatch):
+    registry_mod.reset()
+    loaded: list[str] = []
+
+    monkeypatch.setattr(registry_mod, "_builtin_discovered", True)
+    monkeypatch.setattr(
+        registry_mod.pkgutil,
+        "iter_modules",
+        lambda _path: [(None, "_private_probe", False), (None, "public_strategy", False)],
+    )
+    monkeypatch.setattr(registry_mod, "_load_custom_strategy_module", loaded.append)
+    monkeypatch.setattr(registry_mod, "_ensure_active_db_strategy_modules", lambda: None)
+
+    registry_mod.discover()
+
+    assert loaded == ["public_strategy"]
+
+
+def test_discover_quarantines_custom_system_exit(monkeypatch):
+    registry_mod.reset()
+    loaded: list[str] = []
+
+    def _load(modname: str) -> None:
+        loaded.append(modname)
+        if modname == "bad_strategy":
+            raise SystemExit(0)
+
+    monkeypatch.setattr(registry_mod, "_builtin_discovered", True)
+    monkeypatch.setattr(
+        registry_mod.pkgutil,
+        "iter_modules",
+        lambda _path: [(None, "bad_strategy", False), (None, "good_strategy", False)],
+    )
+    monkeypatch.setattr(registry_mod, "_load_custom_strategy_module", _load)
+    monkeypatch.setattr(registry_mod, "_ensure_active_db_strategy_modules", lambda: None)
+
+    registry_mod.discover()
+
+    assert loaded == ["bad_strategy", "good_strategy"]
+    assert "bad_strategy" in registry_mod._FAILED_CUSTOM_MODULES
+
+
+def test_prebuilt_catalog_skips_strategy_constructor_system_exit(monkeypatch):
+    class ExitStrategy:
+        def __init__(self, *_args, **_kwargs) -> None:
+            raise SystemExit(0)
+
+    ExitStrategy.__module__ = "forven.strategies.builtin.test_exit"
+    monkeypatch.setattr(registry_mod, "discover", lambda **_kwargs: None)
+    monkeypatch.setattr(registry_mod, "_TYPE_MAP", {"exit_strategy": ExitStrategy})
+
+    assert get_prebuilt_catalog() == []
+
+
+def test_prebuilt_catalog_excludes_custom_registry_types(monkeypatch):
+    class CustomStrategy:
+        pass
+
+    CustomStrategy.__module__ = "forven.strategies.custom.generated"
+    monkeypatch.setattr(registry_mod, "discover", lambda **_kwargs: None)
+    monkeypatch.setattr(registry_mod, "_TYPE_MAP", {"custom_strategy": CustomStrategy})
+
+    assert get_prebuilt_catalog() == []
 
 
 def test_resolve_runtime_type_loads_archived_custom_module_by_exact_name():


### PR DESCRIPTION
## Summary

- restrict the prebuilt strategy catalog to built-in strategy types
- ignore private custom strategy modules during discovery and intake
- quarantine extension modules that raise `SystemExit` instead of allowing them to terminate the API event loop
- add regression coverage for private probes, `SystemExit`, and custom catalog exclusion

## Root cause

The prebuilt-strategy endpoint instantiated every registered custom strategy. A leftover private diagnostic probe raised `SystemExit`, which escaped the normal exception handling and shut down Uvicorn's event loop. The frontend then reported `signal timed out` across the strategy detail cards.

## Impact

Strategy detail pages remain responsive even when a custom extension is broken, and the prebuilt catalog no longer scans or serializes thousands of custom/generated strategies.

## Validation

- `python -m pytest tests/test_registry.py -q` — 22 passed
- `python -m ruff check forven/strategies/catalog.py forven/strategies/custom_catalog.py forven/strategies/registry.py forven/strategies/intake.py tests/test_registry.py`
- `git diff --check`
- verified strategy pages S07678 and S07689 load without timeout errors
