### PR TITLE
fix(execution): recorded-row execution lane drives close/refresh dispatch (LANE-1)

### DIFF
--- a/forven/api_domains/paper.py
+++ b/forven/api_domains/paper.py
@@ -605,6 +605,23 @@ def _resolve_live_equity_baseline(strategy_id: str) -> float | None:
     return None
 
 
+def _filter_session_lane_trades(trades: list[dict], *, is_deployed: bool) -> list[dict]:
+    """A deployed/live card shows ONLY live-typed trades.
+
+    After a promotion the strategy's paper history (and any open paper position)
+    would otherwise "carry over" into the Live Trades view and render as live
+    results. PAPER cards are deliberately NOT filtered: a demoted strategy with a
+    live position still open must keep that position visible/reachable through the
+    manual controls (which dispatch on the TRADE's execution_type) — hiding it
+    would strand the one position the operator most needs to manage."""
+    if not is_deployed:
+        return trades
+    return [
+        trade for trade in trades
+        if str((trade or {}).get("execution_type") or "").strip().lower() == "live"
+    ]
+
+
 def _collect_compat_paper_sessions(
     include_deployed: bool = False,
     session_limit: int | None = None,
@@ -696,6 +713,9 @@ def _collect_compat_paper_sessions(
         symbol = str(strategy_row.get("symbol") or "").strip().upper() or "BTC/USDT"
         timeframe = str(strategy_row.get("timeframe") or "").strip() or "1h"
 
+        stage_status = core._to_core_status(str(strategy_row.get("stage") or strategy_row.get("status") or "")) or ""
+        is_deployed = stage_status == "live_graduated"
+
         keys = _strategy_trade_keys(strategy_row)
         matched_trades = [
             trade
@@ -703,6 +723,9 @@ def _collect_compat_paper_sessions(
             if _matches_strategy_trade(trade, keys)
             and _trade_belongs_to_strategy_incarnation(trade, strategy_row)
         ]
+        # LANE-1: the card reflects ONLY its current lane's trades (see
+        # _filter_session_lane_trades) — position, history, and PnL summary alike.
+        matched_trades = _filter_session_lane_trades(matched_trades, is_deployed=is_deployed)
 
         open_trades = [
             trade
@@ -788,8 +811,6 @@ def _collect_compat_paper_sessions(
             or 1.0
         )
 
-        stage_status = core._to_core_status(str(strategy_row.get("stage") or strategy_row.get("status") or "")) or ""
-        is_deployed = stage_status == "live_graduated"
         total_pnl = total_closed_pnl + unrealized_pnl
 
         # Capital semantics differ by stage:

--- a/forven/scanner.py
+++ b/forven/scanner.py
@@ -4380,7 +4380,10 @@ def manage_positions(
         account_equity = _get_account_equity()
 
     def _close_via_execution(trade, exit_price: float, pnl_pct: float, close_reason: str | None = None) -> bool:
-        if paper_test_local_execution:
+        # LANE-1: a paper-typed row must NEVER receive a real exchange close, even when
+        # the STRATEGY is live-stage (a promotion with an open paper position) — the
+        # order would reject on a flat wallet or reduce an unrelated real position.
+        if paper_test_local_execution or _recorded_row_execution_lane(trade) == "paper":
             # Simulate fill recording for paper trades
             _update_trade_fill(
                 trade_id=str(trade["id"]),
@@ -6428,6 +6431,14 @@ def _kernel_close_orphan(action, *, last_close: float, last_time: str) -> str | 
     row = (action.recorded or {}).get("_row")
     if row is None or not last_close or last_close <= 0:
         return None
+    # LANE-1: never locally flat-close a LIVE-typed row — the exchange position would
+    # survive the local "close" and sit unmanaged. Hold it for operator review.
+    if _recorded_row_execution_lane(row) == "live":
+        log.warning(
+            "KERNEL-CONVERGE: recorded OPEN %s (%s) is live-typed — never flat-closed "
+            "locally; held for operator review", row.get("asset"), row.get("id"),
+        )
+        return None
     # A LATE hop-in is owned by the re-anchored stop/target monitor, never the converge
     # path: flattening it at the last bar would bypass its real (re-anchored) stop and
     # close at an arbitrary current price. Leave it for _kernel_handle_late_entry_exits.
@@ -6460,6 +6471,14 @@ def _kernel_close_cross_asset_orphan(row: dict) -> str | None:
     trade_id = row.get("id")
     entry_price = _coerce_positive_float(row.get("fill_entry_price")) or _coerce_positive_float(row.get("entry_price"))
     if not trade_id or entry_price is None:
+        return None
+    # LANE-1: a live-typed row is a REAL position — a local flat-close would strand it
+    # on-exchange. Hold it (the live lane's cross-asset branch surfaces these).
+    if _recorded_row_execution_lane(row) == "live":
+        log.warning(
+            "KERNEL-CROSS-ASSET: recorded OPEN %s (%s) is live-typed — never flat-closed "
+            "locally; held for operator review", row.get("asset"), trade_id,
+        )
         return None
     # A late hop-in is owned by its own re-anchored stop monitor — never auto-flatten it here.
     if parse_trade_signal_data(row.get("signal_data")).get("late_entry"):
@@ -6627,6 +6646,51 @@ def _live_kernel_execution_enabled() -> bool:
     live_kernel_execution=false to fall back to the legacy live engine.
     """
     return _scanner_bool_setting("live_kernel_execution", True)
+
+
+# LANE-1: execution lanes for RECORDED trade rows. An action that targets an
+# existing row must follow the ROW's execution_type, not the strategy's current
+# stage: a strategy promoted to live with an open paper trade (or demoted to paper
+# with an open live one) otherwise gets the wrong applier — a REAL reduce-only
+# order fired at a local-only paper row (rejected while the wallet is flat, but
+# REDUCING an unrelated real position when one exists), or a real position
+# "closed" locally and stranded on the exchange.
+_PAPER_LANE_EXECUTION_TYPES = ("paper", "paper_challenger", "simulation")
+
+
+def _recorded_row_execution_lane(row) -> str | None:
+    """'paper' | 'live' for a recorded trade row; None for missing/unknown types
+    (legacy rows predate the stamp — those keep the strategy-lane behavior)."""
+    if not isinstance(row, dict):
+        return None
+    exec_type = str(row.get("execution_type") or "").strip().lower()
+    if exec_type in _PAPER_LANE_EXECUTION_TYPES:
+        return "paper"
+    if exec_type == "live":
+        return "live"
+    return None
+
+
+def _kernel_action_execution_lane(action) -> str | None:
+    rec = getattr(action, "recorded", None)
+    row = rec.get("_row") if isinstance(rec, dict) else None
+    return _recorded_row_execution_lane(row)
+
+
+def _kernel_row_dispatch(action, is_live: bool) -> str:
+    """'paper' | 'live' | 'hold' — which applier a close/backfill/refresh action gets.
+
+    The row's lane wins over the strategy's lane. The one asymmetry: a live-typed
+    row in the PAPER lane is HELD, not closed — the paper lane must never place a
+    real order (the paper-test "no real orders" contract), and a local close would
+    strand the exchange position, which is strictly worse than holding it for the
+    operator."""
+    row_lane = _kernel_action_execution_lane(action)
+    if row_lane == "paper" and is_live:
+        return "paper"
+    if row_lane == "live" and not is_live:
+        return "hold"
+    return "live" if is_live else "paper"
 
 
 def _is_live_kernel_stage(strat: dict) -> bool:
@@ -7381,14 +7445,40 @@ def manage_positions_via_kernel(strat_id: str, strat: dict, *, account_equity=No
                 msg = open_applier(strat_id, strat, a, sizing_equity=sizing_equity, leverage=leverage,
                                    current_price=hop_price, current_time=hop_time)
             elif a.kind in ("close", "backfill"):
-                msg = close_applier(
-                    strat_id, strat, a, current_price=hop_price, current_time=hop_time,
-                    funding_df=df, timeframe=timeframe,
-                )
+                # LANE-1: a close that targets a RECORDED row follows the ROW's
+                # execution lane, not the strategy's stage — a promotion/demotion
+                # with an open position would otherwise cross the paper/live order
+                # paths (a real reduce-only order fired at a paper row, or a real
+                # position closed locally and stranded).
+                _dispatch = _kernel_row_dispatch(a, is_live)
+                if _dispatch == "hold":
+                    log.warning(
+                        "[%s] kernel paper: recorded OPEN %s row is live-typed — a local close "
+                        "would strand the exchange position; held for operator review",
+                        strat_id, asset,
+                    )
+                    msg = f"HELD {asset} close — live-typed row in the paper lane (close it via the live flow)"
+                else:
+                    if is_live and _dispatch == "paper":
+                        log.warning(
+                            "[%s] kernel live: recorded %s row is paper-typed — routing close via "
+                            "the paper path (no real order)",
+                            strat_id, asset,
+                        )
+                    msg = (_kernel_close_live_trade if _dispatch == "live" else _kernel_close_paper_trade)(
+                        strat_id, strat, a, current_price=hop_price, current_time=hop_time,
+                        funding_df=df, timeframe=timeframe,
+                    )
             elif a.kind == "refresh":
                 # LIVE-TRAIL-1: the live refresh mirrors the kernel's ratcheted trailing
                 # stop onto the resting exchange order; the paper refresh is display-only.
-                msg = _kernel_refresh_live_trade(strat_id, a) if is_live else _kernel_refresh_paper_trade(a)
+                # LANE-1: same row-lane dispatch as closes — never touch a real resting
+                # order for a paper row, never locally re-stamp a live row from paper.
+                _dispatch = _kernel_row_dispatch(a, is_live)
+                if _dispatch == "hold":
+                    msg = None
+                else:
+                    msg = _kernel_refresh_live_trade(strat_id, a) if _dispatch == "live" else _kernel_refresh_paper_trade(a)
             elif a.kind == "orphan_close":
                 msg = _kernel_close_orphan(a, last_close=last_close, last_time=last_time)
             else:

--- a/tests/test_execution_lane_dispatch.py
+++ b/tests/test_execution_lane_dispatch.py
@@ -1,0 +1,131 @@
+"""LANE-1: actions targeting an EXISTING recorded trade row follow the ROW's
+execution lane, not the strategy's current stage.
+
+A strategy promoted to live with an open paper trade (or demoted to paper with an
+open live one) must never cross the paper/live order paths: a real reduce-only
+order fired at a local-only paper row rejects on a flat wallet — and REDUCES an
+unrelated real position when one exists; a live row "closed" locally strands the
+real position on the exchange. Also covers the view-layer half: a session card
+renders only its current lane's trades (the paper history must not "carry over"
+into the Live Trades view after a promotion).
+"""
+
+from __future__ import annotations
+
+import forven.scanner as scanner
+from forven.api_domains.paper import _filter_session_lane_trades
+from forven.strategies.paper_reconcile import ReconcileAction
+
+
+def _close_action(row: dict | None) -> ReconcileAction:
+    recorded = {"_row": row} if row is not None else None
+    return ReconcileAction("close", "long", "2026-01-01T00:00:00+00:00", recorded=recorded)
+
+
+# ── row lane resolution ──────────────────────────────────────────────────────
+
+
+def test_recorded_row_execution_lane():
+    assert scanner._recorded_row_execution_lane({"execution_type": "paper"}) == "paper"
+    assert scanner._recorded_row_execution_lane({"execution_type": "paper_challenger"}) == "paper"
+    assert scanner._recorded_row_execution_lane({"execution_type": "simulation"}) == "paper"
+    assert scanner._recorded_row_execution_lane({"execution_type": "LIVE"}) == "live"
+    # Legacy rows without a stamp keep strategy-lane behavior.
+    assert scanner._recorded_row_execution_lane({"execution_type": None}) is None
+    assert scanner._recorded_row_execution_lane({"execution_type": "recovered?"}) is None
+    assert scanner._recorded_row_execution_lane(None) is None
+    assert scanner._recorded_row_execution_lane("not-a-row") is None
+
+
+def test_kernel_action_execution_lane_reads_recorded_row():
+    assert scanner._kernel_action_execution_lane(_close_action({"execution_type": "paper"})) == "paper"
+    assert scanner._kernel_action_execution_lane(_close_action({"execution_type": "live"})) == "live"
+    assert scanner._kernel_action_execution_lane(_close_action(None)) is None
+
+
+# ── dispatch matrix ──────────────────────────────────────────────────────────
+
+
+def test_dispatch_paper_row_under_live_lane_routes_paper():
+    # The S06325/E0208 case: promotion left an open PAPER row under the live lane —
+    # its close must take the paper path (no real order).
+    assert scanner._kernel_row_dispatch(_close_action({"execution_type": "paper"}), is_live=True) == "paper"
+
+
+def test_dispatch_live_row_under_paper_lane_holds():
+    # Mirror: a live row in the paper lane is HELD (the paper lane never places real
+    # orders, and a local close would strand the exchange position).
+    assert scanner._kernel_row_dispatch(_close_action({"execution_type": "live"}), is_live=False) == "hold"
+
+
+def test_dispatch_matching_lanes_unchanged():
+    assert scanner._kernel_row_dispatch(_close_action({"execution_type": "live"}), is_live=True) == "live"
+    assert scanner._kernel_row_dispatch(_close_action({"execution_type": "paper"}), is_live=False) == "paper"
+
+
+def test_dispatch_without_recorded_row_follows_strategy_lane():
+    assert scanner._kernel_row_dispatch(_close_action(None), is_live=True) == "live"
+    assert scanner._kernel_row_dispatch(_close_action(None), is_live=False) == "paper"
+    # Unknown execution_type == no row: strategy lane decides.
+    assert scanner._kernel_row_dispatch(_close_action({"execution_type": ""}), is_live=True) == "live"
+
+
+# ── orphan flat-closers never touch live rows ────────────────────────────────
+
+
+def test_kernel_close_orphan_holds_live_row(monkeypatch):
+    def _boom(*a, **k):  # a live row must never be locally flat-closed
+        raise AssertionError("close_trade_record called for a live-typed orphan")
+
+    monkeypatch.setattr(scanner, "close_trade_record", _boom)
+    action = _close_action({
+        "id": "T1", "asset": "ETH", "execution_type": "live", "signal_data": "{}",
+    })
+    assert scanner._kernel_close_orphan(action, last_close=100.0, last_time="t") is None
+
+
+def test_kernel_close_orphan_still_closes_paper_row(monkeypatch):
+    calls = {}
+    monkeypatch.setattr(scanner, "close_trade_record", lambda tid, **k: calls.setdefault("id", tid))
+    action = _close_action({
+        "id": "T2", "asset": "ETH", "execution_type": "paper", "signal_data": "{}",
+    })
+    msg = scanner._kernel_close_orphan(action, last_close=100.0, last_time="t")
+    assert calls["id"] == "T2"
+    assert msg and "KERNEL-CONVERGE-CLOSE" in msg
+
+
+def test_kernel_close_cross_asset_orphan_holds_live_row(monkeypatch):
+    def _boom(*a, **k):
+        raise AssertionError("close_trade_record called for a live-typed cross-asset orphan")
+
+    monkeypatch.setattr(scanner, "close_trade_record", _boom)
+    row = {"id": "T3", "asset": "SOL", "entry_price": 100.0, "execution_type": "live", "signal_data": "{}"}
+    assert scanner._kernel_close_cross_asset_orphan(row) is None
+
+
+# ── session cards render only their current lane ─────────────────────────────
+
+
+def test_deployed_session_hides_paper_history():
+    trades = [
+        {"id": "P1", "execution_type": "paper"},
+        {"id": "P2", "execution_type": "paper_challenger"},
+        {"id": "L1", "execution_type": "live"},
+        {"id": "X1", "execution_type": None},
+    ]
+    kept = _filter_session_lane_trades(trades, is_deployed=True)
+    assert [t["id"] for t in kept] == ["L1"]
+
+
+def test_paper_session_keeps_live_rows_reachable():
+    # Deliberately unfiltered: a demoted strategy's stuck live position must stay
+    # visible on its paper card so the manual controls (which dispatch on the
+    # TRADE's execution_type) can still reach it.
+    trades = [
+        {"id": "P1", "execution_type": "paper"},
+        {"id": "L1", "execution_type": "live"},
+        {"id": "X1", "execution_type": None},
+    ]
+    kept = _filter_session_lane_trades(trades, is_deployed=False)
+    assert [t["id"] for t in kept] == ["P1", "L1", "X1"]

--- a/tests/test_kernel_live_parity.py
+++ b/tests/test_kernel_live_parity.py
@@ -61,8 +61,9 @@ def test_kernel_open_live_places_real_order(monkeypatch):
     assert calls["x"]["action"] == "open"
     assert calls["x"]["direction"] == "long"
     assert calls["x"]["asset"] == "BTC"
-    # units = equity*leverage*size_fraction/price = 10000*2*0.5/100 = 100
-    assert calls["x"]["size"] == pytest.approx(100.0)
+    # units = equity*leverage*size_fraction/price = 10000*2*0.5/100 = 100, then
+    # LIVE-CLAMP-1 caps loss-at-stop at 2% of equity: $200/$3-per-unit = 66.67
+    assert calls["x"]["size"] == pytest.approx(200.0 / 3.0, rel=1e-4)
     assert calls["x"]["stop"] == 97.0 and calls["x"]["tp"] == 105.0
     assert "LIVE-KERNEL-OPEN" in msg
 


### PR DESCRIPTION
## What

Two defects surfaced by the 2026-07-21 live promotions (5 strategies moved paper->live_graduated with the operator override):

**1. Real-order hazard: close/refresh dispatched on the STRATEGY stage, not the TRADE row**

S06325 was promoted with an open paper trade (E0208). The kernel picks its close applier per strategy lane (`_kernel_close_live_trade` when live), so on the next exit signal that PAPER row would have received a **real reduce-only ETH order on mainnet** — rejected while the wallet is flat, but **reducing an unrelated real ETH position** if one exists by then. The legacy `_close_via_execution` had the same stage-level dispatch.

Fix (LANE-1): any action that targets a RECORDED row follows the row''s `execution_type`:
- paper row under the live lane -> paper applier (no real order), warning logged
- live row under the paper lane -> **HELD** for operator review (a local close would strand the exchange position, and the paper lane must never place real orders)
- no recorded row / unstamped legacy rows -> strategy-lane behavior unchanged
- both orphan flat-closers (converge + cross-asset) now refuse live-typed rows
- legacy `_close_via_execution`: paper-typed trades always take the simulated local fill

**2. Display: paper history "carried over" into the Live Trades view**

The compat session builder attached ALL of a strategy''s trades to its card regardless of execution type, so the promoted strategies'' paper histories (and S06325''s open paper position) rendered as live results under "LIVE STRATEGIES — REAL EXCHANGE ORDERS". No data was mutated — display only.

Fix: a deployed/live card renders only `execution_type=''live''` rows. Paper cards are deliberately NOT filtered — a demoted strategy''s stuck live position must stay visible/reachable through the manual controls (which dispatch on the trade''s type; encoded in `tests/test_paper_control.py`).

**Also**: updated the stale sizing assert in `test_kernel_live_parity.py` — broken on main since PR #92''s LIVE-CLAMP-1 clamp (verified failing on clean main).

## Tests

- New `tests/test_execution_lane_dispatch.py`: 12 cases — lane resolution, the full dispatch matrix (promotion/demotion/matched/unstamped), both orphan-closer live-row guards, and the session-card filter semantics.
- `pytest tests/test_execution_lane_dispatch.py tests/test_kernel_live_parity.py tests/test_paper_control.py tests/test_paper_summary.py tests/test_scanner_kernel_paper_integration.py` -> **68 passed**; plus CI capital-integrity suites (`test_engine_audit_phase1`, `test_per_bar_kernel_adapter`, `test_execution_results`) -> 29 passed; ruff clean.

## Notes

- E0208 itself was already defused manually (closed via the sanctioned paper close at +7.0%) before this fix; the fix prevents the class.
- Backend restart required to activate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)