### PR TITLE
fix(runtime): stop console windows popping from the console-detached backend (CONSOLE-2)

### DIFF
--- a/forven/agents/mcp_client.py
+++ b/forven/agents/mcp_client.py
@@ -294,6 +294,16 @@ async def connect(config: MCPServerConfig) -> MCPSession:
                 raise MCPProtocolError("stdio config requires command")
             scrubbed_extra = _scrub_user_env(config.env)
             env = build_subprocess_env(extra=scrubbed_extra)
+            # CONSOLE-2: CREATE_NO_WINDOW on Windows — the supervised backend is
+            # console-detached, so a stdio MCP server spawned without it pops a
+            # visible console window.
+            _spawn_kwargs = {}
+            if os.name == "nt":
+                import subprocess as _subprocess
+
+                _spawn_kwargs["creationflags"] = getattr(
+                    _subprocess, "CREATE_NO_WINDOW", 0x08000000
+                )
             session.proc = await asyncio.create_subprocess_exec(
                 config.command,
                 *config.args,
@@ -301,6 +311,7 @@ async def connect(config: MCPServerConfig) -> MCPSession:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=env,
+                **_spawn_kwargs,
             )
         elif config.transport == "http":
             if not config.url:

--- a/forven/agents/tools_core.py
+++ b/forven/agents/tools_core.py
@@ -147,6 +147,7 @@ async def _kill_shell_process_tree(proc: asyncio.subprocess.Process) -> None:
                 "/F",
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.DEVNULL,
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000),
             )
             await asyncio.wait_for(killer.wait(), timeout=5)
         except Exception:
@@ -269,7 +270,13 @@ async def _tool_run_shell(command: str) -> str:
                     f"(H-S3 strict mode). Set FORVEN_SHELL_STRICT_ALLOWLIST=0 to disable."
                 )
 
-    creationflags = subprocess.CREATE_NEW_PROCESS_GROUP if os.name == "nt" else 0
+    # CONSOLE-2: CREATE_NO_WINDOW alongside the process group — the supervised
+    # backend is console-detached, so a shell child without it pops a visible
+    # console window per command. Never DETACHED_PROCESS (overrides NO_WINDOW).
+    creationflags = (
+        (subprocess.CREATE_NEW_PROCESS_GROUP | getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000))
+        if os.name == "nt" else 0
+    )
     start_new_session = os.name != "nt"
     async with _get_shell_tool_semaphore():
         proc = await asyncio.create_subprocess_shell(

--- a/forven/api.py
+++ b/forven/api.py
@@ -957,10 +957,35 @@ if __name__ == "__main__":
             try:
                 import ctypes
 
-                if ctypes.windll.kernel32.FreeConsole():
+                _k32 = ctypes.windll.kernel32
+                if _k32.FreeConsole():
                     log.info(
                         "Detached from the launcher console (supervised run) — "
                         "operator console events can no longer reach this process."
+                    )
+                # CONSOLE-2: a console-LESS process makes every console-subsystem
+                # child (sandbox workers, multiprocessing backtest pools, taskkill,
+                # ruff, MCP servers) allocate a fresh VISIBLE console window — the
+                # "random python windows" regression CONSOLE-1 introduced. The
+                # multiprocessing pools can't pass creationflags, so the only
+                # complete fix is here at the parent: re-anchor on a PRIVATE
+                # console of our own and hide its window. Operator console events
+                # still cannot reach us (their console is no longer ours), and all
+                # children quietly inherit this hidden one. The AllocConsole window
+                # may flash for an instant at boot before ShowWindow hides it —
+                # once per backend start, not per child spawn.
+                if _k32.AllocConsole():
+                    _hwnd = _k32.GetConsoleWindow()
+                    if _hwnd:
+                        ctypes.windll.user32.ShowWindow(_hwnd, 0)  # SW_HIDE
+                    log.info(
+                        "Re-anchored on a private hidden console — child processes "
+                        "inherit it instead of popping console windows."
+                    )
+                else:
+                    log.warning(
+                        "AllocConsole failed after detach — console-subsystem child "
+                        "processes will open visible console windows."
                     )
             except Exception:
                 log.warning("Could not detach from the launcher console", exc_info=True)

--- a/forven/sandbox/__init__.py
+++ b/forven/sandbox/__init__.py
@@ -27,6 +27,14 @@ TIMEOUT_SECONDS = 60
 IS_WINDOWS = sys.platform == "win32"
 PYTHON_EXE = sys.executable or "python"
 
+# CONSOLE-2: the supervised backend runs console-detached, so a console-subsystem
+# child spawned without this flag allocates a fresh VISIBLE console window.
+# CREATE_NO_WINDOW only — never combine with DETACHED_PROCESS, which Windows lets
+# override CREATE_NO_WINDOW (see bot_factory.manager). No-op on POSIX.
+NO_WINDOW_CREATION_FLAGS = (
+    getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000) if os.name == "nt" else 0
+)
+
 # Cap BLAS thread pools in sandbox subprocesses. NumPy/pandas pull in
 # OpenBLAS (and sometimes MKL/OMP), each of which allocates per-thread
 # workspaces on import — one per CPU core by default. On a many-core host
@@ -223,6 +231,7 @@ def run_code(
                     cmd, shell=False,
                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
                     env=env, cwd=str(REPO_ROOT),
+                    creationflags=NO_WINDOW_CREATION_FLAGS,
                 )
             except Exception as exc:
                 return {
@@ -313,6 +322,7 @@ def lint_code(code: str) -> dict:
         check = subprocess.run(
             [PYTHON_EXE, "-m", "ruff", "check", script_path, "--output-format=text"],
             capture_output=True, text=True, timeout=15,
+            creationflags=NO_WINDOW_CREATION_FLAGS,
         )
         issues = [line for line in check.stdout.strip().split("\n") if line.strip()]
 
@@ -324,6 +334,7 @@ def lint_code(code: str) -> dict:
             subprocess.run(
                 [PYTHON_EXE, "-m", "ruff", "check", "--fix", fix_path],
                 capture_output=True, timeout=15,
+                creationflags=NO_WINDOW_CREATION_FLAGS,
             )
             try:
                 fixed_code = Path(fix_path).read_text(encoding="utf-8")

--- a/forven/sandbox/strategy_worker.py
+++ b/forven/sandbox/strategy_worker.py
@@ -52,6 +52,7 @@ import pandas as pd
 
 from forven.sandbox import (
     IS_WINDOWS,
+    NO_WINDOW_CREATION_FLAGS,
     PYTHON_EXE,
     REPO_ROOT,
     _BLAS_THREAD_ENV,
@@ -428,6 +429,7 @@ class _PersistentWorker:
             env=env,
             cwd=str(REPO_ROOT),
             preexec_fn=(None if IS_WINDOWS else _build_posix_preexec(PERSISTENT_MAX_MEMORY_MB)),
+            creationflags=NO_WINDOW_CREATION_FLAGS,
         )
         if IS_WINDOWS:
             self._job, self._kernel32 = _create_windows_job_object(PERSISTENT_MAX_MEMORY_MB)
@@ -662,6 +664,7 @@ def validate_custom_module_isolated(
             env=env,
             cwd=str(REPO_ROOT),
             preexec_fn=(None if IS_WINDOWS else _build_posix_preexec(PERSISTENT_MAX_MEMORY_MB)),
+            creationflags=NO_WINDOW_CREATION_FLAGS,
         )
         job = kernel32 = None
         if IS_WINDOWS:

--- a/forven/strategies/backtest.py
+++ b/forven/strategies/backtest.py
@@ -250,9 +250,12 @@ def _kill_executor_processes(executor):
     for pid in list(executor._processes.keys()):
         try:
             if sys.platform == "win32":
-                # Use taskkill on Windows - more reliable than os.kill
+                # Use taskkill on Windows - more reliable than os.kill.
+                # CONSOLE-2: CREATE_NO_WINDOW, or the console-detached backend
+                # pops a visible console window per kill.
                 subprocess.run(["taskkill", "/PID", str(pid), "/T", "/F"],
-                             capture_output=True, timeout=5)
+                             capture_output=True, timeout=5,
+                             creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000))
             else:
                 os.kill(pid, signal.SIGKILL)
         except (subprocess.SubprocessError, OSError):

--- a/scripts/watchdog.py
+++ b/scripts/watchdog.py
@@ -19,7 +19,7 @@ import signal
 import subprocess
 import sqlite3
 import logging
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
@@ -133,10 +133,17 @@ def _get_bot_lock_age_seconds() -> float | None:
 def _start_bot() -> int | None:
     """Start the bot process in the background. Returns the new PID."""
     try:
+        # CONSOLE-2: CREATE_NO_WINDOW, not DETACHED_PROCESS — a detached child has
+        # no console at all, so every console-subsystem process IT spawns pops a
+        # visible console window (and Windows ignores CREATE_NO_WINDOW when
+        # DETACHED_PROCESS is set — see bot_factory.manager). With NO_WINDOW the
+        # child owns its own hidden console: still isolated from this console's
+        # Ctrl+C/close, but its children inherit the hidden console silently.
         proc = subprocess.Popen(
             BOT_START_CMD,
             cwd=str(Path(__file__).resolve().parent.parent),
-            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS,
+            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP
+            | getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000),
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )

--- a/tests/test_no_console_window_spawns.py
+++ b/tests/test_no_console_window_spawns.py
@@ -1,0 +1,96 @@
+"""CONSOLE-2: child processes must never pop visible console windows.
+
+Since CONSOLE-1 (PR #95) the supervised backend runs console-detached, so any
+console-subsystem child spawned WITHOUT CREATE_NO_WINDOW allocates a fresh
+VISIBLE console window (the "random python windows" regression). These lock in
+the two rules: every direct spawn passes CREATE_NO_WINDOW, and nothing combines
+it with DETACHED_PROCESS (Windows ignores CREATE_NO_WINDOW when DETACHED_PROCESS
+is set — the documented bot_factory gotcha).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+CREATE_NO_WINDOW = 0x08000000
+DETACHED_PROCESS = 0x00000008
+
+
+def test_sandbox_no_window_flags_constant():
+    from forven.sandbox import NO_WINDOW_CREATION_FLAGS
+
+    if os.name == "nt":
+        assert NO_WINDOW_CREATION_FLAGS & CREATE_NO_WINDOW
+        assert not (NO_WINDOW_CREATION_FLAGS & DETACHED_PROCESS)
+    else:
+        assert NO_WINDOW_CREATION_FLAGS == 0
+
+
+def test_strategy_worker_uses_sandbox_flags():
+    import forven.sandbox.strategy_worker as sw
+
+    # The constant must be imported into the worker module — both Popen call
+    # sites pass it (source-asserted below).
+    from forven.sandbox import NO_WINDOW_CREATION_FLAGS
+
+    assert sw.NO_WINDOW_CREATION_FLAGS is NO_WINDOW_CREATION_FLAGS
+    src = Path(sw.__file__).read_text(encoding="utf-8")
+    assert src.count("creationflags=NO_WINDOW_CREATION_FLAGS") == 2
+
+
+def test_sandbox_spawns_pass_flags_in_source():
+    src = (REPO_ROOT / "forven" / "sandbox" / "__init__.py").read_text(encoding="utf-8")
+    # Windows sandbox Popen + both ruff runs.
+    assert src.count("creationflags=NO_WINDOW_CREATION_FLAGS") == 3
+
+
+def test_no_detached_process_anywhere_in_spawn_paths():
+    """DETACHED_PROCESS must not be used for child spawns — a detached child has
+    no console, so ITS children pop visible console windows (the exact failure
+    mode this suite guards). The only sanctioned pattern is CREATE_NO_WINDOW."""
+    offenders = []
+    for rel in (
+        "forven/sandbox/__init__.py",
+        "forven/sandbox/strategy_worker.py",
+        "forven/strategies/backtest.py",
+        "forven/agents/tools_core.py",
+        "forven/agents/mcp_client.py",
+        "forven/bot_factory/manager.py",
+        "forven/lab_worker_service.py",
+        "scripts/watchdog.py",
+    ):
+        text = (REPO_ROOT / rel).read_text(encoding="utf-8")
+        for match in re.finditer(r"^.*DETACHED_PROCESS.*$", text, flags=re.MULTILINE):
+            line = match.group(0).strip()
+            if line.startswith("#") or "never" in line or "not DETACHED" in line:
+                continue  # comments documenting the gotcha are fine
+            offenders.append(f"{rel}: {line}")
+    assert not offenders, f"DETACHED_PROCESS used in spawn paths: {offenders}"
+
+
+def test_windows_kill_and_shell_spawns_pass_no_window():
+    """taskkill / agent-shell / MCP stdio spawns all carry CREATE_NO_WINDOW."""
+    backtest = (REPO_ROOT / "forven" / "strategies" / "backtest.py").read_text(encoding="utf-8")
+    assert 'CREATE_NO_WINDOW' in backtest
+
+    tools_core = (REPO_ROOT / "forven" / "agents" / "tools_core.py").read_text(encoding="utf-8")
+    assert tools_core.count("CREATE_NO_WINDOW") >= 2  # shell tool + taskkill killer
+
+    mcp_client = (REPO_ROOT / "forven" / "agents" / "mcp_client.py").read_text(encoding="utf-8")
+    assert "CREATE_NO_WINDOW" in mcp_client
+
+
+def test_api_reanchors_hidden_console_after_detach():
+    """CONSOLE-2: after FreeConsole, the supervised backend must AllocConsole and
+    hide it — the only fix that also covers multiprocessing pool workers, which
+    cannot pass creationflags."""
+    api_src = (REPO_ROOT / "forven" / "api.py").read_text(encoding="utf-8")
+    detach_idx = api_src.find("FreeConsole()")
+    assert detach_idx != -1
+    tail = api_src[detach_idx:]
+    assert "AllocConsole()" in tail
+    assert "ShowWindow" in tail


### PR DESCRIPTION
## What

Since CONSOLE-1 (PR #95) a supervised backend calls `FreeConsole()` at boot. On Windows, a console-LESS parent makes **every console-subsystem child allocate a fresh visible console window** — after the first post-#95 restart the operator sees "random python windows" popping: the persistent sandbox strategy worker (a lingering blank `python.exe` console), one-shot validate workers, multiprocessing backtest/robustness pool workers, `taskkill`/ruff calls, and stdio MCP servers.

## Fix (two layers)

**1. The umbrella (`forven/api.py`)** — after `FreeConsole()`, `AllocConsole()` a **private console and hide its window** (`ShowWindow(..., SW_HIDE)`). CONSOLE-1''s goal is intact — the operator''s console is no longer ours, so their Ctrl+C/close can''t reach the backend — but all children now quietly inherit the hidden console. This is the **only possible fix for the multiprocessing spawn pools**, which cannot pass creationflags.

**2. `CREATE_NO_WINDOW` on every direct spawn site** (belt-and-suspenders; also covers non-backend parents):
- `forven/sandbox/__init__.py`: new `NO_WINDOW_CREATION_FLAGS` constant; sandboxed exec Popen + both ruff runs
- `forven/sandbox/strategy_worker.py`: persistent worker + one-shot validate worker
- `forven/strategies/backtest.py`: executor taskkill
- `forven/agents/tools_core.py`: agent shell tool + its taskkill killer
- `forven/agents/mcp_client.py`: stdio MCP server spawn
- `scripts/watchdog.py`: bot spawn switches `DETACHED_PROCESS` → `CREATE_NO_WINDOW` (the documented bot_factory gotcha: Windows *ignores* CREATE_NO_WINDOW when DETACHED_PROCESS is set, and a detached child leaks windows from ITS children); also drops a pre-existing unused `timedelta` import (ruff F401)

## Tests

`tests/test_no_console_window_spawns.py` (6 cases) locks in both rules: every spawn path carries CREATE_NO_WINDOW, nothing combines it with DETACHED_PROCESS, and api.py re-anchors on a hidden console after the detach. Full sweep: those + `test_strategy_worker_db_jail` + `test_registry_custom_module_guard` + `test_sandbox_ast_guard` + `test_per_bar_kernel_adapter` → **58 passed**; ruff clean on all touched files.

## Notes

- Backend restart required to activate (the current process is already detached; the hidden-console re-anchor only runs at boot).
- One cosmetic residue: the `AllocConsole` window may flash for an instant **once per backend start** before it''s hidden — not per child spawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)