### PR TITLE
fix(jobs): orphaned-running-job sweep runs only at API startup (JOB-SWEEP-1)

### DIFF
--- a/forven/api_core.py
+++ b/forven/api_core.py
@@ -213,6 +213,16 @@ async def _on_startup():
     except Exception as exc:
         log.warning("Research settings seeding failed: %s", exc)
     try:
+        # Orphaned-job sweep belongs HERE, once per API boot — never at module
+        # import, which spawn-context pool workers re-execute against the live
+        # job table, failing genuinely-running jobs mid-flight (see
+        # _cleanup_orphaned_running_jobs).
+        from forven.routers.robustness import _cleanup_orphaned_running_jobs
+
+        _cleanup_orphaned_running_jobs()
+    except Exception as exc:
+        log.warning("Orphaned running-job cleanup failed: %s", exc)
+    try:
         from forven.data_manager import assert_data_root_consistent
 
         # Launch hardening: don't silently continue on a split-brain data root.

--- a/forven/routers/robustness.py
+++ b/forven/routers/robustness.py
@@ -230,7 +230,22 @@ def _cleanup_orphaned_running_jobs() -> None:
     tasks were still executing — those threads are gone but the DB rows
     still say 'running'. Optimization (and backtest) placeholder rows are
     included so orphaned jobs don't linger as ghost "Active Processes".
+
+    ONLY the main API process may run this, exactly once at startup (the
+    api_core._on_startup hook). It used to fire at module import, and this
+    module is imported by every spawn-context pool worker that pickles
+    _monte_carlo_bootstrap_worker / the regime-split worker — so every such
+    spawn swept the LIVE job table and marked genuinely-running jobs as
+    "Server restarted while job was running" mid-flight (the UI then showed
+    that error on every long run while the job actually completed fine).
     """
+    try:
+        import multiprocessing
+
+        if multiprocessing.parent_process() is not None:
+            return  # a pool/sandbox child must never sweep the live job table
+    except Exception:
+        pass
     try:
         from forven.db import get_db
         import json as _json
@@ -255,9 +270,6 @@ def _cleanup_orphaned_running_jobs() -> None:
                 log.info("Cleaned up orphaned running job: %s", row["result_id"])
     except Exception as exc:
         log.debug("Orphaned job cleanup skipped: %s", exc)
-
-
-_cleanup_orphaned_running_jobs()
 
 
 def _model_to_dict(model: BaseModel) -> dict:

--- a/tests/test_orphan_job_cleanup_scope.py
+++ b/tests/test_orphan_job_cleanup_scope.py
@@ -1,0 +1,81 @@
+"""JOB-SWEEP-1: the orphaned-running-job sweep runs ONLY at API startup in the
+main process.
+
+It used to fire at forven.routers.robustness IMPORT time. That module is
+imported by every spawn-context pool worker that pickles its module-level
+worker functions (_monte_carlo_bootstrap_worker, the regime-split worker), so
+every such spawn swept the LIVE job table and marked genuinely-running jobs as
+"Server restarted while job was running" mid-flight — the UI showed that error
+on every long walk-forward while the job actually completed and persisted fine.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _insert_running_row(result_id: str = "rob_walk_forward_testrun") -> None:
+    from forven.db import get_db
+
+    config = {"job_id": "job_testrun", "status": "running", "submitted_at": "2026-07-21T00:00:00+00:00"}
+    with get_db() as conn:
+        conn.execute(
+            """INSERT OR IGNORE INTO strategies (id, name, type, symbol, timeframe, params, stage, status, created_at, updated_at)
+               VALUES ('S99001', 'S99001', 'rule_engine', 'ETH', '4h', '{}', 'paper', 'paper',
+                       '2026-07-21T00:00:00+00:00', '2026-07-21T00:00:00+00:00')"""
+        )
+        conn.execute(
+            """INSERT INTO backtest_results
+                   (result_id, strategy_id, result_type, symbol, timeframe, config_json, metrics_json, created_at)
+               VALUES (?, 'S99001', 'walk_forward', 'ETH', '4h', ?, '{}', '2026-07-21T00:00:00+00:00')""",
+            (result_id, json.dumps(config)),
+        )
+
+
+def _row_status(result_id: str = "rob_walk_forward_testrun") -> str:
+    from forven.db import get_db
+
+    with get_db() as conn:
+        row = conn.execute(
+            "SELECT config_json FROM backtest_results WHERE result_id = ?", (result_id,)
+        ).fetchone()
+    return str(json.loads(row["config_json"]).get("status"))
+
+
+def test_child_process_never_sweeps_running_jobs(forven_db, monkeypatch):
+    import multiprocessing
+
+    from forven.routers import robustness
+
+    _insert_running_row()
+    monkeypatch.setattr(multiprocessing, "parent_process", lambda: object())
+    robustness._cleanup_orphaned_running_jobs()
+    assert _row_status() == "running"  # untouched: a pool child must never sweep
+
+
+def test_main_process_startup_sweep_still_marks_orphans(forven_db, monkeypatch):
+    import multiprocessing
+
+    from forven.routers import robustness
+
+    _insert_running_row()
+    monkeypatch.setattr(multiprocessing, "parent_process", lambda: None)
+    robustness._cleanup_orphaned_running_jobs()
+    assert _row_status() == "failed"  # genuine boot-time orphan is still reaped
+
+
+def test_sweep_is_not_invoked_at_module_import():
+    src = (REPO_ROOT / "forven" / "routers" / "robustness.py").read_text(encoding="utf-8")
+    # A bare module-level invocation (column 0) is the regression; calls inside
+    # functions/hooks are indented and fine.
+    assert not re.search(r"^_cleanup_orphaned_running_jobs\(\)", src, flags=re.MULTILINE)
+
+
+def test_startup_hook_invokes_sweep():
+    src = (REPO_ROOT / "forven" / "api_core.py").read_text(encoding="utf-8")
+    hook = src[src.find("async def _on_startup") :]
+    assert "_cleanup_orphaned_running_jobs()" in hook


### PR DESCRIPTION
## What

The "Server restarted while job was running" error the operator saw on **every** walk-forward run (while the runs actually completed and persisted PASS verdicts) was caused by an import-time side effect:

`_cleanup_orphaned_running_jobs()` was invoked at `forven.routers.robustness` **module import**. That module is imported by every spawn-context `ProcessPoolExecutor` worker that pickles its module-level worker functions (`_monte_carlo_bootstrap_worker`, the regime-split worker) — so every background robustness spawn re-ran the "startup" sweep against the **live job table** and marked genuinely-running jobs failed mid-flight. Any multi-minute WFA overlapped some background spawn, so the UI reported the error on essentially every run; the job itself finished and overwrote its row to `succeeded` seconds later (which is why FAIL banners coexisted with fresh PASS artifacts). Optimization/backtest placeholder rows were poisoned the same way (see the ghost failures `test_ordering_ignores_failed_optimization` models).

## Fix

- Remove the module-level invocation. The sweep now runs **exactly once per API boot** from `api_core._on_startup` — before traffic, same correctness as the old placement had in the API process.
- Defense-in-depth guard inside the function: a multiprocessing child (`parent_process() is not None`) returns immediately, so no future import path can re-weaponize it.

## Tests

`tests/test_orphan_job_cleanup_scope.py` (4 cases): a child process never sweeps a running row; the main process still reaps genuine boot orphans; no module-level invocation exists in the source; the startup hook calls the sweep. Plus `test_robustness_router.py` (CI-curated) — **17 passed**, ruff clean.

## Notes

Backend restart required to activate. After it, RUN WFA should complete without the spurious restart error; the stale-result fallback display that showed a July-8 FAIL is a separate cosmetic issue, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)