### PR TITLE
fix(gauntlet): status composite scored live from artifacts, not the frozen stamp (COMPOSITE-LIVE-1)

### DIFF
--- a/forven/gauntlet/status.py
+++ b/forven/gauntlet/status.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 
 from forven.gauntlet.models import ROBUSTNESS_STEP_KEYS, STEP_TERMINAL_STATUSES
 from forven.gauntlet.settings import build_settings_snapshot, normalize_required_tests
 from forven.gauntlet.store import get_latest_workflow_for_strategy, get_workflow_detail
 from forven.util import normalize_stage
+
+log = logging.getLogger("forven.gauntlet.status")
 
 _RESULT_TYPE_TO_STEP = {
     "walk_forward": "walk_forward",
@@ -304,19 +307,37 @@ def get_strategy_gauntlet_status(strategy_id: str) -> dict[str, Any]:
     strategy_metrics = _parse_json(strategy.get("metrics"), {})
     if not isinstance(strategy_metrics, dict):
         strategy_metrics = {}
-    composite = strategy_metrics.get("composite_robustness_score")
-    if composite is None:
-        composite = strategy_metrics.get("robustness_score") or strategy_metrics.get("robustness") or strategy_metrics.get("gauntlet_score")
-    # Scale-blend guard: legacy writers stored these keys as 0-1 fractions (every
-    # pre-v3 `robustness` value in prod is <= 1.0) while this payload's contract —
-    # and the floor it is compared against — is 0-100. Mirror the frontend history
-    # readers' convention (abs(v) <= 1 -> x100) so a legacy 0.726 surfaces as 72.6
-    # instead of rendering as "0.7 / 100" and false-failing the floor.
+    # LIVE composite: score the CURRENT artifacts instead of trusting the stored
+    # stamp. Paper/live strategies have FROZEN stored metrics (the recalc's
+    # metric-sync deliberately skips operator-owned stages), so the stored value
+    # pins at its pre-promotion state forever while the per-test chips above read
+    # the live artifacts — ~40 prod strategies rendered "0.0 / 100" beside 5/5
+    # PASS chips. The stored value stays as the fallback for scorer errors and
+    # strategies with no artifacts.
+    composite = None
     try:
-        if composite is not None and abs(float(composite)) <= 1.0:
-            composite = round(float(composite) * 100.0, 1)
-    except (TypeError, ValueError):
-        pass
+        from forven.routers.robustness import compute_composite_robustness_score
+
+        computed = compute_composite_robustness_score(strategy_id)
+        if computed is not None:
+            composite = float(computed["score"])
+    except Exception as exc:
+        log.debug("live composite computation failed for %s: %s", strategy_id, exc)
+    if composite is None:
+        composite = strategy_metrics.get("composite_robustness_score")
+        if composite is None:
+            composite = strategy_metrics.get("robustness_score") or strategy_metrics.get("robustness") or strategy_metrics.get("gauntlet_score")
+        # Scale-blend guard (fallback path only — the live score above is 0-100 by
+        # construction): legacy writers stored these keys as 0-1 fractions (every
+        # pre-v3 `robustness` value in prod is <= 1.0) while this payload's contract —
+        # and the floor it is compared against — is 0-100. Mirror the frontend history
+        # readers' convention (abs(v) <= 1 -> x100) so a legacy 0.726 surfaces as 72.6
+        # instead of rendering as "0.7 / 100" and false-failing the floor.
+        try:
+            if composite is not None and abs(float(composite)) <= 1.0:
+                composite = round(float(composite) * 100.0, 1)
+        except (TypeError, ValueError):
+            pass
 
     min_robustness = gauntlet_cfg.get("min_robustness_score")
     try:

--- a/forven/routers/robustness.py
+++ b/forven/routers/robustness.py
@@ -2156,117 +2156,149 @@ def _test_pass_margin(result_type: str, metrics: dict, config: dict) -> float:
     return 0.5
 
 
+def compute_composite_robustness_score(strategy_id: str) -> dict | None:
+    """Margin-weighted composite over the latest GENUINE artifact per test type.
+
+    The single scorer: the metrics-sync recalc below AND the gauntlet-status
+    readout both use it, so the status panel shows the LIVE score even for
+    paper/live strategies whose stored metrics are frozen — the frozen stamp
+    otherwise pins the panel at its pre-promotion value forever while the
+    per-test chips read the live artifacts. Returns ``None`` when the strategy
+    has no artifact rows at all; otherwise
+    ``{score, passed, canonical_total, avg_margin, measured_total, tests}``.
+    """
+    from forven.db import get_db
+
+    with get_db() as conn:
+        rows = conn.execute(
+            """SELECT result_type, metrics_json, config_json
+               FROM backtest_results
+               WHERE strategy_id = ?
+                 AND (deleted_at IS NULL OR TRIM(COALESCE(deleted_at, '')) = '')
+                 AND LOWER(TRIM(COALESCE(result_type, ''))) IN (
+                     'walk_forward', 'monte_carlo', 'param_jitter', 'cost_stress', 'regime_split'
+                 )
+               ORDER BY datetime(created_at) DESC""",
+            (strategy_id,),
+        ).fetchall()
+
+    if not rows:
+        return None
+
+    from forven.policy import (
+        is_nonresult_validation_row,
+        is_nonresult_wfa_row,
+        load_pipeline_config,
+    )
+
+    gauntlet_cfg = load_pipeline_config().get("gauntlet", {})
+    min_trades = int(gauntlet_cfg.get("min_trades", 10) or 10)
+
+    # Deduplicate by result_type (keep the latest GENUINE verdict). A pending or
+    # errored/timed-out row is a NON-RESULT: skip it without claiming the type so
+    # an older genuine verdict can still surface — mirroring the paper gate's
+    # extractor. Counting an infra failure as `passed=False` here dragged
+    # composite_robustness_score/robustness_tests_passed and the brain then
+    # archived on a phantom merit fail (2026-07-11).
+    parsed = [
+        (
+            str(r["result_type"] or "").strip().lower(),
+            _parse_json_object(r["metrics_json"]),
+            _parse_json_object(r["config_json"]),
+        )
+        for r in rows
+    ]
+    # Mirror the paper-gate extractor's current-params preference: a re-run
+    # scored on since-changed params must not displace a current-params
+    # verdict here either (the two readers feed the same brain decisions).
+    current_hash = _current_params_hash(strategy_id)
+    if current_hash:
+        matching = [
+            p for p in parsed
+            if str((p[2] or {}).get("params_hash") or "").strip() == current_hash
+        ]
+        if matching:
+            parsed = matching + [p for p in parsed if p not in matching]
+
+    seen = set()
+    tests: list[dict] = []
+    for rt, metrics, config in parsed:
+        if rt in seen:
+            continue
+        if is_nonresult_validation_row(metrics, config):
+            continue
+        # A completed 0-fold/0-trade walk_forward measured nothing — same
+        # rule as the paper-gate extractor (policy.is_nonresult_wfa_row).
+        if rt == "walk_forward" and is_nonresult_wfa_row(metrics):
+            continue
+        seen.add(rt)
+        passed_result, reason = _validation_row_passed(
+            rt,
+            metrics,
+            config,
+            min_trades=min_trades,
+        )
+        margin = _test_pass_margin(rt, metrics, config) if passed_result else 0.0
+        tests.append({"type": rt, "passed": passed_result, "reason": reason, "margin": margin})
+
+    # NOTE: no early return when tests is empty — if every persisted row is a
+    # non-result the score below computes to 0 and OVERWRITES whatever stale
+    # composite was last written (matching the pre-fix net effect for the
+    # all-errored case; leaving a stale 100 standing would let the brain keep
+    # reading robustness no surviving evidence supports).
+
+    # Denominator = the canonical REQUIRED test set, NOT just the tests that happen
+    # to have a row. Counting only measured tests means a single passing test of N
+    # scores 100 (a partial run looks perfect and clears the floor). Using the
+    # required set (or all 5 when "enforce all" / required_tests is empty) makes
+    # unmeasured/failed required tests correctly pull the score down.
+    from forven.gauntlet.models import ROBUSTNESS_STEP_KEYS, normalize_step_key
+    from forven.gauntlet.settings import normalize_required_tests
+
+    required = normalize_required_tests(gauntlet_cfg.get("required_tests"))
+    canonical = set(required) if required else set(ROBUSTNESS_STEP_KEYS)
+    canonical_tests = [t for t in tests if normalize_step_key(str(t["type"])) in canonical]
+    passed = sum(1 for t in canonical_tests if t["passed"])
+    canonical_total = len(canonical)
+    total = len(tests)  # measured count, kept for logging only
+    # Margin-weighted, gate-safe composite: base = (passed/canonical_total)*100; a
+    # bounded bonus (capped just under one band step) then ranks already-passing
+    # strategies WITHIN their band without ever crossing into the next pass-count
+    # band. avg_margin is over PASSED canonical tests only.
+    if canonical_total > 0:
+        base = (passed / canonical_total) * 100.0
+        passed_margins = [float(t.get("margin") or 0.0) for t in canonical_tests if t["passed"]]
+        avg_margin = sum(passed_margins) / len(passed_margins) if passed_margins else 0.0
+        band_step = 100.0 / canonical_total
+        bonus = avg_margin * max(band_step - 0.1, 0.0)
+        score = round(min(base + bonus, 100.0), 2)
+    else:
+        avg_margin = 0.0
+        score = 0.0
+
+    return {
+        "score": score,
+        "passed": passed,
+        "canonical_total": canonical_total,
+        "avg_margin": avg_margin,
+        "measured_total": total,
+        "tests": tests,
+    }
+
+
 def _recalculate_robustness_score(strategy_id: str) -> None:
     """Recalculate composite robustness score from all test results and sync to strategy record."""
     try:
         from forven.db import get_db
 
-        with get_db() as conn:
-            rows = conn.execute(
-                """SELECT result_type, metrics_json, config_json
-                   FROM backtest_results
-                   WHERE strategy_id = ?
-                     AND (deleted_at IS NULL OR TRIM(COALESCE(deleted_at, '')) = '')
-                     AND LOWER(TRIM(COALESCE(result_type, ''))) IN (
-                         'walk_forward', 'monte_carlo', 'param_jitter', 'cost_stress', 'regime_split'
-                     )
-                   ORDER BY datetime(created_at) DESC""",
-                (strategy_id,),
-            ).fetchall()
-
-        if not rows:
+        computed = compute_composite_robustness_score(strategy_id)
+        if computed is None:
             return
-
-        from forven.policy import (
-            is_nonresult_validation_row,
-            is_nonresult_wfa_row,
-            load_pipeline_config,
-        )
-
-        gauntlet_cfg = load_pipeline_config().get("gauntlet", {})
-        min_trades = int(gauntlet_cfg.get("min_trades", 10) or 10)
-
-        # Deduplicate by result_type (keep the latest GENUINE verdict). A pending or
-        # errored/timed-out row is a NON-RESULT: skip it without claiming the type so
-        # an older genuine verdict can still surface — mirroring the paper gate's
-        # extractor. Counting an infra failure as `passed=False` here dragged
-        # composite_robustness_score/robustness_tests_passed and the brain then
-        # archived on a phantom merit fail (2026-07-11).
-        parsed = [
-            (
-                str(r["result_type"] or "").strip().lower(),
-                _parse_json_object(r["metrics_json"]),
-                _parse_json_object(r["config_json"]),
-            )
-            for r in rows
-        ]
-        # Mirror the paper-gate extractor's current-params preference: a re-run
-        # scored on since-changed params must not displace a current-params
-        # verdict here either (the two readers feed the same brain decisions).
-        current_hash = _current_params_hash(strategy_id)
-        if current_hash:
-            matching = [
-                p for p in parsed
-                if str((p[2] or {}).get("params_hash") or "").strip() == current_hash
-            ]
-            if matching:
-                parsed = matching + [p for p in parsed if p not in matching]
-
-        seen = set()
-        tests: list[dict] = []
-        for rt, metrics, config in parsed:
-            if rt in seen:
-                continue
-            if is_nonresult_validation_row(metrics, config):
-                continue
-            # A completed 0-fold/0-trade walk_forward measured nothing — same
-            # rule as the paper-gate extractor (policy.is_nonresult_wfa_row).
-            if rt == "walk_forward" and is_nonresult_wfa_row(metrics):
-                continue
-            seen.add(rt)
-            passed_result, reason = _validation_row_passed(
-                rt,
-                metrics,
-                config,
-                min_trades=min_trades,
-            )
-            margin = _test_pass_margin(rt, metrics, config) if passed_result else 0.0
-            tests.append({"type": rt, "passed": passed_result, "reason": reason, "margin": margin})
-
-        # NOTE: no early return when tests is empty — if every persisted row is a
-        # non-result the score below computes to 0 and OVERWRITES whatever stale
-        # composite was last written (matching the pre-fix net effect for the
-        # all-errored case; leaving a stale 100 standing would let the brain keep
-        # reading robustness no surviving evidence supports).
-
-        # Denominator = the canonical REQUIRED test set, NOT just the tests that happen
-        # to have a row. Counting only measured tests means a single passing test of N
-        # scores 100 (a partial run looks perfect and clears the floor). Using the
-        # required set (or all 5 when "enforce all" / required_tests is empty) makes
-        # unmeasured/failed required tests correctly pull the score down.
-        from forven.gauntlet.models import ROBUSTNESS_STEP_KEYS, normalize_step_key
-        from forven.gauntlet.settings import normalize_required_tests
-
-        required = normalize_required_tests(gauntlet_cfg.get("required_tests"))
-        canonical = set(required) if required else set(ROBUSTNESS_STEP_KEYS)
-        canonical_tests = [t for t in tests if normalize_step_key(str(t["type"])) in canonical]
-        passed = sum(1 for t in canonical_tests if t["passed"])
-        canonical_total = len(canonical)
-        total = len(tests)  # measured count, kept for logging only
-        # Margin-weighted, gate-safe composite: base = (passed/canonical_total)*100; a
-        # bounded bonus (capped just under one band step) then ranks already-passing
-        # strategies WITHIN their band without ever crossing into the next pass-count
-        # band. avg_margin is over PASSED canonical tests only.
-        if canonical_total > 0:
-            base = (passed / canonical_total) * 100.0
-            passed_margins = [float(t.get("margin") or 0.0) for t in canonical_tests if t["passed"]]
-            avg_margin = sum(passed_margins) / len(passed_margins) if passed_margins else 0.0
-            band_step = 100.0 / canonical_total
-            bonus = avg_margin * max(band_step - 0.1, 0.0)
-            score = round(min(base + bonus, 100.0), 2)
-        else:
-            avg_margin = 0.0
-            score = 0.0
+        score = computed["score"]
+        passed = computed["passed"]
+        canonical_total = computed["canonical_total"]
+        avg_margin = computed["avg_margin"]
+        total = computed["measured_total"]
 
         # Sync to strategy record
         with get_db() as conn:

--- a/tests/test_gauntlet_status_live_composite.py
+++ b/tests/test_gauntlet_status_live_composite.py
@@ -1,0 +1,81 @@
+"""COMPOSITE-LIVE-1: the gauntlet-status composite is scored from the CURRENT
+artifacts, not the frozen stored stamp.
+
+Paper/live strategies have frozen stored metrics (the recalc's metric-sync
+deliberately skips operator-owned stages), so the stored composite pinned at its
+pre-promotion value forever — ~40 prod strategies rendered "0.0 / 100" beside
+5/5 PASS test chips. The status endpoint now calls the same scorer the recalc
+uses (compute_composite_robustness_score) and only falls back to the stored
+value when the scorer has nothing to say.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+def _insert_strategy(strategy_id: str, *, stage: str, metrics: dict) -> None:
+    from forven.db import get_db
+
+    with get_db() as conn:
+        conn.execute(
+            """INSERT INTO strategies (id, name, type, symbol, timeframe, params, stage, status, metrics, created_at, updated_at)
+               VALUES (?, ?, 'rule_engine', 'ETH', '4h', '{}', ?, ?, ?,
+                       '2026-07-21T00:00:00+00:00', '2026-07-21T00:00:00+00:00')""",
+            (strategy_id, strategy_id, stage, stage, json.dumps(metrics)),
+        )
+
+
+def test_status_composite_prefers_live_scorer(forven_db, monkeypatch):
+    from forven.gauntlet.status import get_strategy_gauntlet_status
+    import forven.routers.robustness as robustness
+
+    _insert_strategy(
+        "S99101", stage="live_graduated",
+        metrics={"composite_robustness_score": 0.0, "robustness_tests_passed": 0},
+    )
+    monkeypatch.setattr(
+        robustness, "compute_composite_robustness_score",
+        lambda sid: {"score": 100.0, "passed": 5, "canonical_total": 5,
+                     "avg_margin": 0.5, "measured_total": 5, "tests": []},
+    )
+    status = get_strategy_gauntlet_status("S99101")
+    assert status["composite_robustness_score"] == 100.0  # not the frozen 0.0
+
+
+def test_status_composite_falls_back_to_stored_when_no_artifacts(forven_db, monkeypatch):
+    from forven.gauntlet.status import get_strategy_gauntlet_status
+    import forven.routers.robustness as robustness
+
+    _insert_strategy(
+        "S99102", stage="gauntlet",
+        metrics={"composite_robustness_score": 72.6},
+    )
+    monkeypatch.setattr(robustness, "compute_composite_robustness_score", lambda sid: None)
+    status = get_strategy_gauntlet_status("S99102")
+    assert status["composite_robustness_score"] == 72.6
+
+
+def test_status_composite_fallback_applies_legacy_scale_guard(forven_db, monkeypatch):
+    from forven.gauntlet.status import get_strategy_gauntlet_status
+    import forven.routers.robustness as robustness
+
+    # Legacy 0-1 fraction in the stored blob must still surface as 0-100.
+    _insert_strategy("S99103", stage="gauntlet", metrics={"robustness": 0.726})
+    monkeypatch.setattr(robustness, "compute_composite_robustness_score", lambda sid: None)
+    status = get_strategy_gauntlet_status("S99103")
+    assert status["composite_robustness_score"] == 72.6
+
+
+def test_status_composite_survives_scorer_error(forven_db, monkeypatch):
+    from forven.gauntlet.status import get_strategy_gauntlet_status
+    import forven.routers.robustness as robustness
+
+    _insert_strategy("S99104", stage="paper", metrics={"composite_robustness_score": 40.0})
+
+    def _boom(sid):
+        raise RuntimeError("scorer exploded")
+
+    monkeypatch.setattr(robustness, "compute_composite_robustness_score", _boom)
+    status = get_strategy_gauntlet_status("S99104")
+    assert status["composite_robustness_score"] == 40.0  # fail-soft to stored


### PR DESCRIPTION
## What

The gauntlet-status panel showed **COMPOSITE 0.0 / 100 — FLOOR 30** beside five green PASS chips. The chip read `composite_robustness_score` from the strategy row''s stored metrics blob, but paper/live strategies have **frozen** stored metrics (the recalc''s metric-sync deliberately skips operator-owned stages), so the stored value pins at its pre-promotion state forever while the per-test chips read the live artifacts. ~40 prod paper/live strategies carried the same stale `0.0, passed 0/1` stamp.

## Fix

- Extract the scorer core of `_recalculate_robustness_score` into `compute_composite_robustness_score()` — identical semantics (latest genuine artifact per type, non-result skips, current-params preference, required-set denominator, band-capped margin bonus). The metric-sync recalc now routes through it; its behavior (including the frozen-stage skip) is unchanged.
- `gauntlet/status.py` computes the panel composite through that same scorer. The stored value remains the fallback for scorer errors and strategies with no artifacts; the legacy 0-1 scale guard now applies only to that fallback path (the live score is 0-100 by construction).

Verified against prod data: S06325 (the reported panel) now scores **100.0** (3/3 required, all five artifacts pass); S01566/S06151/S06153 score 92–97 — honestly below the full-pass band because their latest walk-forward artifacts genuinely fail.

## Tests

New `tests/test_gauntlet_status_live_composite.py` (4 cases): live score preferred over the frozen stamp; stored fallback when the scorer has no artifacts; legacy scale guard on the fallback; fail-soft on scorer error. Existing scorer suites (`test_robustness_score_skips_nonresult_rows`, `test_robustness_score_backfills_plain_backtest_metrics`, `test_gauntlet_workflow_status`, `test_robustness_router`) exercise the refactored core — **39 passed**, ruff clean.

## Notes

Backend restart required to activate (stacks with #98/#99 already pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)