### PR TITLE
fix(dsr): freeze the deflated-Sharpe stamp at operator-owned stages (DSR-FREEZE-1)

### DIFF
--- a/forven/gauntlet/deflated_sharpe.py
+++ b/forven/gauntlet/deflated_sharpe.py
@@ -273,6 +273,35 @@ def compute_strategy_dsr(strategy_id: str, *, default_trials: int | None = None)
             except (TypeError, ValueError):
                 default_trials = 50
 
+        # DSR-FREEZE-1: an operator-owned (paper/live) strategy's DSR stamp is
+        # promotion EVIDENCE — the number capital was committed on. The
+        # write-through below used to re-score it on every status read off
+        # whatever the LATEST backtest row happened to be (a revalidation
+        # window, not the promotion sample), silently flipping a live
+        # strategy's headline statistic (S06325: 0.46 -> 0.01 while live,
+        # 2026-07-21) — an unstable input for anything weighing demotion
+        # evidence. Mirror the stored-metrics freeze: locked stages return
+        # the stored stamp and never recompute/overwrite.
+        with get_db() as conn:
+            strat = conn.execute(
+                "SELECT stage, status, deflated_sharpe, deflated_sharpe_at "
+                "FROM strategies WHERE id = ?",
+                (strategy_id,),
+            ).fetchone()
+        if strat is not None:
+            from forven.brain import stage_is_param_locked
+
+            if stage_is_param_locked(strat["stage"] or strat["status"]):
+                stored = strat["deflated_sharpe"]
+                if stored is None:
+                    return None
+                return {
+                    "dsr": float(stored),
+                    "frozen_stamp": True,
+                    "stamped_at": strat["deflated_sharpe_at"],
+                    "trials_source": "frozen_stamp",
+                }
+
         with get_db() as conn:
             bt = conn.execute(
                 """SELECT result_id FROM backtest_results

--- a/tests/test_dsr_freeze.py
+++ b/tests/test_dsr_freeze.py
@@ -1,0 +1,66 @@
+"""DSR-FREEZE-1: an operator-owned (paper/live) strategy's deflated-Sharpe stamp
+is promotion evidence and must never be recomputed or overwritten.
+
+compute_strategy_dsr()'s write-through snapshot used to re-score the stamp on
+every gauntlet-status read, off whatever the LATEST backtest row happened to be
+(a revalidation window, not the promotion sample) — S06325's DSR silently went
+0.46 -> 0.01 while live (2026-07-21). Locked stages now return the stored stamp;
+unlocked stages keep the compute + write-through behavior.
+"""
+
+from __future__ import annotations
+
+
+def _insert_strategy(strategy_id: str, *, stage: str, dsr, dsr_at: str | None) -> None:
+    from forven.db import get_db
+
+    with get_db() as conn:
+        conn.execute(
+            """INSERT INTO strategies (id, name, type, symbol, timeframe, params, stage, status,
+                                       deflated_sharpe, deflated_sharpe_at, created_at, updated_at)
+               VALUES (?, ?, 'rule_engine', 'ETH', '4h', '{}', ?, ?, ?, ?,
+                       '2026-07-01T00:00:00+00:00', '2026-07-01T00:00:00+00:00')""",
+            (strategy_id, strategy_id, stage, stage, dsr, dsr_at),
+        )
+
+
+def _stamp(strategy_id: str) -> tuple:
+    from forven.db import get_db
+
+    with get_db() as conn:
+        row = conn.execute(
+            "SELECT deflated_sharpe, deflated_sharpe_at FROM strategies WHERE id = ?",
+            (strategy_id,),
+        ).fetchone()
+    return (row["deflated_sharpe"], row["deflated_sharpe_at"])
+
+
+def test_locked_stage_returns_frozen_stamp_without_recompute(forven_db):
+    from forven.gauntlet.deflated_sharpe import compute_strategy_dsr
+
+    _insert_strategy("S99201", stage="live_graduated", dsr=0.46452, dsr_at="2026-07-07")
+    result = compute_strategy_dsr("S99201")
+    assert result is not None
+    assert result["dsr"] == 0.46452
+    assert result["frozen_stamp"] is True
+    assert result["stamped_at"] == "2026-07-07"
+    # The stamp itself is untouched — no write-through for locked stages.
+    assert _stamp("S99201") == (0.46452, "2026-07-07")
+
+
+def test_locked_stage_without_stamp_returns_none(forven_db):
+    from forven.gauntlet.deflated_sharpe import compute_strategy_dsr
+
+    _insert_strategy("S99202", stage="paper", dsr=None, dsr_at=None)
+    assert compute_strategy_dsr("S99202") is None
+    assert _stamp("S99202") == (None, None)  # and nothing was stamped
+
+
+def test_unlocked_stage_still_computes(forven_db):
+    from forven.gauntlet.deflated_sharpe import compute_strategy_dsr
+
+    # Gauntlet-stage strategies keep the live compute path. With no backtest
+    # artifacts the function returns None — the point is it did NOT take the
+    # frozen-stamp branch (which would have returned the stored 0.9).
+    _insert_strategy("S99203", stage="gauntlet", dsr=0.9, dsr_at="2026-07-01")
+    assert compute_strategy_dsr("S99203") is None


### PR DESCRIPTION
## What

`compute_strategy_dsr()` carries a "write-through snapshot" that re-scores the strategies-row `deflated_sharpe` on **every gauntlet-status page read**, using whatever the *latest* plain backtest row happens to be. For paper/live strategies that''s a revalidation window, not the promotion sample — so a live strategy''s headline statistic silently flipped on page view (S06325: **0.46452 → 0.00959 while live**, then re-stamped again minutes later on the next view). The stored-metrics JSON is already frozen at operator-owned stages for exactly this reason; the DSR column writer bypassed the freeze. Anything weighing demotion evidence off `deflated_sharpe` was reading an unstable, apples-to-oranges input.

## Fix

Locked stages (`brain.stage_is_param_locked` — the same predicate the metrics-sync freeze uses) now return the **stored stamp** from `compute_strategy_dsr` (`{dsr, frozen_stamp: true, stamped_at}`) and never recompute or write. Unlocked (gauntlet-era) stages keep the live compute + write-through unchanged, so the pre-promotion DSR gate in policy behaves exactly as before. Single chokepoint — both callers (status panel, promotion gate) are covered.

## State repair

S06325''s stamp restored to its promotion-era **0.46452** (provable from two direct DB reads earlier the same day, before the overwrite), dated 2026-07-07 per the DSR-hunt records — with an activity-log audit entry. S07689/S07678 were also re-stamped today but value-neutrally (same numbers); no repair needed. Caveat: until the next backend restart the RUNNING process still has the old write-through, so viewing S06325''s page before restarting can re-clobber the repair — re-verify after the bounce.

## Tests

`tests/test_dsr_freeze.py` (3 cases): frozen stamp returned + row untouched for locked stages; locked-without-stamp returns None without stamping; unlocked stages still compute. Plus gauntlet status suites — **21 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)