### PR TITLE
fix(health): provider-health tiles get a lifecycle (PROV-HEALTH-2)

### DIFF
--- a/forven/provider_runtime_health.py
+++ b/forven/provider_runtime_health.py
@@ -120,10 +120,68 @@ def record_call_failure(provider: str, error: BaseException) -> None:
     record_provider_event(p, kind, msg)
 
 
+# PROV-HEALTH-2: how long an entry for a DISCONNECTED provider stays visible
+# after its last event. A straggler call to a disconnected provider must stay
+# loud while it is actually happening (each attempt refreshes last_event_at);
+# once the calls stop, the tile retires.
+_DISCONNECTED_GRACE_SECONDS = 15 * 60
+
+
+def _connected_providers() -> set[str] | None:
+    """Providers connected in-app. ``None`` on any read error — fail OPEN:
+    better to keep showing every tile than to hide a real failure because the
+    config read broke.
+
+    Deliberately NOT "connected or referenced": the routing policy seeds a
+    default-model entry for every known provider and the enabled-models list
+    keeps free-tier rows around, so reference-based retention would keep every
+    tile forever. A disconnected provider cannot be spent on (the allowed-pairs
+    gate fails closed), so its health is only interesting while something is
+    still actively attempting it — which the recency grace covers.
+    """
+    try:
+        from forven.model_selection import list_connected_providers
+
+        return {str(p or "").strip().lower() for p in list_connected_providers() if p}
+    except Exception:  # pragma: no cover — never let a config read break the health view
+        return None
+
+
 def get_provider_health_runtime() -> list[dict]:
-    """All recorded per-provider runtime health entries (most-degraded first)."""
+    """Recorded per-provider runtime health entries (most-degraded first).
+
+    PROV-HEALTH-2: entries used to live forever — a provider the operator had
+    disconnected kept its last DOWN/degraded tile indefinitely ("why is
+    OpenRouter still appearing?"), with no expiry, no reconciliation against
+    the current configuration, and no dismiss. Entries for providers that are
+    no longer connected are now garbage-collected once their last event is
+    older than a grace window; a provider that is still being CALLED keeps
+    refreshing its last_event_at and stays visible (the fail-loud purpose of
+    this store), and connected providers always show their state.
+    """
+    store = _load()
+    connected = _connected_providers()
+    if connected is not None:
+        now = time.time()
+        keep: dict = {}
+        for name, entry in store.items():
+            provider = str(name or "").strip().lower()
+            last_event = entry.get("last_event_at") if isinstance(entry, dict) else None
+            try:
+                recent = (now - float(last_event)) <= _DISCONNECTED_GRACE_SECONDS
+            except (TypeError, ValueError):
+                recent = False
+            if provider in connected or recent:
+                keep[name] = entry
+        if len(keep) != len(store):
+            try:
+                kv_set(_KEY, keep)
+            except Exception:  # pragma: no cover — GC is best-effort
+                pass
+        store = keep
+
     order = {"down": 0, "degraded": 1, "ok": 2}
-    entries = list(_load().values())
+    entries = list(store.values())
     entries.sort(key=lambda e: order.get(str(e.get("state")), 3))
     return entries
 

--- a/forven/routers/agents.py
+++ b/forven/routers/agents.py
@@ -45,6 +45,20 @@ def get_agent_provider_health():
     return {"warnings": warnings, "count": len(warnings), "runtime": runtime}
 
 
+@router.post("/api/agents/provider-health/clear")
+def post_clear_provider_health(body: dict | None = None):
+    """Dismiss runtime provider-health entries (one provider, or all).
+
+    Covers the case auto-retirement (PROV-HEALTH-2) can't: a provider that is
+    still connected/referenced but idle, carrying an old degraded/down tile the
+    operator has already dealt with. A new event re-creates the tile."""
+    from forven.provider_runtime_health import clear_provider_health, get_provider_health_runtime
+
+    provider = str((body or {}).get("provider") or "").strip().lower() or None
+    clear_provider_health(provider)
+    return {"cleared": provider or "all", "runtime": get_provider_health_runtime()}
+
+
 @router.post("/api/agents/reconcile-providers")
 def post_reconcile_agent_providers():
     """Repoint credential-less agents to a configured provider (wizard/manual)."""

--- a/frontend/src/lib/api/forven.ts
+++ b/frontend/src/lib/api/forven.ts
@@ -1463,6 +1463,20 @@ export async function reconcileAgentProviders(): Promise<{
 	return fetchApi('/agents/reconcile-providers', { method: 'POST' });
 }
 
+/**
+ * Dismiss runtime provider-health entries — one provider, or all when omitted.
+ * Returns the refreshed runtime list. A new call event re-creates the tile.
+ */
+export async function clearProviderHealth(provider?: string): Promise<{
+	cleared: string;
+	runtime: ProviderRuntimeHealth[];
+}> {
+	return fetchApi('/agents/provider-health/clear', {
+		method: 'POST',
+		body: JSON.stringify(provider ? { provider } : {}),
+	});
+}
+
 export async function runSignalScanNow(): Promise<ManualScannerRunResponse> {
 	return fetchApi('/system/scanner/signal-run', { method: 'POST' });
 }

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -393,6 +393,7 @@ export {
 	getForvenModelPolicy,
 	updateForvenModelPolicy,
 	getProviderHealth,
+	clearProviderHealth,
 	updateForvenAgentModel,
 	getForvenBacktestingStatus,
 	getSystemStatus,

--- a/frontend/src/routes/agents/components/tabs/HealthTab.svelte
+++ b/frontend/src/routes/agents/components/tabs/HealthTab.svelte
@@ -12,6 +12,7 @@
 	 */
 	import { onDestroy, onMount } from 'svelte';
 	import {
+		clearProviderHealth,
 		getProviderHealth,
 		reconcileAgentProviders,
 		type ProviderRuntimeHealth,
@@ -38,6 +39,21 @@
 			error = e instanceof Error ? e.message : 'Failed to load provider health';
 		} finally {
 			loading = false;
+		}
+	}
+
+	let dismissing: string | null = null;
+
+	async function dismiss(provider: string) {
+		dismissing = provider;
+		try {
+			const res = await clearProviderHealth(provider);
+			runtime = res.runtime ?? [];
+			addToast(`Dismissed ${provider} health entry — a new call event re-creates it.`, 'success');
+		} catch (e) {
+			addToast(e instanceof Error ? e.message : 'Failed to dismiss entry', 'error');
+		} finally {
+			dismissing = null;
 		}
 	}
 
@@ -161,9 +177,25 @@
 						{#if r.fallback_to}
 							<p class="text-xs text-yellow-400">Falling back to <span class="font-mono">{r.fallback_to}</span></p>
 						{/if}
-						{#if r.since && formatSince(r.since)}
-							<p class="text-[10px] text-[#555]">since {formatSince(r.since)}</p>
-						{/if}
+						<div class="flex items-end justify-between gap-2">
+							<div class="text-[10px] text-[#555] space-y-0.5">
+								{#if r.since && formatSince(r.since)}
+									<p>since {formatSince(r.since)}</p>
+								{/if}
+								{#if r.last_event_at && formatSince(r.last_event_at)}
+									<p>last attempt {formatSince(r.last_event_at)}</p>
+								{/if}
+							</div>
+							<button
+								type="button"
+								on:click={() => dismiss(r.provider)}
+								disabled={dismissing === r.provider}
+								class="terminal-button text-[10px] px-2 py-0.5 disabled:opacity-60"
+								title="Remove this entry. A new call event re-creates it — dismissing never hides an active failure for long."
+							>
+								{dismissing === r.provider ? '…' : 'Dismiss'}
+							</button>
+						</div>
 					</div>
 				{/each}
 			</div>

--- a/tests/test_provider_health_lifecycle.py
+++ b/tests/test_provider_health_lifecycle.py
@@ -1,0 +1,100 @@
+"""PROV-HEALTH-2: runtime provider-health entries have a lifecycle.
+
+Entries used to live forever — a provider the operator had fully disconnected
+and de-referenced kept its last DOWN/degraded tile indefinitely ("I pointed all
+models to DeepSeek, so why is OpenRouter still appearing?"), with no expiry, no
+reconciliation against configuration, and no dismiss. Now: entries whose
+provider is no longer connected retire
+once their last event is older than a grace window; recent events keep a tile
+loud regardless (a straggler call to a disconnected provider must stay
+visible); config-read failures fail OPEN (show everything).
+"""
+
+from __future__ import annotations
+
+import time
+
+
+def _seed(provider: str, *, last_event_age_s: float, state: str = "down") -> None:
+    from forven.db import kv_get, kv_set
+
+    store = kv_get("forven:provider-health-runtime", {}) or {}
+    now = time.time()
+    store[provider] = {
+        "provider": provider,
+        "state": state,
+        "kind": "auth",
+        "message": "test",
+        "since": now - last_event_age_s,
+        "last_event_at": now - last_event_age_s,
+        "last_ok_at": None,
+    }
+    kv_set("forven:provider-health-runtime", store)
+
+
+def _providers() -> set[str]:
+    from forven.provider_runtime_health import get_provider_health_runtime
+
+    return {e["provider"] for e in get_provider_health_runtime()}
+
+
+def test_disconnected_stale_entry_is_retired(forven_db, monkeypatch):
+    import forven.provider_runtime_health as prh
+
+    _seed("openrouter", last_event_age_s=3600)  # old event, provider fully removed
+    monkeypatch.setattr(prh, "_connected_providers", lambda: {"minimax"})
+    assert "openrouter" not in _providers()
+    # And it was garbage-collected from the store, not just filtered.
+    from forven.db import kv_get
+
+    assert "openrouter" not in (kv_get("forven:provider-health-runtime", {}) or {})
+
+
+def test_disconnected_but_recent_entry_stays_loud(forven_db, monkeypatch):
+    import forven.provider_runtime_health as prh
+
+    _seed("openrouter", last_event_age_s=60)  # something called it a minute ago
+    monkeypatch.setattr(prh, "_connected_providers", lambda: {"minimax"})
+    assert "openrouter" in _providers()
+
+
+def test_connected_entry_is_kept_regardless_of_age(forven_db, monkeypatch):
+    import forven.provider_runtime_health as prh
+
+    _seed("minimax", last_event_age_s=7 * 86400, state="ok")
+    monkeypatch.setattr(prh, "_connected_providers", lambda: {"minimax"})
+    assert "minimax" in _providers()
+
+
+def test_config_read_failure_fails_open(forven_db, monkeypatch):
+    import forven.provider_runtime_health as prh
+
+    _seed("openrouter", last_event_age_s=3600)
+    monkeypatch.setattr(prh, "_connected_providers", lambda: None)  # read broke
+    assert "openrouter" in _providers()  # never hide entries on a config error
+
+
+def test_clear_endpoint_dismisses_one_provider(forven_db, monkeypatch):
+    import forven.provider_runtime_health as prh
+    from forven.routers.agents import post_clear_provider_health
+
+    _seed("openrouter", last_event_age_s=60)
+    _seed("minimax", last_event_age_s=60, state="ok")
+    monkeypatch.setattr(prh, "_connected_providers", lambda: {"minimax", "openrouter"})
+    res = post_clear_provider_health({"provider": "OpenRouter"})
+    assert res["cleared"] == "openrouter"
+    remaining = {e["provider"] for e in res["runtime"]}
+    assert "openrouter" not in remaining
+    assert "minimax" in remaining
+
+
+def test_clear_endpoint_dismisses_all(forven_db, monkeypatch):
+    import forven.provider_runtime_health as prh
+    from forven.routers.agents import post_clear_provider_health
+
+    _seed("openrouter", last_event_age_s=60)
+    _seed("gemini", last_event_age_s=60)
+    monkeypatch.setattr(prh, "_connected_providers", lambda: {"openrouter", "gemini"})
+    res = post_clear_provider_health(None)
+    assert res["cleared"] == "all"
+    assert res["runtime"] == []


### PR DESCRIPTION
## What

Runtime provider-health entries lived forever in KV — a provider the operator disconnected kept its last DOWN/degraded tile indefinitely, with no expiry, no reconciliation against configuration, and no dismiss. Reported by a user ("I pointed all models to DeepSeek, so why is OpenRouter still appearing?") and reproduced locally: disconnecting OpenRouter left its tile through Refresh and Reconcile providers (neither touches this store).

## Fix

**Lifecycle rule**: a tile stays only while its provider is **connected in-app**, or had a call event within a **15-minute grace window**. Deliberately *not* "connected or referenced" — decomposing a real instance showed the routing policy seeds a default-model entry for every known provider (all 16 appeared as "referenced") and the enabled-models list retains free-tier rows, so reference-based retention would keep every tile forever. A disconnected provider cannot be spent on anyway (`allowed_pairs` fails closed), and one that''s still being attempted keeps refreshing `last_event_at` and stays loud — the store''s fail-loud purpose is preserved. Retired entries are garbage-collected from the KV; config-read failures fail **open**.

**Plus**:
- `POST /api/agents/provider-health/clear` (optional `provider`) — dismiss, for the case auto-retirement can''t cover: a connected-but-idle provider carrying an already-handled stale tile. A new call event re-creates it.
- Health tab: per-tile **Dismiss** button + **"last attempt"** timestamp, so "failing right now" is visually distinct from "failed once, hours ago".

## Verification

- 6 new backend tests (`test_provider_health_lifecycle.py`): disconnected+stale retired and GC''d, disconnected+recent stays loud, connected kept regardless of age, config-read failure fails open, clear endpoint one/all — all green; ruff clean; `svelte-check` 0 errors.
- Ran against the real store: `openrouter` + `zai` (disconnected, quiet) retired; the six connected providers keep their genuine states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)