### PR TITLE
fix(gauntlet): drop fold-starving dated WFA windows at measured cadence (WFA-WINDOW-2)

### DIFF
--- a/forven/gauntlet/tasks.py
+++ b/forven/gauntlet/tasks.py
@@ -1565,6 +1565,13 @@ def _window_supports_wfa_folds(start: str, end: str, timeframe: str) -> bool:
     forwarding one smaller than the floor to the persisted FULL-HISTORY
     walk-forward can only ever error ('109 bars requested (need 420+)',
     S06895's fourth run, 2026-07-12)."""
+    span_bars = _window_span_bars(start, end, timeframe)
+    if span_bars is None:
+        return True  # unparseable window: let the runner decide
+    return span_bars >= 420
+
+
+def _window_span_bars(start: str, end: str, timeframe: str) -> int | None:
     from datetime import datetime
 
     from forven.api_core import _timeframe_to_minutes
@@ -1573,10 +1580,69 @@ def _window_supports_wfa_folds(start: str, end: str, timeframe: str) -> bool:
         s = datetime.fromisoformat(str(start).replace("Z", "+00:00"))
         e = datetime.fromisoformat(str(end).replace("Z", "+00:00"))
         minutes_per_bar = max(_timeframe_to_minutes(str(timeframe or "1h")), 1)
-        span_bars = (e - s).total_seconds() / 60.0 / minutes_per_bar
-        return span_bars >= 420
-    except Exception:  # noqa: BLE001 — unparseable window: let the runner decide
-        return True
+        return int((e - s).total_seconds() / 60.0 / minutes_per_bar)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _dated_wfa_window_issue(
+    strategy_id: str,
+    start: str,
+    end: str,
+    timeframe: str,
+    *,
+    n_splits: int,
+    train_ratio: float,
+) -> str | None:
+    """Reason the optimizer's dated validation window cannot judge WFA folds, or None.
+
+    Two structural floors (absence of evidence, never merit):
+      * the 420-bar fold floor — below it the runner hard-errors; and
+      * expected OOS trades per fold at the strategy's MEASURED cadence — a
+        window can clear 420 bars yet still hand a low-frequency strategy OOS
+        folds of 0–1 trades. S07680 (2026-07-19/20): ~118 days at 1h passed the
+        bar floor, but at ~2.5 trades/month its 5 × ~7-day OOS folds could never
+        reach wfa_min_fold_trades, so the verdict was FAIL by construction and
+        both operator revivals were re-archived by the same window. Trades per
+        fold, not bars, decide whether a fold is judgeable. Without a measured
+        trade rate the dated window is kept — the bar floor is the only
+        structural fact available (and the existing behavior).
+    """
+    if not _window_supports_wfa_folds(start, end, timeframe):
+        return "optimizer validation window too small for folds"
+    span_bars = _window_span_bars(start, end, timeframe)
+    if span_bars is None:
+        return None
+    try:
+        from forven.api_core import _timeframe_to_minutes
+        from forven.policy import load_pipeline_config
+        from forven.wfa_window import measured_trade_rate
+
+        rate_per_day, rate_source = measured_trade_rate(strategy_id, timeframe)
+        if not rate_per_day or rate_per_day <= 0:
+            # Never-measured cadence: the bar floor is the only structural fact
+            # available — keep the dated window rather than guess.
+            return None
+        rob = load_pipeline_config().get("robustness_thresholds", {})
+        min_fold_trades = int(rob.get("wfa_min_fold_trades", 5) or 5)
+        minutes_per_bar = max(_timeframe_to_minutes(str(timeframe or "1h")), 1)
+        window_days = span_bars * minutes_per_bar / (24.0 * 60.0)
+        oos_days_per_fold = window_days * (1.0 - train_ratio) / max(n_splits, 1)
+        expected_fold_trades = rate_per_day * oos_days_per_fold
+        if expected_fold_trades < min_fold_trades:
+            return (
+                f"optimizer validation window ({window_days:.0f} days) expects only "
+                f"~{expected_fold_trades:.1f} OOS trades per fold at the measured cadence "
+                f"(~{rate_per_day * 30.44:.1f}/mo, {rate_source}) — below "
+                f"wfa_min_fold_trades={min_fold_trades}, so folds cannot be judged"
+            )
+    except Exception as exc:  # noqa: BLE001 — sizing must never block the step
+        log.warning(
+            "walk_forward %s: trade-frequency window check failed (keeping dated window): %s",
+            strategy_id,
+            exc,
+        )
+    return None
 
 
 def run_walk_forward(workflow: dict[str, Any], step: dict[str, Any]) -> dict[str, Any]:
@@ -1587,21 +1653,28 @@ def run_walk_forward(workflow: dict[str, Any], step: dict[str, Any]) -> dict[str
     wf_cfg = settings.get("walk_forward") if isinstance(settings.get("walk_forward"), dict) else {}
     _selection_window, validation_window = _workflow_optimization_windows(workflow)
     tf = str(row.get("timeframe") or "1h")
+    n_splits = int(wf_cfg.get("n_folds") or 5)
+    train_ratio = float(wf_cfg.get("in_sample_pct") or 0.7)
     start_date = str(validation_window.get("start") or "").strip() or None
     end_date = str(validation_window.get("end") or "").strip() or None
-    if start_date and end_date and not _window_supports_wfa_folds(start_date, end_date, tf):
+    if start_date and end_date:
         # The persisted walk-forward is the FULL-HISTORY edge-existence test; the
         # anti-leak validation on the optimizer's holdout already ran inside the
         # optimizer itself. Fall back to the windowless trade-frequency-sized
         # window (the path every successful WFA has used) rather than submitting
-        # a window that structurally cannot produce the fold floor.
-        log.info(
-            "walk_forward %s: optimizer validation window too small for folds at %s — "
-            "running full-history windowless WFA instead",
-            row["id"], tf,
+        # a window that structurally cannot judge folds — too few bars OR too few
+        # expected trades per OOS fold at the strategy's measured cadence.
+        window_issue = _dated_wfa_window_issue(
+            str(row["id"]), start_date, end_date, tf,
+            n_splits=n_splits, train_ratio=train_ratio,
         )
-        start_date = None
-        end_date = None
+        if window_issue:
+            log.info(
+                "walk_forward %s: %s — running full-history windowless WFA instead",
+                row["id"], window_issue,
+            )
+            start_date = None
+            end_date = None
     try:
         from forven.routers.robustness import WalkForwardBody
 
@@ -1610,8 +1683,8 @@ def run_walk_forward(workflow: dict[str, Any], step: dict[str, Any]) -> dict[str
                 strategy_id=str(row["id"]),
                 symbol=str(row.get("symbol") or "BTC/USDT"),
                 timeframe=tf,
-                n_splits=int(wf_cfg.get("n_folds") or 5),
-                train_ratio=float(wf_cfg.get("in_sample_pct") or 0.7),
+                n_splits=n_splits,
+                train_ratio=train_ratio,
                 start_date=start_date,
                 end_date=end_date,
                 as_of=_workflow_as_of(workflow),

--- a/scripts/revive_wrongly_archived_2026_07_22.py
+++ b/scripts/revive_wrongly_archived_2026_07_22.py
@@ -1,0 +1,179 @@
+"""Revive the wrongly-archived strategies from the 2026-07-22 audit.
+
+Audit: outputs/archived-strategy-audit-2026-07-22.md. Four defect clusters
+archived strategies on structural (non-merit) failures:
+
+  1. Short-window workflow WFA (2026-07-18..20): the walk_forward step judged a
+     ~4-month optimizer holdout whose OOS folds could not contain
+     wfa_min_fold_trades at the strategy's measured cadence — verdict FAIL by
+     construction. Fixed by WFA-WINDOW-2 (PR #103); the fix MUST be deployed
+     (merged + backend restarted) before running this script, or the reset
+     workflows re-run walk_forward on the same starved window and the sweep
+     re-archives everything (proven live twice on S07680/81, 2026-07-20).
+  2. "Runtime unloadable in paper" wave (2026-07-07): PAPER-stage strategies
+     archived because their runtime class was not registered (orphan
+     runtime_type, fixed in PR #76-79 four days later). Never revived.
+  3. cost_stress ordering-violation loop: workflows stuck re-running
+     cost_stress against the ordering guard until the 2-day un-promotable
+     hygiene sweep archived them (S06895: 253 rejections).
+  4. tier2 "no runtime class registered" (2026-07-19/20): post-fix recurrence
+     of the registration-loss class.
+
+For each candidate this script:
+  * verifies the runtime class resolves TODAY (runtime_unloadable_reason —
+    the same check the paper runtime and pipeline_sweep use); skips otherwise;
+  * resets the latest current-version gauntlet workflow in place to ``pending``
+    (steps zeroed) — create_or_get_workflow reuses terminal workflows and the
+    self-heal backfill deliberately skips ``failed_gate`` ones, so without this
+    reset demote_failed_gate_strategies re-archives the strategy on its next
+    tick off the stale terminal workflow;
+  * transitions archived -> quick_screen via brain.transition_stage (the
+    sanctioned, event-logged path) so the gauntlet re-adjudicates from scratch
+    under the current engine. No force-promotion anywhere.
+
+Usage:
+  python scripts/revive_wrongly_archived_2026_07_22.py             # dry-run
+  python scripts/revive_wrongly_archived_2026_07_22.py --execute --backend-restarted
+  python scripts/revive_wrongly_archived_2026_07_22.py --all ...   # include weak-stat tail
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timezone
+
+# Cluster 1 — short-window WFA victims worth compute (audit table order).
+CLUSTER1 = [
+    "S07680", "S07681", "S07686", "S07674", "S07690", "S07707", "S07699", "S07676",
+]
+# Cluster 1 tail — archived in the same wave with weak/noisy stats; --all only.
+CLUSTER1_TAIL = [
+    "S07664", "S07673", "S07670", "S07677", "S07702", "S07703", "S07684",
+    "S07693", "S07698", "S07683", "S07695", "S07696", "S07675", "S07701",
+]
+# Cluster 3 — ordering-violation loop victims.
+CLUSTER3 = ["S06895", "S05904", "S06135"]
+# Cluster 4 — tier2 no-runtime-class notables (loadable as of 2026-07-22).
+CLUSTER4 = ["S06164", "S06155", "S07466", "S05074", "S07018"]
+# Individual: 1-fold WFA reject on the same window class (verify the lookahead
+# stamp with the tier2 probe before any paper promotion — audit note).
+INDIVIDUAL = ["S03524"]
+# Cluster 2 — runtime-unloadable paper wave, loadable subset with real stats.
+CLUSTER2 = [
+    "S04369", "S03517", "S03171", "S03523", "S03219", "S06023", "S03184",
+    "S03493", "S03151", "S03222", "S06030", "S03106", "S01598", "S05799",
+]
+# Cluster 2 tail — weak stats; --all only.
+CLUSTER2_TAIL = ["S05275", "S05276"]
+
+REASON = (
+    "Operator-approved revival (archived-strategy audit 2026-07-22, "
+    "outputs/archived-strategy-audit-2026-07-22.md): archived on a structural "
+    "non-merit failure ({cause}). Workflow reset for full re-adjudication under "
+    "the current engine with WFA-WINDOW-2 (PR #103) deployed."
+)
+CAUSES = {
+    **{sid: "short-window workflow WFA noise verdict, 2026-07-18..20 wave" for sid in CLUSTER1 + CLUSTER1_TAIL},
+    **{sid: "cost_stress ordering-violation loop -> un-promotable hygiene archive" for sid in CLUSTER3},
+    **{sid: "tier2 runtime-class registration loss" for sid in CLUSTER4},
+    **{sid: "1-fold WFA reject on a fold-starving window" for sid in INDIVIDUAL},
+    **{sid: "runtime unloadable in paper (orphan runtime_type, pre-PR #76-79)" for sid in CLUSTER2 + CLUSTER2_TAIL},
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--execute", action="store_true", help="apply changes (default: dry-run)")
+    parser.add_argument(
+        "--backend-restarted", action="store_true",
+        help="acknowledge the backend was restarted AFTER PR #103 merged (required with --execute)",
+    )
+    parser.add_argument("--all", action="store_true", help="include the weak-stat tail candidates")
+    parser.add_argument("--only", help="comma-separated strategy ids to restrict to")
+    args = parser.parse_args()
+
+    # The fix must exist in this checkout; the backend must run it too.
+    try:
+        from forven.gauntlet.tasks import _dated_wfa_window_issue  # noqa: F401
+    except ImportError:
+        print("REFUSING: forven.gauntlet.tasks._dated_wfa_window_issue not found — "
+              "this checkout predates WFA-WINDOW-2 (PR #103). Pull main first.")
+        return 2
+    if args.execute and not args.backend_restarted:
+        print("REFUSING: --execute requires --backend-restarted. The gauntlet sweep runs "
+              "inside the backend process; without the restarted fix it re-runs "
+              "walk_forward on the starved window and re-archives every revival "
+              "(proven on S07680/81, 2026-07-20).")
+        return 2
+
+    from forven.brain import transition_stage
+    from forven.db import get_db
+    from forven.gauntlet.engine import _reset_workflow_to_pending
+    from forven.gauntlet.store import WORKFLOW_DEFINITION_VERSION
+    from forven.strategies.registry import runtime_unloadable_reason
+
+    candidates = CLUSTER1 + CLUSTER3 + CLUSTER4 + INDIVIDUAL + CLUSTER2
+    if args.all:
+        candidates += CLUSTER1_TAIL + CLUSTER2_TAIL
+    if args.only:
+        wanted = {s.strip().upper() for s in args.only.split(",") if s.strip()}
+        candidates = [sid for sid in candidates if sid in wanted]
+
+    now = datetime.now(timezone.utc).isoformat()
+    revived, skipped = [], []
+    for sid in candidates:
+        with get_db() as conn:
+            row = conn.execute(
+                "SELECT id, display_id, stage, type, runtime_type FROM strategies WHERE id = ?",
+                (sid,),
+            ).fetchone()
+        if not row:
+            skipped.append((sid, "not found"))
+            continue
+        if str(row["stage"] or "").lower() not in {"archived", "rejected"}:
+            skipped.append((sid, f"already in stage {row['stage']} — leaving alone"))
+            continue
+        unloadable = runtime_unloadable_reason(row["type"], row["runtime_type"])
+        if unloadable:
+            skipped.append((sid, f"runtime still unloadable: {unloadable}"))
+            continue
+
+        with get_db() as conn:
+            wf = conn.execute(
+                """SELECT id, status FROM gauntlet_workflows
+                   WHERE strategy_id = ? AND definition_version = ?
+                   ORDER BY datetime(created_at) DESC LIMIT 1""",
+                (sid, WORKFLOW_DEFINITION_VERSION),
+            ).fetchone()
+
+        if args.execute:
+            # Reset the terminal workflow FIRST: demote_failed_gate_strategies keys
+            # off status='failed_gate', so flipping it to pending before the stage
+            # transition closes the re-archive race.
+            if wf:
+                with get_db() as conn:
+                    _reset_workflow_to_pending(
+                        conn, str(wf["id"]), now,
+                        reason=REASON.format(cause=CAUSES.get(sid, "audit 2026-07-22")),
+                    )
+            transition_stage(
+                sid, "quick_screen",
+                reason=REASON.format(cause=CAUSES.get(sid, "audit 2026-07-22")),
+                actor="ui",
+            )
+            revived.append(sid)
+            print(f"REVIVED {sid} ({row['display_id']}) — workflow "
+                  f"{wf['id'][:16] + ' reset' if wf else 'none (backfill will create one)'}")
+        else:
+            print(f"DRY-RUN would revive {sid} ({row['display_id']}, stage={row['stage']}, "
+                  f"wf={wf['status'] if wf else 'none'}) — {CAUSES.get(sid, '')}")
+            revived.append(sid)
+
+    print(f"\n{'revived' if args.execute else 'would revive'}: {len(revived)}  skipped: {len(skipped)}")
+    for sid, why in skipped:
+        print(f"  SKIP {sid}: {why}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_gauntlet_workflow_tasks.py
+++ b/tests/test_gauntlet_workflow_tasks.py
@@ -619,6 +619,83 @@ def test_run_walk_forward_drops_undersized_validation_window(forven_db, monkeypa
     assert captured.get("start") == big_window["start"]
 
 
+def test_run_walk_forward_drops_window_starving_folds_at_measured_cadence(forven_db, monkeypatch):
+    """A dated window can clear the 420-bar floor yet still be structurally
+    unjudgeable: S07680 (2026-07-19/20) got ~118 days at 1h — ~2830 bars — but at
+    its measured ~2.5 trades/month the 5 × ~7-day OOS folds could never reach
+    wfa_min_fold_trades, so walk_forward FAILed by construction and both operator
+    revivals were re-archived off the same window. When the measured cadence
+    predicts fewer than wfa_min_fold_trades OOS trades per fold, the dated window
+    must be dropped in favor of the windowless full-history path. Without a
+    measured rate the dated window is kept (covered by the test above)."""
+    from datetime import datetime, timedelta, timezone
+
+    from forven.db import get_db
+    from forven.gauntlet import tasks as gtasks
+
+    sid = "S-WFWIN2"
+    now = datetime.now(timezone.utc)
+    # Canonical metrics carry the measured cadence: 26 trades over ~3.6 months
+    # (S07680's combined IS+OOS figures) ≈ 0.24 trades/day.
+    metrics = (
+        '{"in_sample": {"total_trades": 17, "backtest_months": 2.5},'
+        ' "out_of_sample": {"total_trades": 9, "backtest_months": 1.1}}'
+    )
+    with get_db() as conn:
+        conn.execute(
+            "INSERT INTO strategies (id, name, type, symbol, timeframe, params, metrics, "
+            "status, owner, stage, stage_changed_at, created_at, updated_at) "
+            "VALUES (?, ?, 'rsi_momentum', 'SOL/USDT', '1h', '{}', ?, 'gauntlet', 'brain', "
+            "'gauntlet', ?, ?, ?)",
+            (sid, sid, metrics, now.isoformat(), now.isoformat(), now.isoformat()),
+        )
+        conn.commit()
+
+    captured: dict = {}
+
+    def _fake_run_wf(body):
+        captured["start"] = body.start_date
+        captured["end"] = body.end_date
+        return {
+            "verdict": "PASS",
+            "splits": [
+                {"out_of_sample": {"sharpe": 1.0, "total_trades": 12}} for _ in range(5)
+            ],
+            "aggregate_oos": {"sharpe": 0.9, "total_trades": 60},
+        }
+
+    monkeypatch.setattr(gtasks, "_run_walk_forward", _fake_run_wf)
+    # ~118 days at 1h ≈ 2830 bars — passes the 420-bar floor, but expected OOS
+    # trades per fold = 0.24/day * 118d * 0.3 / 5 ≈ 1.7 < wfa_min_fold_trades (5).
+    starved_window = {
+        "start": (now - timedelta(days=118)).isoformat(),
+        "end": now.isoformat(),
+    }
+    monkeypatch.setattr(
+        gtasks, "_workflow_optimization_windows", lambda _wf: ({}, starved_window)
+    )
+
+    workflow = {"id": "gw-test-wfwin2", "strategy_id": sid, "settings_snapshot_json": "{}"}
+    outcome = gtasks.run_walk_forward(workflow, {"step_key": "walk_forward"})
+
+    assert captured.get("start") is None and captured.get("end") is None, (
+        f"fold-starving window must be dropped, got {captured}"
+    )
+    assert outcome["status"] == "passed"
+
+    # The same cadence with a window long enough to feed the folds is kept:
+    # 0.24/day * 1500d * 0.3 / 5 ≈ 21 expected trades/fold >= 5.
+    roomy_window = {
+        "start": (now - timedelta(days=1500)).isoformat(),
+        "end": now.isoformat(),
+    }
+    monkeypatch.setattr(
+        gtasks, "_workflow_optimization_windows", lambda _wf: ({}, roomy_window)
+    )
+    gtasks.run_walk_forward(workflow, {"step_key": "walk_forward"})
+    assert captured.get("start") == roomy_window["start"]
+
+
 def test_confirmation_backfills_canonical_metrics_when_blob_lacks_trade_count(forven_db, monkeypatch):
     """When the strategy blob carries no performance metrics (the quick-screen
     gate deliberately skips persisting a degeneracy-skipped declared-TF slice),


### PR DESCRIPTION
## Problem

The gauntlet workflow's walk_forward step forwards the optimizer's validation window into the persisted full-history WFA, guarded only by the 420-bar fold floor (`_window_supports_wfa_folds`). A window can clear that floor and still be structurally unjudgeable for a low-frequency strategy.

**Evidence (2026-07-18..20 archive wave, ~20 strategies):** S07680 ran WFA on a ~118-day window at 1h (~2830 bars, passes the floor) with a measured cadence of ~2.3 trades/month. Its 5 × ~7-day OOS folds contained 0–1 trades each — below `wfa_min_fold_trades=5` — so the verdict was FAIL by construction and the fold-rescue path had zero evaluable folds. `gauntlet_sweep` archived it (DSR 0.953, composite 97.9). Both operator revivals (07-19 ADZ-0072, 07-20 post-zombie) were re-archived within minutes by a fresh run on the same window, while the operator-run **full-history WFA passes** (avg OOS Sharpe 1.52).

## Fix

In `run_walk_forward`, when a dated window is present and a **measured** trade rate exists (`measured_trade_rate`, own-timeframe rows first), estimate expected OOS trades per fold; if below `wfa_min_fold_trades`, drop the dates and use the windowless full-history path — the same fallback the bar floor already uses. Without a measured rate the dated window is kept (existing behavior, still locked by `test_run_walk_forward_drops_undersized_validation_window`).

This also makes the S00552 `wfa_window_insufficient` re-run promise ("re-run WFA on the trade-frequency-aware window") actually true when the gate re-queues walk_forward.

## Verification

- New test `test_run_walk_forward_drops_window_starving_folds_at_measured_cadence` reproduces the S07680 signature (118d window dropped; 1500d window at the same cadence kept).
- Simulated against the production DB: all 16 audited victims (S076xx fleet, S06164, S06895, S05904, S03524) show expected fold trades 0.2–3.8 < 5 → would run windowless; high-cadence strategies keep dated windows.
- `tests/test_gauntlet_workflow_tasks.py` + `tests/test_gauntlet_robustness_steps.py`: 29 passed.

Unblocks the revival of the wrongly-archived 07-18..20 cluster (see `outputs/archived-strategy-audit-2026-07-22.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)