### PR TITLE
Green the whole test suite, and gate CI on all of it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
   backend:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 40
 
     steps:
       - name: Check out repository
@@ -68,87 +68,21 @@ jobs:
       - name: Collect backend tests
         run: python -m pytest --collect-only -q
 
-      - name: Run backend release stability tests
-        run: |
-          python -m pytest -q \
-            tests/test_db_kv_bootstrap.py \
-            tests/test_bot_loop_resilience.py \
-            tests/test_bot_stale_recovery_loop.py \
-            tests/test_discord_owner_guard.py \
-            tests/test_notification_renderers.py \
-            tests/test_brain_router.py \
-            tests/test_lab_worker_service.py \
-            tests/test_url_ingest.py \
-            tests/test_url_ingest_research_enqueue.py \
-            tests/test_scheduler_background_jobs.py \
-            tests/test_gauntlet_legitimacy.py \
-            tests/test_robustness_router.py \
-            tests/test_pipeline_hardening.py::test_failed_walk_forward_verdict_is_fold_rescued_when_oos_folds_pass \
-            tests/test_pipeline_hardening.py::test_evaluate_promotion_accepts_persisted_validation_artifacts_for_paper \
-            tests/test_pipeline_hardening.py::test_evaluate_promotion_blocks_failed_required_verdict_tests_for_paper
-
-      - name: Run async runtime regression tests
-        run: |
-          python -m pytest -q \
-            tests/test_daemon_price_freshness.py \
-            tests/test_loop_starvation_fixes.py
-
-      # Real-money execution integrity: ambiguous/partial IOC responses must
-      # never release local exposure or remove the last protective order.
-      - name: Run capital-integrity regression tests
-        run: |
-          python -m pytest -q \
-            tests/test_execution_results.py \
-            tests/test_paper_control.py \
-            tests/test_open_trades_exchange_verification.py \
-            tests/test_live_entry_finalization.py \
-            tests/test_kill_switch_close_integrity.py \
-            tests/test_mtier_hardening.py \
-            tests/test_engine_audit_phase1.py
-
-      # Data-engine regression gate — locks in the 2026-07 data hardening + edge-data
-      # expansion (tail-append storage, perp canonicalization, causality shifts,
-      # quality gates, fingerprints, symbol registry, basis/IV streams, kernel
-      # intra-bar arbitration) AND the hub/legacy engine-on parity suite, which is the
-      # stated prerequisite for flipping data_engine.enabled. Network-free: the
-      # autobackfill/registry network paths are pytest-gated, everything runs on tmp
-      # lakes (~90s).
-      - name: Run data-engine regression tests
-        run: |
-          python -m pytest -q \
-            tests/test_data_hardening.py \
-            tests/test_data_remaining_phases.py \
-            tests/test_research_universe.py \
-            tests/test_edge_data_runs.py \
-            tests/test_data_manager.py \
-            tests/test_data_coverage.py \
-            tests/test_dataeng_foundation.py \
-            tests/test_enrichment_causality.py \
-            tests/test_enrich_backtest_frame.py \
-            tests/test_data_engine_p2_hardening.py \
-            tests/test_orderflow_lookahead.py \
-            tests/test_binance_vision.py \
-            tests/test_keepalive_staleness.py \
-            tests/test_ohlcv_keepalive_gate.py \
-            tests/test_data_root_unified.py
-
-      # Security regression gate — locks in the 2026-06 security-hardening work so a
-      # regression fails the PR. Fast (~10s), no sandbox-worker subprocess / heavy data
-      # deps, so it is safe on the CI runner. Covers: the AST guard (every confirmed
-      # bypass family stays blocked; the R3-de-allowlisted forven.scanner/data/
-      # data_manager/sentiment stay rejected; the indicator facade stays allowed), the
-      # strategy-worker DB jail, the custom-module intake guard, secret redaction, the
-      # SIZE-1 stop-floor, and the KCOPY-3 impure-strategy fail-closed.
-      - name: Run security regression tests
-        run: |
-          python -m pytest -q \
-            tests/test_sandbox_ast_guard.py \
-            tests/test_ast_guard_bypasses.py \
-            tests/test_strategy_worker_db_jail.py \
-            tests/test_registry_custom_module_guard.py \
-            tests/test_redact.py \
-            tests/test_sizing.py \
-            tests/test_per_bar_kernel_adapter.py
+      # The WHOLE suite gates now, not a hand-curated allowlist. It previously ran
+      # 44 of 546 files (810 of 5769 tests); the ungated 86% accumulated 69
+      # failures against deliberate product changes nobody was told about --
+      # including the only tests asserting that the kill switch fires, that the
+      # paper->live gate enforces its floors, and that the funding math is right.
+      # A curated list cannot notice the test it was never given.
+      #
+      # -n auto shards across the runner's cores (the suite is ~28m serial).
+      # --dist loadfile keeps each FILE on one worker: several suites share
+      # module-level state (the HyperLiquid SDK fixtures rebuild
+      # forven.exchange.hyperliquid), so splitting a file across workers is not
+      # safe yet. Order-independence is not something this suite has earned;
+      # revisit --dist load once it has.
+      - name: Run backend test suite
+        run: python -m pytest -q -n auto --dist loadfile
 
   frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements-ci.txt
+          # Install the package itself (deps already pinned above, hence --no-deps).
+          # Without this `forven` is importable only because pytest runs from the
+          # repo root -- a SUBPROCESS does not inherit that, so the sandbox
+          # (forven/sandbox) fails with "No module named 'forven'" and every test
+          # that executes strategy code through it dies. Only visible once the
+          # whole suite gates; the previous 44-file allowlist ran none of them.
+          python -m pip install -e . --no-deps
 
       - name: Run Ruff
         run: ruff check forven tests

--- a/forven/api.py
+++ b/forven/api.py
@@ -831,17 +831,19 @@ async def shutdown(request: Request):
 
 
 # Serve the prebuilt SvelteKit bundle at "/" when FORVEN_FRONTEND_DIR points to
-# a real directory. Mount is registered last so explicit API routes always win.
-# The status_router's bare "GET /" would otherwise shadow the SPA index, so we
-# remove it from app.routes before adding the mount.
+# a real directory. Mount is registered last so explicit API routes always win,
+# and html=True makes StaticFiles resolve SPA deep links to index.html.
+#
+# The bare "GET /" is NOT handled here. FastAPI keeps included routers as internal
+# `_IncludedRouter` wrappers instead of flattening their APIRoutes into
+# app.router.routes, so the filter that used to live here ("drop any route whose
+# path == '/'") matched nothing and left routers/status.py:root() shadowing the SPA
+# index — the packaged app served API JSON at "/". That route now serves index.html
+# itself when this env var is set; see routers/status.py.
 from fastapi.staticfiles import StaticFiles  # noqa: E402
 
 _frontend_dir = os.environ.get("FORVEN_FRONTEND_DIR")
 if _frontend_dir and os.path.isdir(_frontend_dir):
-    app.router.routes = [
-        r for r in app.router.routes
-        if not (getattr(r, "path", None) == "/" and "GET" in (getattr(r, "methods", None) or set()))
-    ]
     app.mount("/", StaticFiles(directory=_frontend_dir, html=True), name="frontend")
 
 

--- a/forven/routers/status.py
+++ b/forven/routers/status.py
@@ -1,4 +1,7 @@
+import os
+
 from fastapi import APIRouter
+from fastapi.responses import FileResponse
 
 from forven import api_core as core
 from forven.control_plane import status as control_plane_status
@@ -9,6 +12,21 @@ router = APIRouter(tags=["status"])
 
 @router.get("/")
 def root():
+    """Service info — or the SPA index when a prebuilt frontend is configured.
+
+    api.py mounts StaticFiles(html=True) at "/" for the packaged build, but a
+    mount is registered LAST and this route still wins: FastAPI keeps included
+    routers as internal `_IncludedRouter` wrappers rather than flattening them
+    into app.router.routes, so api.py's "drop any route whose path == '/'"
+    filter matches nothing and silently leaves this handler shadowing the SPA
+    index. Serving index.html here fixes that without reaching into FastAPI
+    internals; every other SPA asset and deep link still resolves via the mount.
+    """
+    frontend_dir = os.environ.get("FORVEN_FRONTEND_DIR")
+    if frontend_dir:
+        index_path = os.path.join(frontend_dir, "index.html")
+        if os.path.isfile(index_path):
+            return FileResponse(index_path)
     return control_plane_status.root()
 
 

--- a/forven/sandbox/__init__.py
+++ b/forven/sandbox/__init__.py
@@ -29,7 +29,14 @@ MAX_CPU_SECONDS = 30
 # sandbox path in this same package already runs with; it is still a hard cap.
 MAX_MEMORY_MB = 2048
 MAX_FILE_SIZE_MB = 10
-MAX_OPEN_FILES = 32
+# Applied on POSIX as RLIMIT_NOFILE. 32 descriptors cannot get through
+# `import pandas`: CPython's import machinery, numpy's several shared objects and
+# the BLAS/LAPACK libraries behind them open well over that before any strategy
+# code runs. Windows never applies this (the preexec is POSIX-only), which is why
+# the limit looked fine on the author's machine. This bounds descriptor
+# exhaustion, not capability — the meaningful confinement is the env allowlist,
+# the AST guard, and the filesystem/CPU caps.
+MAX_OPEN_FILES = 256
 MAX_ACTIVE_CHILD_PROCESSES = 4  # H-S4: limit fork-bomb / process-storm risk
 TIMEOUT_SECONDS = 60
 

--- a/forven/sandbox/__init__.py
+++ b/forven/sandbox/__init__.py
@@ -18,7 +18,16 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 # Resource limits (ulimit only applies to Linux)
 MAX_CPU_SECONDS = 30
-MAX_MEMORY_MB = 512
+# NOTE: on POSIX this is applied as RLIMIT_AS, which caps VIRTUAL ADDRESS SPACE,
+# not resident memory. numpy/pandas reserve far more address space than they ever
+# fault in (BLAS thread arenas, mmap'd allocator pools), so the previous 512 MB
+# made `import pandas` itself fail inside the sandbox on Linux — every self-heal
+# validation and manual-strategy registration was dead on that platform, and
+# every strategy starts with `import pandas as pd`. Windows was unaffected
+# (Job Object caps commit, not reserve), which is why it went unnoticed.
+# 2048 matches strategy_worker.PERSISTENT_MAX_MEMORY_MB, the value the sibling
+# sandbox path in this same package already runs with; it is still a hard cap.
+MAX_MEMORY_MB = 2048
 MAX_FILE_SIZE_MB = 10
 MAX_OPEN_FILES = 32
 MAX_ACTIVE_CHILD_PROCESSES = 4  # H-S4: limit fork-bomb / process-storm risk

--- a/forven/sandbox/__init__.py
+++ b/forven/sandbox/__init__.py
@@ -18,25 +18,9 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 # Resource limits (ulimit only applies to Linux)
 MAX_CPU_SECONDS = 30
-# NOTE: on POSIX this is applied as RLIMIT_AS, which caps VIRTUAL ADDRESS SPACE,
-# not resident memory. numpy/pandas reserve far more address space than they ever
-# fault in (BLAS thread arenas, mmap'd allocator pools), so the previous 512 MB
-# made `import pandas` itself fail inside the sandbox on Linux — every self-heal
-# validation and manual-strategy registration was dead on that platform, and
-# every strategy starts with `import pandas as pd`. Windows was unaffected
-# (Job Object caps commit, not reserve), which is why it went unnoticed.
-# 2048 matches strategy_worker.PERSISTENT_MAX_MEMORY_MB, the value the sibling
-# sandbox path in this same package already runs with; it is still a hard cap.
-MAX_MEMORY_MB = 2048
+MAX_MEMORY_MB = 512
 MAX_FILE_SIZE_MB = 10
-# Applied on POSIX as RLIMIT_NOFILE. 32 descriptors cannot get through
-# `import pandas`: CPython's import machinery, numpy's several shared objects and
-# the BLAS/LAPACK libraries behind them open well over that before any strategy
-# code runs. Windows never applies this (the preexec is POSIX-only), which is why
-# the limit looked fine on the author's machine. This bounds descriptor
-# exhaustion, not capability — the meaningful confinement is the env allowlist,
-# the AST guard, and the filesystem/CPU caps.
-MAX_OPEN_FILES = 256
+MAX_OPEN_FILES = 32
 MAX_ACTIVE_CHILD_PROCESSES = 4  # H-S4: limit fork-bomb / process-storm risk
 TIMEOUT_SECONDS = 60
 

--- a/forven/scheduler.py
+++ b/forven/scheduler.py
@@ -44,11 +44,15 @@ _DEFAULT_JOB_IDS = {
     "forven-regime-update",
     "forven-regime-gate-mtm",
     "forven-slippage-monitor",
-    # SEED-DRIFT-1: these two were seeded but missing from this allowlist, so
+    # SEED-DRIFT-1: these were seeded but missing from this allowlist, so
     # every reconcile_forven_jobs run silently DELETED them (the testnet harness
     # and exec-quality watchdog quietly stopped running until the next reseed).
+    # forven-live-graduation-scan (LIVE-LOOP-1) was a later instance of the same
+    # defect: seeded by seed_forven_jobs, reaped by the very next reconcile, so
+    # the paper->live recommender never stayed on its daily schedule.
     "forven-exec-quality-watchdog",
     "forven-testnet-harness",
+    "forven-live-graduation-scan",
     "forven-scanner-signal",
     "forven-scanner-hourly",
     "forven-recalibration",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
 
 [project.optional-dependencies]
 discord = ["discord.py>=2.3"]
-test = ["pytest>=8.0", "pytest-asyncio>=1.3,<2"]
+test = ["pytest>=8.0", "pytest-asyncio>=1.3,<2", "pytest-xdist>=3.6"]
 
 [project.scripts]
 forven = "forven.cli:cli"

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -21,6 +21,7 @@ pyarrow>=16.0.0
 PyJWT>=2.8
 pytest>=8.0
 pytest-asyncio>=1.3,<2
+pytest-xdist>=3.6
 python-multipart>=0.0.9
 PyYAML>=6.0
 requests>=2.31

--- a/tests/gauntlet_artifact_fixtures.py
+++ b/tests/gauntlet_artifact_fixtures.py
@@ -1,0 +1,146 @@
+"""Shared builders for PERSISTED gauntlet artifacts in gate tests.
+
+The live/paper gates no longer score a strategy's stored ``metrics`` blob in
+isolation: ``policy._strict_robustness_reject`` first calls
+``_extract_gauntlet_verdict_payloads`` and rejects outright with
+
+    "Live gate: robustness evidence unavailable (no usable gauntlet artifacts)"
+
+when no usable ``backtest_results`` validation rows exist. A fixture that only
+inserts a strategy row therefore never reaches the PF / overfitting / duration
+logic it means to exercise — every assertion fails on the evidence precondition
+instead.
+
+Rows must also survive two provenance filters and a legitimacy check:
+
+* ``engine_provenance.is_stale_engine_artifact`` — a row stamped with a
+  different ``engine_version`` contributes no payload.
+* ``data_provenance.is_stale_data_artifact`` — a row stamped with a different
+  data fingerprint contributes no payload.
+* ``gauntlet.legitimacy.validate_robustness_payload`` — per-type minimum
+  evidence (fold counts, simulation counts, jitter iterations + a pass rate,
+  cost-stress original/stressed metrics, >=2 regimes).
+
+IMPORTANT: the engine stamp is read from ``BACKTEST_ENGINE_VERSION`` at call
+time rather than hardcoded. The v2->v3->v4->v5 re-baselines silently rotted
+every fixture that pinned a literal, because the version bump stales artifacts
+by design but nothing staled the tests. Reading the constant keeps these
+fixtures correct across future bumps. The data fingerprint is deliberately left
+UNSTAMPED, which ``data_provenance`` grandfathers — these tests assert gate
+arithmetic, not data provenance (``test_data_provenance.py`` owns that).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+from forven.engine_provenance import BACKTEST_ENGINE_VERSION
+
+__all__ = [
+    "artifact_config_json",
+    "passing_payloads",
+    "insert_gauntlet_artifacts",
+]
+
+
+def artifact_config_json(**extra) -> str:
+    """A ``config_json`` blob stamped with the CURRENT engine version."""
+    config = {"engine_version": BACKTEST_ENGINE_VERSION}
+    config.update(extra)
+    return json.dumps(config)
+
+
+def passing_payloads() -> dict[str, dict]:
+    """Per-type ``metrics_json`` payloads that clear the strict live battery.
+
+    Values sit comfortably inside the Default-preset thresholds so a gate
+    rejection in a test always points at the knob under test rather than at the
+    scaffolding: WFA degradation 10% (limit 35%), 40 OOS trades (min 20), OOS
+    Sharpe 1.20 (floor 0.30), MC percentile 0.85 (min 0.65), cost-stressed
+    Sharpe 0.90 (min 0.30), 75% profitable regimes (min 50%).
+    """
+    return {
+        "walk_forward": {
+            "status": "succeeded",
+            "verdict": "PASS",
+            "n_folds": 5,
+            "splits": [{"oos_sharpe": 1.2, "oos_trades": 8} for _ in range(5)],
+            "degradation": 0.10,
+            "total_oos_trades": 40,
+            "avg_oos_sharpe": 1.20,
+        },
+        "monte_carlo": {
+            "status": "succeeded",
+            "verdict": "PASS",
+            "n_simulations": 1000,
+            "n_trades": 60,
+            "percentile_score": 0.85,
+        },
+        "param_jitter": {
+            "status": "succeeded",
+            "verdict": "PASS",
+            "n_iterations": 25,
+            "pass_rate": 0.80,
+        },
+        "cost_stress": {
+            "status": "succeeded",
+            "verdict": "PASS",
+            "original": {"sharpe_ratio": 1.30, "total_trades": 60},
+            "stressed": {"sharpe_ratio": 0.90, "total_trades": 60},
+            "degradation_pct": 30.0,
+            "stressed_sharpe": 0.90,
+        },
+        "regime_split": {
+            "status": "succeeded",
+            "verdict": "PASS",
+            "n_regimes": 4,
+            "regimes": [
+                {"regime": "uptrend", "profitable": True},
+                {"regime": "downtrend", "profitable": True},
+                {"regime": "chop", "profitable": True},
+                {"regime": "highvol", "profitable": False},
+            ],
+            "profitable_regime_pct": 0.75,
+        },
+    }
+
+
+def insert_gauntlet_artifacts(
+    conn,
+    strategy_id: str,
+    *,
+    symbol: str = "BTC/USDT",
+    timeframe: str = "1h",
+    overrides: dict[str, dict] | None = None,
+    created_at: str | None = None,
+) -> None:
+    """Persist one passing validation row per gauntlet test type.
+
+    ``overrides`` merges per-type keys into the default payloads so a test can
+    push a single dimension out of tolerance (e.g.
+    ``overrides={"walk_forward": {"degradation": 0.90}}``) while the rest of the
+    battery stays clean.
+    """
+    payloads = passing_payloads()
+    for test_type, extra in (overrides or {}).items():
+        payloads.setdefault(test_type, {}).update(extra)
+
+    stamp = created_at or (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+    config_json = artifact_config_json()
+    for test_type, payload in payloads.items():
+        conn.execute(
+            "INSERT INTO backtest_results (result_id, strategy_id, result_type, symbol, "
+            "timeframe, metrics_json, config_json, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                f"{strategy_id}-{test_type}",
+                strategy_id,
+                test_type,
+                symbol,
+                timeframe,
+                json.dumps(payload),
+                config_json,
+                stamp,
+            ),
+        )
+    conn.commit()

--- a/tests/hl_sdk_sandbox.py
+++ b/tests/hl_sdk_sandbox.py
@@ -1,0 +1,67 @@
+"""Swap in a fake ``hyperliquid`` SDK, reload the connector, restore everything.
+
+Several tests need ``forven.exchange.hyperliquid`` imported against a stand-in SDK
+(a deliberately broken ``Info``, a recording ``Exchange``, ...). Doing that by hand
+is a trap: the naive teardown
+
+    sys.modules.pop("forven.exchange.hyperliquid", None)
+
+restores nothing. Importing the connector under the fake SDK rebinds it as the
+``hyperliquid`` ATTRIBUTE of the ``forven.exchange`` package, and popping only the
+sys.modules entry leaves that attribute pointing at the throwaway module. Every
+later ``from forven.exchange import hyperliquid`` — and every monkeypatch aimed at
+it — then lands on the fake while the code under test imports the real one, so
+stubs silently do nothing.
+
+That is not hypothetical: it is why nine test_reconcile_sweep cases reported
+``skipped_exchange_unreachable`` (the sweep calling the REAL get_positions and
+failing) whenever they ran after one of these fixtures in the same process, and it
+went undiagnosed because both files pass in isolation.
+
+Use :func:`swapped_hyperliquid_sdk` instead — it restores BOTH bindings, and never
+reloads the genuine connector module (reloading swaps out every function object
+other modules captured at import time).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import sys
+
+__all__ = ["swapped_hyperliquid_sdk"]
+
+_CONNECTOR = "forven.exchange.hyperliquid"
+
+
+@contextlib.contextmanager
+def swapped_hyperliquid_sdk(fake_modules: dict[str, object]):
+    """Yield ``forven.exchange.hyperliquid`` imported against *fake_modules*.
+
+    ``fake_modules`` maps dotted SDK module names (``"hyperliquid"``,
+    ``"hyperliquid.utils.types"``, ...) to stand-in module objects. It must cover
+    every symbol the connector imports at module scope, or the import below dies
+    with ModuleNotFoundError before the test body runs.
+    """
+    import forven.exchange as exchange_pkg
+
+    names = tuple(fake_modules)
+    saved_sdk = {name: sys.modules.get(name) for name in names}
+    if _CONNECTOR not in sys.modules:
+        importlib.import_module(_CONNECTOR)
+    saved_connector = sys.modules[_CONNECTOR]
+
+    try:
+        sys.modules.update(fake_modules)
+        # Import a SEPARATE module object against the fake SDK; the saved one is
+        # never mutated, so teardown is a pure restore.
+        sys.modules.pop(_CONNECTOR, None)
+        yield importlib.import_module(_CONNECTOR)
+    finally:
+        for name, original in saved_sdk.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+        sys.modules[_CONNECTOR] = saved_connector
+        exchange_pkg.hyperliquid = saved_connector

--- a/tests/test_ai_dropzone_sessions.py
+++ b/tests/test_ai_dropzone_sessions.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import pathlib
 import sys
 
 from forven.ai_dropzone_sessions import (
@@ -120,38 +121,45 @@ def test_get_session_and_session_exists(forven_db):
     assert get_session("ADZ-9999") is None
 
 
-def test_register_custom_strategy_file_tags_session(forven_db, monkeypatch, tmp_path):
+def test_register_custom_strategy_file_tags_session(forven_db):
     sess = create_session(label="intake-session")
 
-    temp_custom_dir = tmp_path / "custom"
-    temp_custom_dir.mkdir()
-    strategy_file = temp_custom_dir / "btc_ai_dropzone_wave_test.py"
+    # register_custom_strategy_file validates in a sandbox SUBPROCESS that
+    # re-imports forven.strategies.custom from scratch, so a monkeypatched
+    # __path__ in this process is invisible to it. The module has to live in the
+    # real package dir for the call to resolve.
+    modname = "forven.strategies.custom.btc_ai_dropzone_wave_test"
+    real_custom_dir = pathlib.Path(custom_pkg.__file__).parent
+    strategy_file = real_custom_dir / "btc_ai_dropzone_wave_test.py"
     _write_custom_strategy(strategy_file)
-
-    monkeypatch.setattr(custom_pkg, "__path__", [str(temp_custom_dir)])
-    monkeypatch.setattr(custom_pkg, "__file__", str(temp_custom_dir / "__init__.py"))
 
     registry.reset()
     importlib.invalidate_caches()
-    sys.modules.pop("forven.strategies.custom.btc_ai_dropzone_wave_test", None)
+    sys.modules.pop(modname, None)
 
-    result = intake_mod.register_custom_strategy_file(
-        file_path=str(strategy_file), session_id=sess["id"]
-    )
+    try:
+        result = intake_mod.register_custom_strategy_file(
+            file_path=str(strategy_file), session_id=sess["id"]
+        )
 
-    assert result["session_id"] == sess["id"]
-    with get_db() as conn:
-        row = conn.execute(
-            "SELECT dropzone_session_id FROM strategies WHERE id = ?",
-            (result["strategy_id"],),
-        ).fetchone()
-    assert row is not None
-    assert str(row["dropzone_session_id"]) == sess["id"]
+        assert result["session_id"] == sess["id"]
+        with get_db() as conn:
+            row = conn.execute(
+                "SELECT dropzone_session_id FROM strategies WHERE id = ?",
+                (result["strategy_id"],),
+            ).fetchone()
+        assert row is not None
+        assert str(row["dropzone_session_id"]) == sess["id"]
 
-    detail = get_session_detail(sess["id"])
-    assert detail is not None
-    assert detail["strategy_count"] == 1
-    assert detail["strategies"][0]["id"] == result["strategy_id"]
+        detail = get_session_detail(sess["id"])
+        assert detail is not None
+        assert detail["strategy_count"] == 1
+        assert detail["strategies"][0]["id"] == result["strategy_id"]
+    finally:
+        strategy_file.unlink(missing_ok=True)
+        sys.modules.pop(modname, None)
+        registry.reset()
+        importlib.invalidate_caches()
 
 
 def test_register_custom_strategy_file_rejects_unknown_session(forven_db, monkeypatch, tmp_path):

--- a/tests/test_backtest_chart_context.py
+++ b/tests/test_backtest_chart_context.py
@@ -265,6 +265,11 @@ def test_chart_context_warns_when_local_ohlcv_is_missing(forven_db, _isolate_for
 
 	import forven.api_core as api_core
 
+	# create_strategy_container refuses a symbol that is in neither the data lake
+	# nor the symbol registry, and this test's whole point is that the 1h series is
+	# absent. Seed BTC at a DIFFERENT timeframe so the symbol is known to be a real
+	# market, while the 1h series the chart asks for stays genuinely missing.
+	_seed_local_candles(symbol="BTC", timeframe="4h")
 	strategy_id = _seed_strategy(strategy_type="macd", params={"fast": 12, "slow": 26, "signal": 9})
 	_insert_result_row(
 		result_id="missing-ohlcv",
@@ -320,9 +325,11 @@ def test_chart_context_fetches_remote_ohlcv_when_local_dataset_is_unreadable(for
 	import forven.api_core as api_core
 	import forven.data as data_mod
 
-	monkeypatch.setattr(data_mod, "pa", None)
-	monkeypatch.setattr(data_mod, "pq", None)
-
+	# NOTE: pyarrow is deliberately NOT disabled here. "Unreadable" in this test
+	# means a CORRUPT parquet file (the broken bytes below); the refetched frame
+	# still has to be written and read back through pyarrow, so nulling data_mod.pa
+	# / data_mod.pq would make the remote fetch unreadable too and yield 0 bars.
+	# The pyarrow-missing case is covered by the preceding test.
 	unreadable_path = data_mod.parquet_path("DOT/USDT", "1h")
 	unreadable_path.parent.mkdir(parents=True, exist_ok=True)
 	unreadable_path.write_bytes(b"PAR1broken-dot-data")

--- a/tests/test_backtest_risk_validation.py
+++ b/tests/test_backtest_risk_validation.py
@@ -1,4 +1,43 @@
+"""Unsupported risk-control params are reported, not silently honoured.
+
+These call the real backtest / walk-forward entry points, which load candles via
+``backtest.load_backtest_candles``. Left unstubbed that reads the local parquet
+lake and, when the lake is empty (a fresh clone, a CI runner), falls through to a
+live Binance fetch — which GitHub's runners get HTTP 451 on, because Binance
+geo-blocks them. These assertions are about parameter validation and have nothing
+to do with market data, so the loader is stubbed with a synthetic frame.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
 from forven.strategies.backtest import backtest_strategy, walk_forward
+
+
+def _fake_ohlcv(rows: int = 1000) -> pd.DataFrame:
+    idx = pd.date_range("2025-01-01", periods=rows, freq="1h", tz="UTC")
+    close = 100.0 + np.sin(np.arange(rows) / 9.0) * 8 + np.linspace(0, 20, rows)
+    return pd.DataFrame(
+        {
+            "open": close,
+            "high": close + 1.0,
+            "low": close - 1.0,
+            "close": close,
+            "volume": np.full(rows, 1000.0),
+        },
+        index=idx,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _offline_candles(monkeypatch):
+    monkeypatch.setattr(
+        "forven.strategies.backtest.load_backtest_candles",
+        lambda *_args, **_kwargs: _fake_ohlcv(1000),
+    )
 
 
 def test_backtest_strategy_rejects_unsupported_risk_controls(forven_db):

--- a/tests/test_brain_model_selection.py
+++ b/tests/test_brain_model_selection.py
@@ -26,11 +26,15 @@ def test_run_brain_task_uses_saved_brain_agent_selection_by_default(forven_db, m
 
     captured: dict[str, str] = {}
 
-    async def _fake_call_with_tools(provider, model, messages, context, tools=None):
+    # Mirrors agents.runner._call_with_tools: it also takes agent_id/trace/
+    # transcript and returns (text, usage). **kwargs keeps this stub from
+    # breaking the next time a keyword is threaded through the brain call.
+    async def _fake_call_with_tools(provider, model, messages, context, tools=None, **kwargs):
         captured["provider"] = provider
         captured["model"] = model
         captured["message"] = messages[-1]["content"]
-        return "ok"
+        captured["agent_id"] = kwargs.get("agent_id")
+        return "ok", {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
 
     monkeypatch.setattr("forven.context.build_brain_context", lambda *_: "ctx")
     monkeypatch.setattr("forven.brain._get_completed_agent_tasks", lambda: [])
@@ -67,10 +71,10 @@ def test_run_brain_task_respects_explicit_payload_override(forven_db, monkeypatc
 
     captured: dict[str, str] = {}
 
-    async def _fake_call_with_tools(provider, model, messages, context, tools=None):
+    async def _fake_call_with_tools(provider, model, messages, context, tools=None, **kwargs):
         captured["provider"] = provider
         captured["model"] = model
-        return "ok"
+        return "ok", {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
 
     monkeypatch.setattr("forven.context.build_brain_context", lambda *_: "ctx")
     monkeypatch.setattr("forven.brain._get_completed_agent_tasks", lambda: [])

--- a/tests/test_daemon_startup_recovery.py
+++ b/tests/test_daemon_startup_recovery.py
@@ -60,7 +60,11 @@ def test_startup_recovery_preflight_blocks_on_reconciliation_issues(monkeypatch)
     assert recovery["recovery_network"] == "testnet"
     assert "New entries remain blocked." in recovery["recovery_summary"]
     assert state["account_equity"] == 986.2
-    assert state["exchange_account"] == {
+    # Subset match, not exact equality: the snapshot carries a per-book breakdown
+    # ("books") alongside the aggregate, and pinning the whole dict makes every
+    # future additive field a failure in a test that is about recovery blocking.
+    account = state["exchange_account"]
+    for key, expected in {
         "accountValue": 986.2,
         "totalMarginUsed": 16.19,
         "totalNtlPos": 323.17,
@@ -68,7 +72,8 @@ def test_startup_recovery_preflight_blocks_on_reconciliation_issues(monkeypatch)
         "source": "exchange",
         "network": "testnet",
         "synced_at": state["account_equity_synced_at"],
-    }
+    }.items():
+        assert account[key] == expected, key
 
 
 def test_startup_recovery_preflight_skips_without_credentials_in_paper(monkeypatch):

--- a/tests/test_data_provenance.py
+++ b/tests/test_data_provenance.py
@@ -16,6 +16,7 @@ import pandas as pd
 import pytest
 
 import forven.data_provenance as dp
+from forven.engine_provenance import BACKTEST_ENGINE_VERSION
 
 
 @pytest.fixture()
@@ -102,7 +103,18 @@ def test_verdict_reader_refuses_stale_data_rows(forven_db, monkeypatch):
             (
                 "cs-stale",
                 json.dumps({"status": "succeeded", "verdict": "PASS", "degradation_pct": 5.0}),
-                json.dumps({"engine_version": 2, dp.DATA_FINGERPRINT_KEY: "oldsemantics"}),
+                # Stamp the CURRENT engine version, not a literal: this test isolates
+                # DATA provenance, so the row must not also be rejected as
+                # engine-stale. A hardcoded version silently turns this into a
+                # vacuous test on the next engine re-baseline (v2->v5 did exactly
+                # that — the negative assertion kept passing for the wrong reason
+                # while the positive one failed).
+                json.dumps(
+                    {
+                        "engine_version": BACKTEST_ENGINE_VERSION,
+                        dp.DATA_FINGERPRINT_KEY: "oldsemantics",
+                    }
+                ),
             ),
         )
 

--- a/tests/test_deepdive_session_tools.py
+++ b/tests/test_deepdive_session_tools.py
@@ -89,7 +89,13 @@ def test_max_rounds_emits_error(thread, monkeypatch):
             events.append(ev)
     asyncio.run(collect())
 
-    assert any(e["type"] == "error" and e.get("code") == "max_rounds" for e in events)
+    # CHAT-ROUNDS-1: exhausting the tool-round cap is a SOFT landing, not a dead
+    # turn. The session forces one final no-tools answer so the user gets a
+    # summary + "continue?" instead of an error event. The old max_rounds error is
+    # now only the fallback when that forced final itself fails.
+    assert not any(e.get("code") == "max_rounds" for e in events)
+    assert events[-1]["type"] == "done"
+    assert any(e["type"] == "assistant_token" and e["content"] for e in events)
 
 
 def test_dispatch_rejects_non_deepdive_tool(forven_db):

--- a/tests/test_duplicate_registration_guard.py
+++ b/tests/test_duplicate_registration_guard.py
@@ -65,9 +65,16 @@ def test_promotion_gate_blocks_duplicate_into_trading_stage(forven_db, monkeypat
     trading must be blocked from entering paper (this is exactly how S05275/S05276
     became doubled exposure)."""
     import forven.brain as brain
+    import forven.strategies.registry as registry
 
     monkeypatch.setattr(brain, "verify_backtest_exists_for_stage_transition",
                         lambda *a, **k: (True, ""))
+    # 'donchian_breakout' is only a REGISTERED runtime type on a machine carrying
+    # local (gitignored) custom strategy modules. On a clean checkout — CI, or any
+    # fresh clone — transition_stage's runtime-loadability gate fires first and the
+    # DUP-1 gate under test is never reached. Stub the loadability check so this
+    # test measures the duplicate guard rather than the operator's scratch dir.
+    monkeypatch.setattr(registry, "runtime_unloadable_reason", lambda *a, **k: None)
     with get_db() as conn:
         _create(conn, stage="paper")
         sid2, _, _ = _create(conn, stage="gauntlet")

--- a/tests/test_funding_strategy.py
+++ b/tests/test_funding_strategy.py
@@ -5,29 +5,71 @@ import pandas as pd
 from forven.strategies.builtin.funding import FundingStrategy
 
 
-def _sample_ohlcv(rows: int = 240) -> pd.DataFrame:
+def _sample_ohlcv(rows: int = 240, funding_rate: float | None = None) -> pd.DataFrame:
     idx = pd.date_range("2025-01-01", periods=rows, freq="h", tz="UTC")
     close = pd.Series([100.0 + i * 0.5 for i in range(rows)], index=idx)
     open_ = close.shift(1).fillna(close.iloc[0])
     high = pd.Series([max(o, c) + 0.2 for o, c in zip(open_, close)], index=idx)
     low = pd.Series([min(o, c) - 0.2 for o, c in zip(open_, close)], index=idx)
     volume = pd.Series([1000.0 + i for i in range(rows)], index=idx)
-    return pd.DataFrame(
+    frame = pd.DataFrame(
         {"open": open_, "high": high, "low": low, "close": close, "volume": volume},
         index=idx,
     )
+    if funding_rate is not None:
+        # The parent enriches this column; it is a PER-HOUR rate (HL is natively
+        # hourly, Binance 8h rates are divided by 8 — one convention across both).
+        frame["funding_rate"] = funding_rate
+    return frame
 
 
-def test_funding_strategy_uses_sentiment_funding_rates(monkeypatch):
-    monkeypatch.setattr(
-        "forven.strategies.sentiment.fetch_funding_rates",
-        lambda: {"BTC": {"funding": -0.0002, "openInterest": 1000.0}},
-    )
+def test_funding_strategy_reads_the_enriched_funding_rate_column():
+    """Deeply negative funding + price above the 200-EMA regime filter -> entry.
 
+    The strategy no longer imports forven.strategies.sentiment (that module is not
+    on the strategy-facing import allowlist); funding arrives as the enriched
+    ``funding_rate`` DataFrame column instead. A fixture that patches
+    sentiment.fetch_funding_rates therefore controls nothing — the column stays
+    absent and the strategy returns its neutral no-funding-data signal.
+    """
     strategy = FundingStrategy("S027-FUND-BTC", {"_asset": "BTC"})
-    signal = strategy.generate_signal(_sample_ohlcv())
+    # entry_threshold defaults to 0.00000375/hr; sit clearly below -threshold.
+    signal = strategy.generate_signal(_sample_ohlcv(funding_rate=-0.0002))
 
     assert signal.price > 0
     assert signal.entry_signal is True
     assert signal.exit_signal is False
     assert float(signal.indicators.get("funding")) == -0.0002
+    assert signal.indicators["regime_ok"] is True
+
+
+def test_funding_strategy_exits_when_funding_normalizes():
+    strategy = FundingStrategy("S027-FUND-BTC", {"_asset": "BTC"})
+    # Above -exit_threshold (0.00000125/hr): the mean-reversion edge is gone.
+    signal = strategy.generate_signal(_sample_ohlcv(funding_rate=0.00005))
+
+    assert signal.entry_signal is False
+    assert signal.exit_signal is True
+
+
+def test_funding_strategy_is_neutral_without_funding_data():
+    """No enriched column -> no funding signal at all (never a fabricated entry)."""
+    strategy = FundingStrategy("S027-FUND-BTC", {"_asset": "BTC"})
+    signal = strategy.generate_signal(_sample_ohlcv())
+
+    assert signal.entry_signal is False
+    assert signal.exit_signal is False
+    assert float(signal.indicators.get("funding")) == 0
+
+
+def test_funding_strategy_regime_filter_blocks_entry_below_the_ema():
+    """Negative funding alone is not enough — price must be above the 200-EMA."""
+    frame = _sample_ohlcv(funding_rate=-0.0002)
+    # Collapse the last close far below the EMA200 so regime_ok is False.
+    frame.loc[frame.index[-1], "close"] = 1.0
+
+    strategy = FundingStrategy("S027-FUND-BTC", {"_asset": "BTC"})
+    signal = strategy.generate_signal(frame)
+
+    assert signal.indicators["regime_ok"] is False
+    assert signal.entry_signal is False

--- a/tests/test_hyperliquid_exchange_bootstrap.py
+++ b/tests/test_hyperliquid_exchange_bootstrap.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import importlib
 import json
-import sys
 import types
 
 import pytest
+
+from tests.hl_sdk_sandbox import swapped_hyperliquid_sdk
 
 
 class _DummyHttpResponse:
@@ -83,20 +83,23 @@ def hl_exchange_module(monkeypatch):
     root.info = info_mod
     root.utils = utils_mod
 
-    monkeypatch.setitem(sys.modules, "hyperliquid", root)
-    monkeypatch.setitem(sys.modules, "hyperliquid.exchange", exchange_mod)
-    monkeypatch.setitem(sys.modules, "hyperliquid.info", info_mod)
-    monkeypatch.setitem(sys.modules, "hyperliquid.utils", utils_mod)
-    monkeypatch.setitem(sys.modules, "hyperliquid.utils.constants", constants_mod)
-    monkeypatch.setitem(sys.modules, "hyperliquid.utils.types", types_mod)
-
-    sys.modules.pop("forven.exchange.hyperliquid", None)
-    import forven.exchange.hyperliquid as hl
-
-    module = importlib.reload(hl)
-    module._exchange_calls = exchange_calls
-    yield module
-    sys.modules.pop("forven.exchange.hyperliquid", None)
+    # Restoration is delegated so BOTH bindings (sys.modules and the
+    # forven.exchange package attribute) go back. The previous teardown popped
+    # only sys.modules, leaving this fake-SDK module bound as
+    # forven.exchange.hyperliquid for the rest of the session — which is what made
+    # nine test_reconcile_sweep cases fail with "skipped_exchange_unreachable"
+    # whenever the full suite ran, while both files passed in isolation.
+    fake_sdk = {
+        "hyperliquid": root,
+        "hyperliquid.exchange": exchange_mod,
+        "hyperliquid.info": info_mod,
+        "hyperliquid.utils": utils_mod,
+        "hyperliquid.utils.constants": constants_mod,
+        "hyperliquid.utils.types": types_mod,
+    }
+    with swapped_hyperliquid_sdk(fake_sdk) as module:
+        module._exchange_calls = exchange_calls
+        yield module
 
 
 def test_get_exchange_retries_with_sanitized_spot_meta(hl_exchange_module, monkeypatch):

--- a/tests/test_hyperliquid_info_fallback.py
+++ b/tests/test_hyperliquid_info_fallback.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import importlib
 import json
-import sys
 import types
 
 import pytest
+
+from tests.hl_sdk_sandbox import swapped_hyperliquid_sdk
 
 
 class _DummyHttpResponse:
@@ -24,8 +24,25 @@ class _DummyHttpResponse:
         return json.dumps(self._payload).encode("utf-8")
 
 
-@pytest.fixture
-def hl_module(monkeypatch):
+_FAKE_SDK_MODULE_NAMES = (
+    "hyperliquid",
+    "hyperliquid.exchange",
+    "hyperliquid.info",
+    "hyperliquid.utils",
+    "hyperliquid.utils.constants",
+    "hyperliquid.utils.types",
+)
+
+
+def _build_fake_sdk() -> dict[str, types.ModuleType]:
+    """A stand-in `hyperliquid` SDK whose Info() bootstrap always blows up.
+
+    Must mirror EVERY symbol forven/exchange/hyperliquid.py imports at module
+    scope, or the reload below dies with ModuleNotFoundError before any test
+    body runs. `Cloid` (hyperliquid.utils.types) was added to the connector for
+    idempotent client order ids and is easy to miss here — if this fixture ever
+    errors at setup again, diff its imports against the connector's.
+    """
     root = types.ModuleType("hyperliquid")
     root.__path__ = []
 
@@ -49,27 +66,57 @@ def hl_module(monkeypatch):
     info_mod.Info = _BrokenInfo
 
     utils_mod = types.ModuleType("hyperliquid.utils")
+    utils_mod.__path__ = []
     constants_mod = types.ModuleType("hyperliquid.utils.constants")
     constants_mod.TESTNET_API_URL = "https://test.hyperliquid.local"
     constants_mod.MAINNET_API_URL = "https://main.hyperliquid.local"
-    utils_mod.constants = constants_mod
 
+    types_mod = types.ModuleType("hyperliquid.utils.types")
+
+    class _DummyCloid:
+        def __init__(self, raw: str):
+            self._raw = str(raw)
+
+        @classmethod
+        def from_str(cls, raw: str) -> "_DummyCloid":
+            return cls(raw)
+
+        def to_raw(self) -> str:
+            return self._raw
+
+        def __eq__(self, other) -> bool:
+            return isinstance(other, _DummyCloid) and other._raw == self._raw
+
+        def __repr__(self) -> str:  # pragma: no cover - debugging aid
+            return f"Cloid({self._raw!r})"
+
+    types_mod.Cloid = _DummyCloid
+
+    utils_mod.constants = constants_mod
+    utils_mod.types = types_mod
     root.exchange = exchange_mod
     root.info = info_mod
     root.utils = utils_mod
 
-    monkeypatch.setitem(sys.modules, "hyperliquid", root)
-    monkeypatch.setitem(sys.modules, "hyperliquid.exchange", exchange_mod)
-    monkeypatch.setitem(sys.modules, "hyperliquid.info", info_mod)
-    monkeypatch.setitem(sys.modules, "hyperliquid.utils", utils_mod)
-    monkeypatch.setitem(sys.modules, "hyperliquid.utils.constants", constants_mod)
+    return {
+        "hyperliquid": root,
+        "hyperliquid.exchange": exchange_mod,
+        "hyperliquid.info": info_mod,
+        "hyperliquid.utils": utils_mod,
+        "hyperliquid.utils.constants": constants_mod,
+        "hyperliquid.utils.types": types_mod,
+    }
 
-    sys.modules.pop("forven.exchange.hyperliquid", None)
-    import forven.exchange.hyperliquid as hl
 
-    module = importlib.reload(hl)
-    yield module
-    sys.modules.pop("forven.exchange.hyperliquid", None)
+@pytest.fixture
+def hl_module():
+    """The connector imported against a broken-SDK stand-in, fully restored after.
+
+    Restoration is delegated to swapped_hyperliquid_sdk because getting it wrong
+    is invisible here and fatal elsewhere — see that module's docstring.
+    """
+    with swapped_hyperliquid_sdk(_build_fake_sdk()) as module:
+        yield module
 
 
 def test_get_account_value_uses_direct_info_fallback_when_sdk_bootstrap_breaks(hl_module, monkeypatch):
@@ -119,18 +166,32 @@ def test_get_account_value_uses_direct_info_fallback_when_sdk_bootstrap_breaks(h
     assert account["withdrawable"] == 1002.68
 
 
-def test_build_info_client_logs_fallback_warning_once_per_process(hl_module, monkeypatch):
+def test_build_info_client_logs_fallback_notice_once_per_process(hl_module, monkeypatch):
     hl = hl_module
+    infos: list[str] = []
     warnings: list[str] = []
 
-    def _fake_warning(message, *args):
-        warnings.append(message % args if args else str(message))
+    def _record(sink):
+        def _log(message, *args):
+            sink.append(message % args if args else str(message))
 
-    monkeypatch.setattr(hl.log, "warning", _fake_warning)
+        return _log
+
+    monkeypatch.setattr(hl.log, "info", _record(infos))
+    monkeypatch.setattr(hl.log, "warning", _record(warnings))
 
     first = hl._build_info_client("https://test.hyperliquid.local")
     second = hl._build_info_client("https://test.hyperliquid.local")
 
     assert first is second
     assert first.__class__.__name__ == "_HyperliquidDirectInfoClient"
-    assert len(warnings) == 1
+
+    # The once-per-process contract: the SDK bootstrap failure is announced on
+    # the FIRST build and suppressed thereafter (_warn_once keys on the url).
+    fallback_notices = [m for m in infos if "direct /info fallback client" in m]
+    assert len(fallback_notices) == 1
+
+    # Deliberately INFO, not WARNING: the testnet spot-meta "list index out of
+    # range" quirk is transparently handled by the direct /info client, and
+    # logging it at WARNING made operators think a healthy exchange was broken.
+    assert warnings == []

--- a/tests/test_hypothesis_discipline_settings.py
+++ b/tests/test_hypothesis_discipline_settings.py
@@ -111,6 +111,10 @@ def test_block_missing_returns_all_defaults() -> None:
         # CRUX-1 allocator knobs.
         "crucible_daily_develop_budget": 150,
         "crucible_short_mode_quota_pct": 30,
+        "crucible_orthogonal_data_quota_pct": 40,
+        # SURV-QUOTA-1 instance-relative survivor-neighborhood quota.
+        "crucible_survivor_neighborhood_quota_pct": 25,
+        "survivor_neighborhood_family_cap_pct": 50,
     }
 
 

--- a/tests/test_hypothesis_graduation.py
+++ b/tests/test_hypothesis_graduation.py
@@ -37,7 +37,12 @@ def _make_strategy(
             type_="rsi",
             symbol=symbol,
             timeframe=timeframe,
-            params={},
+            # DUP-1 refuses creating a second strategy into a TRADING stage with
+            # identical type+symbol+timeframe+params (it would double exposure on
+            # every signal). These fixtures deliberately put two strategies in the
+            # same (symbol, timeframe) cell, so their params must differ — as two
+            # genuinely distinct candidates' would.
+            params={"rsi_period": 14 + sid_seed},
             stage=stage,
             hypothesis_id=hypothesis_id,
             strategy_id=f"S{50000 + sid_seed:05d}",

--- a/tests/test_hypothesis_loop_e2e_smoke.py
+++ b/tests/test_hypothesis_loop_e2e_smoke.py
@@ -51,7 +51,10 @@ def _attach_passing_child(hypothesis_id: str, *, sid_seed: int, symbol: str, sha
             type_="rsi",
             symbol=symbol,
             timeframe="1h",
-            params={},
+            # Distinct params per child: DUP-1 refuses a second strategy into a
+            # TRADING stage with identical type+symbol+timeframe+params, and these
+            # fixtures put multiple children in the same (symbol, timeframe) cell.
+            params={"rsi_period": 14 + sid_seed},
             stage="paper",
             hypothesis_id=hypothesis_id,
             strategy_id=f"S{60000 + sid_seed:05d}",

--- a/tests/test_hypothesis_verdict_writer.py
+++ b/tests/test_hypothesis_verdict_writer.py
@@ -22,11 +22,17 @@ def _seed_passing_children(hypothesis_id: str, n: int = 4) -> None:
         for i in range(n):
             sym, tf = cells[i % len(cells)]
             sid = f"S_VW_{i}"
+            # Stage must be one of hypothesis_verdict._PASSING_STAGES for the child
+            # to count toward the hit rate. 'gauntlet' is still IN FLIGHT, so a
+            # window of gauntlet children yields hit_rate 0.0 and a 'researching'
+            # mathematical floor — and since the LLM auditor can only DOWNGRADE
+            # that floor, a 'proven' LLM response gets clamped and the memo reads
+            # 'researching'. Seed the stage these children are supposed to model.
             conn.execute(
                 """INSERT INTO strategies (id, display_id, name, type, symbol, timeframe,
                    stage, status, hypothesis_id, owner, params, metrics, verdict,
                    created_at, updated_at)
-                   VALUES (?, ?, 'n', 'rsi', ?, ?, 'gauntlet', 'active', ?, 'brain',
+                   VALUES (?, ?, 'n', 'rsi', ?, ?, 'paper', 'active', ?, 'brain',
                            '{}', '{}', '{}', datetime('now'), datetime('now'))""",
                 (sid, sid, sym, tf, hypothesis_id),
             )
@@ -95,13 +101,31 @@ def test_write_verdict_memo_malformed_json_leaves_status(forven_db):
     assert n == 0
 
 
-def test_write_verdict_memo_llm_exception_leaves_status(forven_db):
+def test_write_verdict_memo_llm_exception_falls_back_to_mathematical_floor(forven_db):
+    """An LLM outage must not freeze the hypothesis pipeline OR invent a verdict.
+
+    The auditor only ever DOWNGRADES the deterministic floor, so when it is
+    unavailable the floor stands on its own. With no children the floor is
+    'researching', so the hypothesis is left exactly where it was — but the memo
+    records that the auditor was skipped rather than silently implying it ran.
+    """
     from forven.hypothesis_verdict import write_verdict_memo
     hyp = _hyp()
     with patch("forven.hypothesis_verdict._call_llm", side_effect=RuntimeError("rate limit")):
         result = write_verdict_memo(hyp["id"])
-    assert result["ok"] is False
-    assert result["error_code"] == "llm_call_failed"
+    assert result["ok"] is True
+    assert result["hypothesis"]["status"] == "researching"   # unchanged, not promoted
+
+    with get_db() as conn:
+        memo_row = conn.execute(
+            "SELECT payload FROM hypothesis_verdict_memos WHERE hypothesis_id = ? "
+            "ORDER BY rowid DESC LIMIT 1",
+            (hyp["id"],),
+        ).fetchone()
+    memo = json.loads(memo_row["payload"])
+    assert memo["llm_unavailable"] is True
+    assert memo["llm_verdict"] is None
+    assert "rate limit" in memo["llm_error"]
 
 
 def test_write_verdict_memo_missing_hypothesis_returns_error(forven_db):

--- a/tests/test_intake_ast_guard.py
+++ b/tests/test_intake_ast_guard.py
@@ -6,6 +6,7 @@ now lives in intake.register_custom_strategy_file, the shared chokepoint.
 from __future__ import annotations
 
 import importlib
+import pathlib
 import sys
 
 import pytest
@@ -70,20 +71,38 @@ def test_malicious_top_level_import_is_rejected_before_import(forven_db, monkeyp
     f.write_text(_MALICIOUS, encoding="utf-8")
     sys.modules.pop("forven.strategies.custom.btc_guard_evil_test", None)
 
-    with pytest.raises(ValueError) as exc:
+    # registry.assert_custom_module_safe raises ImportError (not ValueError) and
+    # intake does not wrap it. NOTE: routers/strategies.py catches only ValueError
+    # around this call, so via the HTTP ingress this surfaces as a 500 rather than
+    # a 400 carrying the security reason.
+    with pytest.raises(ImportError) as exc:
         intake_mod.register_custom_strategy_file(file_path=str(f))
     msg = str(exc.value).lower()
-    assert "security scan" in msg
-    # the module must NOT have been imported in-process
+    assert "ast security guard" in msg
+    assert "'os'" in msg and "'socket'" in msg      # names the offending imports
+    # The security property under test: NOT imported in-process.
     assert "forven.strategies.custom.btc_guard_evil_test" not in sys.modules
 
 
-def test_clean_strategy_still_registers(forven_db, monkeypatch, tmp_path):
-    d = _point_custom_dir(monkeypatch, tmp_path)
-    f = d / "btc_guard_ok_test.py"
+def test_clean_strategy_still_registers(forven_db):
+    # This path spawns the sandbox validator SUBPROCESS, which re-imports
+    # forven.strategies.custom from scratch — a monkeypatched __path__ in the
+    # parent is invisible to it ("No module named
+    # forven.strategies.custom.btc_guard_ok_test"). So the module has to live in
+    # the real package dir for the duration of the test.
+    real_dir = pathlib.Path(custom_pkg.__file__).parent
+    f = real_dir / "btc_guard_ok_test.py"
+    modname = "forven.strategies.custom.btc_guard_ok_test"
     f.write_text(_CLEAN, encoding="utf-8")
-    sys.modules.pop("forven.strategies.custom.btc_guard_ok_test", None)
-
-    result = intake_mod.register_custom_strategy_file(file_path=str(f))
-    assert result["strategy_id"]
-    assert result["module_name"] == "btc_guard_ok_test"
+    sys.modules.pop(modname, None)
+    registry.reset()
+    importlib.invalidate_caches()
+    try:
+        result = intake_mod.register_custom_strategy_file(file_path=str(f))
+        assert result["strategy_id"]
+        assert result["module_name"] == "btc_guard_ok_test"
+    finally:
+        f.unlink(missing_ok=True)
+        sys.modules.pop(modname, None)
+        registry.reset()
+        importlib.invalidate_caches()

--- a/tests/test_intake_timeframe.py
+++ b/tests/test_intake_timeframe.py
@@ -34,8 +34,20 @@ def test_absent_or_blank_falls_back_to_1h():
 def test_unsupported_or_typod_timeframe_falls_back_to_1h():
     # Unsupported / no-data intervals must NOT be stored verbatim -- they would
     # wedge the gauntlet on an "unsupported interval" error. They fall back to 1h.
-    for bad in ("3h", "2h", "12h", "1w", "60m", "weekly", "1H_typo"):
+    # The authority is market_data.INTERVAL_TO_MS (what the data layer can
+    # actually fetch), NOT a list hardcoded here — it has grown over time, and a
+    # frozen list would start failing legitimate intervals as the lake widens.
+    for bad in ("3h", "60m", "weekly", "1H_typo", "", "0h", "1y"):
         assert _intended_timeframe({"_timeframe": bad}) == "1h", bad
+
+
+def test_data_layer_supported_timeframes_are_stored_verbatim():
+    # The complement of the case above: anything the data layer CAN fetch must be
+    # preserved, or a 2h/12h edge silently gets quick-screened at 1h.
+    from forven.market_data import INTERVAL_TO_MS
+
+    for good in sorted(INTERVAL_TO_MS):
+        assert _intended_timeframe({"_timeframe": good}) == good, good
 
 
 def test_timeframe_is_normalized_lowercase_stripped():

--- a/tests/test_kernel_exit_ordering.py
+++ b/tests/test_kernel_exit_ordering.py
@@ -116,7 +116,15 @@ def test_kernel_net_pnl_subtracts_drag_exactly_once():
     assert len(res.closed_trades) == 1
     t = res.closed_trades[0]
     assert t["exit_reason"] == "signal"
-    assert t["pnl_pct"] == pytest.approx(0.097, abs=1e-9)  # 0.10 gross - 0.003 drag, drag applied ONCE
+    # Drag is charged ONCE, as two legs: half on the entry notional and half on
+    # the EXIT notional (ek._trade_drag scales the exit leg by exit/entry). At
+    # entry 100 -> exit 110 that is 0.003 * 0.5 * (1 + 1.10) = 0.00315, so net is
+    # 0.10 gross - 0.00315. Asserting the formula rather than a literal keeps
+    # this honest if the cost model is re-baselined again — a flat single-leg
+    # charge (the pre-v4 model) or a double-charge both still fail.
+    expected_drag = drag * 0.5 * (1.0 + 110.0 / 100.0)
+    assert expected_drag == pytest.approx(0.00315, abs=1e-12)
+    assert t["pnl_pct"] == pytest.approx(0.10 - expected_drag, abs=1e-9)
 
 
 def test_atr_entry_sizing_has_no_lookahead():
@@ -135,16 +143,38 @@ def test_atr_entry_sizing_has_no_lookahead():
         (107, 110, 105, 108),  # 8 — signal here → enter at bar 9 open
     ]
     normal_last = base + [(108, 109, 107, 108)]           # tame entry bar
-    wild_last = base + [(108, 250, 5, 108)]               # same OPEN, enormous range
+    wide_high = base + [(108, 250, 107, 108)]             # same OPEN, enormous UP range
+    wild_last = base + [(108, 250, 5, 108)]               # same OPEN, range pierces the stop
     sig = _long_signals(10, entries=[8], exits=[])
     ec = sizing.normalize_execution_controls(
         {"sizing_mode": "atr", "risk_per_trade": 0.02, "atr_stop_multiplier": 2.0}
     )
-    res_a = _simulate(_frame(normal_last), sig, ec)
-    res_b = _simulate(_frame(wild_last), sig, ec)
-    pos_a = res_a.open_positions["long"]
-    pos_b = res_b.open_positions["long"]
-    assert pos_a["entry_price"] == pos_b["entry_price"] == 108.0
-    # sizing + stop must be identical — they read the prior closed bar's ATR, not bar 9's.
-    assert pos_a["size_fraction"] == pos_b["size_fraction"]
-    assert pos_a["stop_price"] == pos_b["stop_price"]
+
+    def _entry_facts(res):
+        """Entry-time sizing facts, whether the position survived the bar or not.
+
+        A position that stops out INTRA-BAR is gone from open_positions by the
+        end of the run, so reading only open_positions conflates "sizing changed"
+        with "the bar happened to touch the stop". The stop of a closed-at-stop
+        trade is its exit_price.
+        """
+        pos = res.open_positions.get("long")
+        if pos is not None:
+            return pos["entry_price"], pos["size_fraction"], pos["stop_price"]
+        trade = res.closed_trades[0]
+        assert trade["exit_reason"] == "stop_loss"
+        return trade["entry_price"], trade["size_fraction"], trade["exit_price"]
+
+    entry_a, size_a, stop_a = _entry_facts(_simulate(_frame(normal_last), sig, ec))
+    entry_b, size_b, stop_b = _entry_facts(_simulate(_frame(wide_high), sig, ec))
+    entry_c, size_c, stop_c = _entry_facts(_simulate(_frame(wild_last), sig, ec))
+
+    assert entry_a == entry_b == entry_c == 108.0
+    # Sizing + stop read the prior CLOSED bar's ATR, never bar 9's own high/low.
+    # A 250-high leaves the position open; a 5-low pierces the stop and closes it
+    # intra-bar — but in both cases the entry decision must be byte-identical to
+    # the tame bar, because none of that was knowable at the open.
+    assert size_a == size_b
+    assert stop_a == stop_b
+    assert size_c == pytest.approx(size_a, rel=1e-3)  # closed rows round size_fraction
+    assert stop_c == pytest.approx(stop_a, abs=1e-9)

--- a/tests/test_kernel_late_entry.py
+++ b/tests/test_kernel_late_entry.py
@@ -24,13 +24,31 @@ import pytest
 
 import forven.scanner as sc
 from forven.db import get_db
-from forven.strategies.execution_kernel import KernelResult
+from forven.strategies.execution_kernel import KernelResult, _trade_drag, round_trip_drag
 from forven.strategies.paper_reconcile import ReconcileAction, reconcile
 
 CUTOFF = "2026-06-26 16:00:00+00:00"
 WINDOW = "2026-05-01 00:00:00+00:00"
 STALE_ENTRY = "2026-06-01 04:00:00+00:00"   # ~25 days before the cutoff
 STRAT = {"asset": "ETH", "params": {"execution_profile": {"risk_per_trade": 0.01}}}
+
+# Default paper cost assumptions these fixtures run under: 4.5bps fee + 2.0bps
+# slippage per leg at 1x leverage.
+FEE_BPS = 4.5
+SLIPPAGE_BPS = 2.0
+
+
+def _expected_price_leg(entry: float, exit_price: float, size_fraction: float, *, leverage: float = 1.0) -> float:
+    """Net (post-cost) equity-fraction PnL for a SHORT leg, kernel-exact.
+
+    Costs are NOT a flat round-trip rate: ``execution_kernel._trade_drag`` charges
+    half on the entry notional and half on the EXIT notional, so the drag depends
+    on where the trade closed. Restating a flat ``2*(fee+slip)`` here is what
+    silently rotted these expectations across the v4 cost re-baseline — deriving
+    from the kernel's own helper keeps them pinned to the real model.
+    """
+    drag = _trade_drag(round_trip_drag(FEE_BPS, SLIPPAGE_BPS, leverage), entry, exit_price)
+    return ((entry - exit_price) / entry * leverage - drag) * size_fraction
 
 
 def _kr(open_pos=None, closed=None):
@@ -131,8 +149,7 @@ def test_fill_now_close_recomputes_equity_fraction_pnl_and_flags_it(forven_db):
         out = dict(c.execute(
             "SELECT status, pnl_pct, net_pnl_pct, closed_at, signal_data FROM trades WHERE id=?",
             (tid,)).fetchone())
-    drag = 2.0 * (4.5 + 2.0) / 10000.0 * 1.0
-    expected_eq = ((1590.0 - 1500.0) / 1590.0 - drag) * 0.5          # net, scaled by size_fraction
+    expected_eq = _expected_price_leg(1590.0, 1500.0, 0.5)          # net, scaled by size_fraction
     assert out["status"] == "CLOSED"
     assert out["closed_at"] == "2026-06-27T16:00:00+00:00"           # kernel exit-bar time
     assert out["pnl_pct"] == pytest.approx(expected_eq, rel=0.02)    # from OUR entry, equity-fraction
@@ -215,8 +232,7 @@ def test_fill_now_close_charges_funding_over_actual_holding_window(forven_db):
     )
     with get_db() as c:
         out = dict(c.execute("SELECT pnl_pct, signal_data FROM trades WHERE id=?", (tid,)).fetchone())
-    drag = 2.0 * (4.5 + 2.0) / 10000.0 * 1.0
-    price_leg = ((1590.0 - 1550.0) / 1590.0 - drag) * 0.5
+    price_leg = _expected_price_leg(1590.0, 1550.0, 0.5)
     expected_funding = 0.02 * 1.0 * 1.0 * 0.5  # funding_sum(0.01+0.01) * hours(1h) * lev(1) * size_fraction(0.5)
     assert out["pnl_pct"] == pytest.approx(price_leg + expected_funding, rel=1e-4)
     sd = json.loads(out["signal_data"])
@@ -241,8 +257,7 @@ def test_fill_now_close_funding_gated_by_setting(forven_db, monkeypatch):
     )
     with get_db() as c:
         out = dict(c.execute("SELECT pnl_pct, signal_data FROM trades WHERE id=?", (tid,)).fetchone())
-    drag = 2.0 * (4.5 + 2.0) / 10000.0 * 1.0
-    price_leg = ((1590.0 - 1550.0) / 1590.0 - drag) * 0.5
+    price_leg = _expected_price_leg(1590.0, 1550.0, 0.5)
     assert out["pnl_pct"] == pytest.approx(price_leg, rel=1e-4)
     assert json.loads(out["signal_data"])["funding_cost_pct"] == 0.0
 
@@ -333,8 +348,7 @@ def test_monitor_price_exit_also_charges_funding(forven_db):
         out = dict(c.execute(
             "SELECT pnl_pct, fill_exit_price, signal_data FROM trades WHERE id=?", (tid,)).fetchone())
     stop_price = _expected_short_stop(1590.0)
-    drag = 2.0 * (4.5 + 2.0) / 10000.0 * 1.0
-    price_leg = ((1590.0 - stop_price) / 1590.0 - drag) * 0.5
+    price_leg = _expected_price_leg(1590.0, stop_price, 0.5)
     # The intrabar breach closes at the 14:00 bar's CLOSE (15:00), so the funding window
     # [12:00, 15:00) covers the 12:00, 13:00 AND 14:00 bars (0.03 total funding rate) —
     # the position really was held through the breach bar's funding hour.
@@ -543,8 +557,7 @@ def test_fill_now_close_uses_current_mark_for_signal_exit(forven_db):
         out = dict(c.execute(
             "SELECT status, pnl_pct, closed_at, fill_exit_price, signal_data FROM trades WHERE id=?",
             (tid,)).fetchone())
-    drag = 2.0 * (4.5 + 2.0) / 10000.0 * 1.0
-    expected_eq = ((1590.0 - 1550.0) / 1590.0 - drag) * 0.5
+    expected_eq = _expected_price_leg(1590.0, 1550.0, 0.5)
     assert out["status"] == "CLOSED"
     assert out["closed_at"] == "2026-06-27T12:05:00+00:00"            # current time, NOT kernel's 16:00
     assert out["fill_exit_price"] == pytest.approx(1550.0)            # current mark, NOT kernel's 1500

--- a/tests/test_launch_hardening_gates.py
+++ b/tests/test_launch_hardening_gates.py
@@ -19,6 +19,7 @@ from forven.policy import (
     _evaluate_quick_screen_gate,
     load_pipeline_config,
 )
+from tests.gauntlet_artifact_fixtures import insert_gauntlet_artifacts
 
 
 def _insert_strategy(conn, sid, *, metrics=None, stage="paper_trading", stage_changed_at="DEFAULT"):
@@ -34,16 +35,26 @@ def _insert_strategy(conn, sid, *, metrics=None, stage="paper_trading", stage_ch
         ),
     )
     conn.commit()
+    # A paper-stage strategy reached that stage through the gauntlet, so it has
+    # persisted validation artifacts. Without them the paper->live gate short-
+    # circuits on "robustness evidence unavailable" and never reaches the
+    # forward-edge floors these tests assert.
+    if stage == "paper_trading":
+        insert_gauntlet_artifacts(conn, sid)
 
 
 def _insert_paper_trades(conn, sid, pnls):
     base = datetime.now(timezone.utc) - timedelta(days=20)
+    # policy._PARITY_PNL_FILTER only counts rows whose signal_data marks pnl_pct
+    # as a NET equity fraction (the shared-kernel parity contract); unmarked rows
+    # are excluded from every gate sample.
+    signal_data = json.dumps({"pnl_is_equity_fraction": 1})
     for i, pnl in enumerate(pnls):
         conn.execute(
             "INSERT INTO trades (id, strategy_id, strategy, asset, direction, status, pnl_pct, "
-            "execution_type, closed_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "execution_type, closed_at, signal_data) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (f"t-{sid}-{i}", sid, sid, "BTC/USDT", "long", "CLOSED", pnl, "paper",
-             (base + timedelta(hours=i)).isoformat()),
+             (base + timedelta(hours=i)).isoformat(), signal_data),
         )
     conn.commit()
 

--- a/tests/test_manual_backtest_api_wiring.py
+++ b/tests/test_manual_backtest_api_wiring.py
@@ -7,6 +7,31 @@ engine, and fee/slippage/window/capital were lost.
 """
 from __future__ import annotations
 
+import sys as _sys
+
+import pytest as _pytest
+
+# KNOWN DEFECT (Linux): forven/sandbox run_code cannot `import pandas` inside its
+# subprocess on Linux -- and every strategy begins with that import, so self-heal
+# validation and manual-strategy registration are dead on that platform. This is a
+# PRODUCT bug, not a test bug, and it predates the whole-suite CI gate; it only
+# became visible when these tests started running in CI at all.
+#
+# Not yet diagnosed. Raising the POSIX rlimits (RLIMIT_AS 512MB -> 2048,
+# RLIMIT_NOFILE 32 -> 256) did NOT fix it, so those changes were reverted rather
+# than left as unverified weakening of a security boundary. The real error stays
+# hidden because selfheal truncates captured stderr (200 chars in the log, 1000 in
+# the payload) and the failure is cut off mid-traceback inside pandas/__init__.
+# Diagnosing it needs a Linux box and the untruncated stderr.
+#
+# Skipped rather than deleted: the assertions are correct and do pass on Windows,
+# and a visible skip keeps the defect on the record instead of silently green.
+_SANDBOX_BROKEN_ON_POSIX = _pytest.mark.skipif(
+    _sys.platform != "win32",
+    reason="forven.sandbox run_code cannot import pandas on Linux - known undiagnosed product defect",
+)
+
+
 import pytest
 
 from forven import api_core as core
@@ -256,6 +281,7 @@ def test_send_to_forge_rejects_bad_mode(forven_db):
         core.send_manual_strategy_to_forge(core.SendToForgeBody(mode="bogus", spec=_FORGE_SPEC))
 
 
+@_SANDBOX_BROKEN_ON_POSIX
 def test_manual_strategy_registers_and_exposes_arbitrary_params():
     import os
     custom_dir = os.path.join(os.path.dirname(core.__file__), "strategies", "custom")

--- a/tests/test_manual_backtest_execution_controls.py
+++ b/tests/test_manual_backtest_execution_controls.py
@@ -253,6 +253,54 @@ def test_atr_sizing_bounded_and_stops_fire():
 
 
 def test_kelly_sizing_bounded():
+    """f* = W - (1-W)/R, scaled by kelly_multiplier, must stay inside [0, 1].
+
+    Asserted against the sizing helper directly rather than through a backtest:
+    see test_kelly_mode_opens_nothing_through_the_kernel below for why an
+    end-to-end kelly run currently yields no trades to inspect.
+    """
+    from forven.strategies import sizing
+
+    ec = sizing.normalize_execution_controls(
+        {"sizing_mode": "kelly", "kelly_multiplier": 0.5, "kelly_lookback": 20}
+    )
+    histories = [
+        [],                                   # no evidence
+        [0.1, 0.2, 0.3],                      # wins only -> no loss to price risk
+        [-0.1, -0.2],                         # losses only
+        [0.1, -0.05, 0.08, -0.04],            # mixed, favourable
+        [0.01, -0.9, 0.02, -0.8],             # mixed, badly unfavourable
+        [5.0, -0.0001],                       # extreme payoff ratio
+        [0.0, 0.0, 0.0],                      # all flat
+    ]
+    for history in histories:
+        fraction = sizing.size_fraction(
+            ec, None, leverage=1.0, initial_capital=10000.0, closed_gross=history
+        )
+        assert 0.0 <= fraction <= 1.0, (history, fraction)
+
+    # Sanity: the helper is actually live, not trivially returning 0 everywhere.
+    assert sizing.size_fraction(
+        ec, None, leverage=1.0, initial_capital=10000.0,
+        closed_gross=[0.1, -0.05, 0.08, -0.04],
+    ) > 0.0
+
+
+def test_kelly_mode_opens_nothing_through_the_kernel():
+    """CHARACTERIZATION — documents a live defect, not desired behavior.
+
+    kelly_fraction() returns 0 until its window holds at least one win AND one
+    loss ("don't bet on no evidence"). The legacy backtest loop still OPENED the
+    zero-size trade, so _finalize recorded its gross return and the next trade had
+    evidence to size on. The shared execution kernel instead SKIPS any entry with
+    size_fraction <= 0 (execution_kernel.py, "if size_fraction <= 0.0: continue"),
+    and _run_directional_signal_series now routes everything through that kernel —
+    so evidence never accumulates, the fraction never leaves 0, and kelly mode
+    opens no positions at all, forever.
+
+    If this test starts failing, the deadlock was fixed: replace it with real
+    end-to-end bound assertions over the resulting trades.
+    """
     closes = []
     for _ in range(8):
         closes += list(np.linspace(100, 90, 15)) + list(np.linspace(90, 106, 15))
@@ -262,9 +310,18 @@ def test_kelly_sizing_bounded():
         df, sig, warmup=0, leverage=1.0, fee_bps=0.0, slippage_bps=0.0,
         execution_controls={"sizing_mode": "kelly", "kelly_multiplier": 0.5, "kelly_lookback": 20},
     )
-    assert trades
-    for t in trades:
-        assert 0.0 <= t["size_fraction"] <= 1.0
+    assert trades == []
+
+    # The same signals size and trade normally under a mode that doesn't need
+    # prior evidence — proving the emptiness above is kelly's bootstrap, not a
+    # broken fixture.
+    full_trades = bt._run_directional_signal_series(
+        df, sig, warmup=0, leverage=1.0, fee_bps=0.0, slippage_bps=0.0,
+        execution_controls={"sizing_mode": "full"},
+    )
+    assert full_trades
+    for trade in full_trades:
+        assert 0.0 < trade["size_fraction"] <= 1.0
 
 
 def test_fixed_sizing_scales_pnl():

--- a/tests/test_mark_watcher_exit_timing.py
+++ b/tests/test_mark_watcher_exit_timing.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 import forven.mark_watcher as mw
 import forven.scanner as sc
 from forven.db import get_db
+from forven.strategies.execution_kernel import _trade_drag, round_trip_drag
 
 
 def _open_paper_trade(
@@ -108,8 +109,13 @@ def test_mark_fill_close_stamps_touch_moment_and_recomputes_pnl(forven_db):
     assert out["status"] == "CLOSED"
     assert out["closed_at"] == "2026-07-02T10:45:12+00:00"  # the touch, not a bar edge
     assert abs(float(out["exit_price"]) - 81.345) < 1e-9  # filled AT the level
-    # Entry-based NET recompute, kernel convention: price return minus round-trip drag.
-    expected = (81.345 - 74.0) / 74.0 - 2.0 * (4.5 + 2.0) / 10000.0
+    # Entry-based NET recompute, kernel convention: price return minus drag. The
+    # drag is two-legged (half on the entry notional, half on the EXIT notional),
+    # so it must come from the kernel's own helper — a flat 2*(fee+slip) is the
+    # pre-v4 model and is off by ~6.5e-5 here.
+    expected = (81.345 - 74.0) / 74.0 - _trade_drag(
+        round_trip_drag(4.5, 2.0, 1.0), 74.0, 81.345
+    )
     assert abs(float(out["pnl_pct"]) - expected) < 1e-6
 
 

--- a/tests/test_market_data_source.py
+++ b/tests/test_market_data_source.py
@@ -65,13 +65,27 @@ def test_fetch_binance_prices_keyed_by_bare_coin(monkeypatch):
     assert all(isinstance(v, float) for v in prices.values())
 
 
+def _patch_candle_exchange(monkeypatch, rows):
+    """Pin the OHLCV source for fetch_binance_candles.
+
+    It resolves its client through resolve_binance_market (perp-canonical: the
+    USD-M futures client when the base has a listed perp, else spot), so patching
+    _binance_exchange alone no longer intercepts it — the futures client is used
+    for BTC and the fake never gets called, yielding an empty frame.
+    """
+    fake = _FakeExchange(rows)
+    monkeypatch.setattr(md, "_binance_exchange", lambda: fake)
+    monkeypatch.setattr(md, "resolve_binance_market", lambda coin: (fake, "BTC/USDT", "spot"))
+    return fake
+
+
 def test_fetch_binance_candles_drops_unclosed_bar(monkeypatch):
     interval_ms = 3_600_000
     end = 10 * interval_ms  # fixed reference so the test is deterministic
     # bars at open times 0..10; the bar opening at `end` (10*interval) is still
     # forming (closes at 11*interval > end) and must be dropped.
     rows = [[i * interval_ms, 1.0 + i, 2.0 + i, 0.5 + i, 1.5 + i, 10 + i] for i in range(0, 11)]
-    monkeypatch.setattr(md, "_binance_exchange", lambda: _FakeExchange(rows))
+    _patch_candle_exchange(monkeypatch, rows)
     df = md.fetch_binance_candles("BTC", bars=5, interval="1h", end_time=end)
     assert list(df.columns) == ["open", "high", "low", "close", "volume"]
     assert len(df) == 5  # tail(5)
@@ -88,7 +102,7 @@ def test_fetch_binance_candles_include_unclosed_keeps_forming_bar(monkeypatch):
     interval_ms = 3_600_000
     end = 10 * interval_ms
     rows = [[i * interval_ms, 1.0 + i, 2.0 + i, 0.5 + i, 1.5 + i, 10 + i] for i in range(0, 11)]
-    monkeypatch.setattr(md, "_binance_exchange", lambda: _FakeExchange(rows))
+    _patch_candle_exchange(monkeypatch, rows)
     closed = md.fetch_binance_candles("BTC", bars=20, interval="1h", end_time=end)
     live = md.fetch_binance_candles("BTC", bars=20, interval="1h", end_time=end, include_unclosed=True)
     assert int(closed.index[-1].value // 1_000_000) == 9 * interval_ms   # forming bar dropped

--- a/tests/test_oauth_ux_rework.py
+++ b/tests/test_oauth_ux_rework.py
@@ -88,16 +88,32 @@ def test_callback_listener_notifies_callback_side_effect():
         listener.shutdown()
 
 
+def _free_port() -> int:
+    """A port nobody is using, chosen by the OS.
+
+    These tests used to hardcode 1455. On Linux a just-closed listener leaves the
+    port in TIME_WAIT, so a plain bind() to the same number fails with
+    EADDRINUSE (errno 98) — Windows is more forgiving, which is why it only ever
+    broke in CI. Asking the kernel for a fresh port per test removes both the
+    TIME_WAIT race and any collision with whatever else the runner has open.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])
+
+
 def test_callback_listener_shutdown_releases_port():
     from forven.auth.callback_listener import LoopbackCallbackListener
 
-    listener = LoopbackCallbackListener(port=1455, ttl_seconds=10)
+    port = _free_port()
+    listener = LoopbackCallbackListener(port=port, ttl_seconds=10)
     listener.start()
     listener.shutdown()
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     try:
-        sock.bind(("127.0.0.1", 1455))
+        sock.bind(("127.0.0.1", port))
     finally:
         sock.close()
 
@@ -105,11 +121,16 @@ def test_callback_listener_shutdown_releases_port():
 def test_callback_listener_bind_failure_signaled():
     from forven.auth.callback_listener import LoopbackCallbackListener
 
+    port = _free_port()
     blocker = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    blocker.bind(("127.0.0.1", 1455))
+    # Deliberately NO SO_REUSEADDR here: the blocker must hold the port
+    # EXCLUSIVELY so the listener's bind genuinely fails. On Windows
+    # SO_REUSEADDR behaves like SO_REUSEPORT and would let the listener bind the
+    # same port anyway, making this assert vacuous.
+    blocker.bind(("127.0.0.1", port))
     blocker.listen(1)
     try:
-        listener = LoopbackCallbackListener(port=1455, ttl_seconds=2)
+        listener = LoopbackCallbackListener(port=port, ttl_seconds=2)
         ok = listener.start()
         assert ok is False
         assert listener.bind_error is not None

--- a/tests/test_paper_chart_bundle.py
+++ b/tests/test_paper_chart_bundle.py
@@ -139,7 +139,16 @@ def test_short_only_strategy_emits_full_history_triggers():
     only strategy produced ZERO trades → NO trigger triangles (the 'no triangles on the
     chart' bug). The trade mode must be resolved from the strategy."""
     import numpy as np
-    from forven.strategies.custom.ETH_emabreakatrshort_s157270 import STRATEGY_CLASS
+
+    # forven/strategies/custom/ is gitignored user scratch: this module exists only
+    # on a machine that authored it, so a clean checkout (CI, a fresh clone) cannot
+    # import it. Skip rather than fail — the regression is real, but it can only be
+    # exercised where the strategy file is present.
+    custom = pytest.importorskip(
+        "forven.strategies.custom.ETH_emabreakatrshort_s157270",
+        reason="local custom strategy module not present in this checkout",
+    )
+    STRATEGY_CLASS = custom.STRATEGY_CLASS
 
     n = 600
     idx = pd.date_range("2026-05-01", periods=n, freq="1h", tz="UTC")

--- a/tests/test_policy_gate_floor_wiring.py
+++ b/tests/test_policy_gate_floor_wiring.py
@@ -31,9 +31,18 @@ from forven.policy import (
     load_pipeline_config,
     save_pipeline_config,
 )
+from tests.gauntlet_artifact_fixtures import insert_gauntlet_artifacts
 
 
-def _insert_strategy(conn, sid, *, metrics=None, stage="paper_trading", stage_changed_at="DEFAULT"):
+def _insert_strategy(
+    conn,
+    sid,
+    *,
+    metrics=None,
+    stage="paper_trading",
+    stage_changed_at="DEFAULT",
+    with_artifacts=None,
+):
     if stage_changed_at == "DEFAULT":
         stage_changed_at = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
     conn.execute(
@@ -50,16 +59,41 @@ def _insert_strategy(conn, sid, *, metrics=None, stage="paper_trading", stage_ch
         ),
     )
     conn.commit()
+    # A strategy sitting in paper_trading reached that stage THROUGH the gauntlet,
+    # so it has persisted validation artifacts. The paper->live gate now requires
+    # them (_strict_robustness_reject rejects with "robustness evidence
+    # unavailable" before any PF/overfitting arithmetic runs), so a fixture
+    # without them asserts nothing about the knob under test.
+    if with_artifacts is None:
+        with_artifacts = stage == "paper_trading"
+    if with_artifacts:
+        insert_gauntlet_artifacts(conn, sid)
 
 
 def _insert_paper_trades(conn, sid, pnls):
     base = datetime.now(timezone.utc) - timedelta(days=20)
+    # policy._PARITY_PNL_FILTER only counts rows whose signal_data marks pnl_pct as
+    # a NET equity fraction — the shared-kernel parity contract. Rows without the
+    # marker are legacy margin-fraction numbers and are excluded from every gate
+    # sample, so an unmarked fixture reads as "0/10 closed trades".
+    signal_data = json.dumps({"pnl_is_equity_fraction": 1})
     for i, pnl in enumerate(pnls):
         closed_at = (base + timedelta(hours=i)).isoformat()
         conn.execute(
             "INSERT INTO trades (id, strategy_id, strategy, asset, direction, status, pnl_pct, "
-            "execution_type, closed_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            (f"t-{sid}-{i}", sid, sid, "BTC/USDT", "long", "CLOSED", pnl, "paper", closed_at),
+            "execution_type, closed_at, signal_data) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                f"t-{sid}-{i}",
+                sid,
+                sid,
+                "BTC/USDT",
+                "long",
+                "CLOSED",
+                pnl,
+                "paper",
+                closed_at,
+                signal_data,
+            ),
         )
     conn.commit()
 
@@ -386,6 +420,8 @@ def test_check_paper_trades_window_falls_back_to_created_at(forven_db):
             )
         conn.commit()
 
-    ok, detail = policy._check_paper_trades("p-window-fallback")
+    # _check_paper_trades returns (ok, detail, extra) — `extra` is the progress
+    # payload the readiness UI renders (current/threshold/direction/unit).
+    ok, detail, _extra = policy._check_paper_trades("p-window-fallback")
     assert not ok
-    assert detail.startswith("Insufficient paper trades: 0/")
+    assert str(detail).startswith("Insufficient paper trades: 0/")

--- a/tests/test_portfolio_allocator.py
+++ b/tests/test_portfolio_allocator.py
@@ -230,9 +230,15 @@ def _mock_live_open_path(monkeypatch, scanner, calls):
 def _live_open(scanner):
     from forven.strategies.paper_reconcile import ReconcileAction
 
+    # stop_price is deliberately TIGHT (0.5% away). LIVE-CLAMP-1 caps live entries
+    # at 2% of equity ($200 here) of loss-at-stop; a 3-point stop would clamp
+    # 100 units -> 66.67 and 200 units -> 66.67, so both allocator assertions below
+    # would be measuring the clamp instead of the allocation multiplier. At $0.50
+    # of risk per unit even the fully-scaled 200-unit case risks $100 and stays
+    # under the cap, leaving the multiplier as the only thing moving the size.
     action = ReconcileAction(
         "open", "long", "2024-01-01T00:00:00+00:00",
-        position={"entry_price": 100.0, "size_fraction": 0.5, "stop_price": 97.0,
+        position={"entry_price": 100.0, "size_fraction": 0.5, "stop_price": 99.5,
                   "target_price": 105.0, "entry_bar": 10},
     )
     return scanner._kernel_open_live_trade(

--- a/tests/test_research_context.py
+++ b/tests/test_research_context.py
@@ -180,7 +180,10 @@ def test_run_agent_task_uses_research_context_for_research_tasks(forven_db, monk
         calls.append(("research", contract.lane, list(contract.available_datasets)))
         return "research-context"
 
-    async def _fake_call_with_tools(provider, model_id, messages, system, tools=None):
+    # **kwargs absorbs agent_id/trace/transcript — the real _call_with_tools takes
+    # them, and a stub with a frozen signature turns a passing test into a
+    # swallowed TypeError that surfaces only as a missing "response" key.
+    async def _fake_call_with_tools(provider, model_id, messages, system, tools=None, **kwargs):
         calls.append(("call", system))
         return ("done", {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2})
 

--- a/tests/test_research_contract.py
+++ b/tests/test_research_contract.py
@@ -75,6 +75,7 @@ def test_exploration_contract_keeps_constraint_memory_and_optional_inspiration()
     assert contract.allowed_external_source_types == [
         "reddit",
         "youtube",
+        "podcast",
         "blog",
         "github",
         "forum",

--- a/tests/test_research_contract_sources_block.py
+++ b/tests/test_research_contract_sources_block.py
@@ -1,9 +1,9 @@
 from forven.research_contract import get_research_sources_block, default_research_settings
 
 
-def test_defaults_contain_all_four_sources():
+def test_defaults_contain_every_gated_source():
     block = default_research_settings()["research_sources"]
-    assert set(block.keys()) == {"reddit", "blog", "github", "forum"}
+    assert set(block.keys()) == {"reddit", "blog", "podcast", "github", "forum"}
     # Enabled by default — matches youtube, which has no per-source gate.
     # Operators can still disable individual sources via the Research Settings UI.
     assert all(block[k]["enabled"] is True for k in block)

--- a/tests/test_risk_drawdown_math.py
+++ b/tests/test_risk_drawdown_math.py
@@ -1,7 +1,7 @@
 """Risk math checks for drawdown and high-water mark tracking."""
 
 from forven.db import kv_get
-from forven.exchange.risk import update_equity
+from forven.exchange.risk import _HALT_CONFIRM_TICKS, update_equity
 
 
 def test_drawdown_percent_tracks_high_water_mark(forven_db):
@@ -25,22 +25,64 @@ def test_drawdown_percent_tracks_high_water_mark(forven_db):
     assert fourth["action"] is None
 
 
-def test_kill_switch_triggers_exactly_at_drawdown_threshold(forven_db):
-    # Establish HWM at 10,000 then drop exactly 10%.
+def test_kill_switch_does_not_latch_on_a_single_breaching_tick(forven_db):
+    # HALT-CONFIRM-1: one breaching equity sample must NOT latch the kill switch.
+    # A single plausible-but-wrong read (the 2026-07-14 phantom-halt class) would
+    # otherwise stop all trading on a loss that never happened.
     update_equity(10000.0)
-    result = update_equity(9000.0)
-    assert result["drawdown_pct"] == 0.1
-    assert result["kill_switch"] is True
-    assert result["action"] == "kill_switch"
+    first = update_equity(9000.0)
+    assert first["drawdown_pct"] == 0.1        # breach is measured...
+    assert first["kill_switch"] is False       # ...but not latched
+    assert first["action"] is None
 
 
-def test_daily_loss_halt_triggers_exactly_at_limit(forven_db):
+def test_kill_switch_latches_after_confirming_ticks(forven_db):
+    # ...and it MUST still fire once the breach is confirmed, or the drawdown
+    # protection does not exist. Latches on the _HALT_CONFIRM_TICKS-th
+    # consecutive breaching tick.
+    update_equity(10000.0)
+    results = [update_equity(9000.0) for _ in range(_HALT_CONFIRM_TICKS)]
+
+    for early in results[:-1]:
+        assert early["kill_switch"] is False
+    final = results[-1]
+    assert final["drawdown_pct"] == 0.1
+    assert final["kill_switch"] is True
+    assert final["action"] == "kill_switch"
+
+
+def test_kill_switch_streak_resets_on_a_clean_tick(forven_db):
+    # The confirmation must be CONSECUTIVE: a recovering tick in the middle
+    # restarts the count, so an intermittent bad sample can never accumulate
+    # its way to a latch.
+    update_equity(10000.0)
+    for _ in range(_HALT_CONFIRM_TICKS - 1):
+        assert update_equity(9000.0)["kill_switch"] is False
+    assert update_equity(9800.0)["kill_switch"] is False   # clean tick resets
+    for _ in range(_HALT_CONFIRM_TICKS - 1):
+        assert update_equity(9000.0)["kill_switch"] is False
+    assert update_equity(9000.0)["kill_switch"] is True    # full streak from scratch
+
+
+def test_daily_loss_halt_does_not_latch_on_a_single_breaching_tick(forven_db):
     # Daily start equity set on first call; second call lands exactly at -5%.
     update_equity(10000.0)
-    result = update_equity(9500.0)
-    assert result["daily_pnl_pct"] == -0.05
-    assert result["daily_halt"] is True
-    assert result["action"] == "daily_halt"
+    first = update_equity(9500.0)
+    assert first["daily_pnl_pct"] == -0.05
+    assert first["daily_halt"] is False
+    assert first["action"] is None
+
+
+def test_daily_loss_halt_latches_after_confirming_ticks(forven_db):
+    update_equity(10000.0)
+    results = [update_equity(9500.0) for _ in range(_HALT_CONFIRM_TICKS)]
+
+    for early in results[:-1]:
+        assert early["daily_halt"] is False
+    final = results[-1]
+    assert final["daily_pnl_pct"] == -0.05
+    assert final["daily_halt"] is True
+    assert final["action"] == "daily_halt"
 
 
 def test_update_equity_persists_drawdown_and_daily_snapshot(forven_db):

--- a/tests/test_risk_module.py
+++ b/tests/test_risk_module.py
@@ -788,8 +788,12 @@ class TestCloseAllPositionsPartialFailure:
         # Real close_position responses carry exit_price (the actual avgPx fill) and
         # mid alongside close_price (the padded IOC LIMIT). The booked price must be
         # the FILL — booking close_price fabricated off-market exits (E0001/E0002).
+        # filled_size is REQUIRED for the close to count as complete: an IOC
+        # response without it is ambiguous, and execution_results.parse_close_receipt
+        # deliberately treats the whole requested size as residual rather than
+        # releasing local exposure the venue may still be holding.
         fake_hl.close_position = lambda coin, size, side, **kwargs: {
-            "close_price": 51500, "exit_price": 50000, "mid": 49990,
+            "close_price": 51500, "exit_price": 50000, "mid": 49990, "filled_size": size,
         }
 
         with patch.dict(sys.modules, {"forven.exchange.hyperliquid": fake_hl}):
@@ -910,7 +914,10 @@ class TestCloseAllPositionsPartialFailure:
         }
         responses = [
             {"error": "temporary timeout"},
-            {"close_price": 1.29, "exit_price": 1.25, "mid": 1.249, "status": "ok"},
+            # filled_size confirms the venue quantity — without it the retry loop
+            # correctly reads the close as unconfirmed and keeps widening.
+            {"close_price": 1.29, "exit_price": 1.25, "mid": 1.249, "status": "ok",
+             "filled_size": 3.0},
         ]
         calls: list[tuple[str, float, str]] = []
 

--- a/tests/test_selfheal.py
+++ b/tests/test_selfheal.py
@@ -1,5 +1,30 @@
 from __future__ import annotations
 
+import sys as _sys
+
+import pytest as _pytest
+
+# KNOWN DEFECT (Linux): forven/sandbox run_code cannot `import pandas` inside its
+# subprocess on Linux -- and every strategy begins with that import, so self-heal
+# validation and manual-strategy registration are dead on that platform. This is a
+# PRODUCT bug, not a test bug, and it predates the whole-suite CI gate; it only
+# became visible when these tests started running in CI at all.
+#
+# Not yet diagnosed. Raising the POSIX rlimits (RLIMIT_AS 512MB -> 2048,
+# RLIMIT_NOFILE 32 -> 256) did NOT fix it, so those changes were reverted rather
+# than left as unverified weakening of a security boundary. The real error stays
+# hidden because selfheal truncates captured stderr (200 chars in the log, 1000 in
+# the payload) and the failure is cut off mid-traceback inside pandas/__init__.
+# Diagnosing it needs a Linux box and the untruncated stderr.
+#
+# Skipped rather than deleted: the assertions are correct and do pass on Windows,
+# and a visible skip keeps the defect on the record instead of silently green.
+_SANDBOX_BROKEN_ON_POSIX = _pytest.mark.skipif(
+    _sys.platform != "win32",
+    reason="forven.sandbox run_code cannot import pandas on Linux - known undiagnosed product defect",
+)
+
+
 import forven.selfheal as selfheal_mod
 
 
@@ -99,6 +124,7 @@ class DemoStrategy(BaseStrategy):
     assert result["code"].lstrip().startswith("from __future__ import annotations")
 
 
+@_SANDBOX_BROKEN_ON_POSIX
 def test_validate_strategy_code_rejects_vector_signal_from_generate_signal():
     result = selfheal_mod.validate_strategy_code(
         """

--- a/tests/test_source_reconciliation_gate.py
+++ b/tests/test_source_reconciliation_gate.py
@@ -76,11 +76,27 @@ def test_ts_close_frame_aligns_across_representations():
 
 # --------------------------- reconcile_one ---------------------------
 
-def _patch_sources(monkeypatch, lake_closes, hl_closes, source="binance"):
-    monkeypatch.setattr(sr, "load_parquet", lambda s, t: _lake_frame(lake_closes))
-    monkeypatch.setattr(sr, "get_dataset_source", lambda s, t: source)
+def _patch_sources(monkeypatch, lake_closes, hl_closes, source="binance", stored_closes=None):
+    """Pin BOTH live-frame sources reconcile_one can use.
+
+    reconcile_one prefers the STORED HyperLiquid venue series
+    (forven.data.load_venue_frame, collected hourly by the venue-collect job) and
+    only falls back to a live fetch when that series is missing or too short.
+    Patching just the fetch leaves the stored path reading the real data lake,
+    whose real timestamps never overlap these synthetic 2026-01-01 frames — every
+    assertion then fails as 'insufficient_overlap'. ``stored_closes=None`` forces
+    the live-fetch fallback; pass a list to exercise the stored-series path.
+    """
+    import forven.data as fdata
     import forven.market_data as md
 
+    monkeypatch.setattr(sr, "load_parquet", lambda s, t: _lake_frame(lake_closes))
+    monkeypatch.setattr(sr, "get_dataset_source", lambda s, t: source)
+    monkeypatch.setattr(
+        fdata,
+        "load_venue_frame",
+        lambda *a, **k: (None if stored_closes is None else _hl_frame(stored_closes)),
+    )
     monkeypatch.setattr(md, "fetch_hyperliquid_candles", lambda coin, **kw: _hl_frame(hl_closes))
 
 
@@ -93,6 +109,30 @@ def test_reconcile_one_ok_low_divergence(monkeypatch):
     assert out["max_divergence_pct"] == pytest.approx(0.0, abs=1e-9)
     assert out["backtest_source"] == "binance"
     assert out["live_venue"] == "hyperliquid"
+
+
+def test_reconcile_one_prefers_stored_venue_series_over_live_fetch(monkeypatch):
+    """The stored HL venue series wins when it covers min_overlap_bars.
+
+    Reconciliation should work from persisted closed-bar data and survive venue-API
+    hiccups; the live fetch is only the fallback. Here the stored series diverges
+    10% and the live fetch matches the lake exactly — reading the live fetch would
+    report 0% and silently hide real divergence.
+    """
+    lake = [100.0 + i for i in range(50)]
+    _patch_sources(monkeypatch, lake, hl_closes=lake, stored_closes=[c * 1.10 for c in lake])
+    out = sr.reconcile_one("BTC/USDT", "1h", min_overlap_bars=20)
+    assert out["status"] == "ok"
+    assert out["max_divergence_pct"] == pytest.approx(10.0, rel=1e-3)
+
+
+def test_reconcile_one_falls_back_to_live_fetch_when_stored_series_too_short(monkeypatch):
+    """A stored series shorter than min_overlap_bars must not pre-empt the fetch."""
+    lake = [100.0 + i for i in range(50)]
+    _patch_sources(monkeypatch, lake, hl_closes=lake, stored_closes=lake[:5])
+    out = sr.reconcile_one("BTC/USDT", "1h", min_overlap_bars=20)
+    assert out["status"] == "ok"
+    assert out["overlap_bars"] == 50
 
 
 def test_reconcile_one_high_divergence(monkeypatch):
@@ -124,9 +164,15 @@ def test_reconcile_one_same_venue_short_circuits(monkeypatch):
 
 
 def test_reconcile_one_fetch_error(monkeypatch):
+    """No stored venue series AND a failing live fetch -> fetch_error (not a pass)."""
+    import forven.data as fdata
+    import forven.market_data as md
+
     monkeypatch.setattr(sr, "load_parquet", lambda s, t: _lake_frame([100.0] * 30))
     monkeypatch.setattr(sr, "get_dataset_source", lambda s, t: "binance")
-    import forven.market_data as md
+    # Without this the stored HL series (real lake data) satisfies the live side
+    # and the fetch is never attempted, so the failure under test never happens.
+    monkeypatch.setattr(fdata, "load_venue_frame", lambda *a, **k: None)
 
     def _boom(coin, **kw):
         raise RuntimeError("hyperliquid down")

--- a/tests/test_transition_stage_outcome_closure.py
+++ b/tests/test_transition_stage_outcome_closure.py
@@ -121,7 +121,14 @@ def test_paper_to_live_graduated_triggers_positive_closure(env, monkeypatch):
     """Brain-driven promotion exercises the positive-closure branch.
     The promotion-gate (symbol resolution, robustness, etc.) is patched out —
     this test is about the closure hook, not the gauntlet of promotion checks."""
-    forven_db.kv_set("forven:settings", {"auto_approve_promotions": "true"})
+    # GO-LIVE-1: paper->live_graduated is never auto-approvable on
+    # auto_approve_promotions alone — it queues an operator approval instead, and
+    # the transition would return to='paper'. This test is about the skill-closure
+    # hook, not the approval rail, so opt out of that rail explicitly by name.
+    forven_db.kv_set(
+        "forven:settings",
+        {"auto_approve_promotions": "true", "allow_auto_live_promotion": True},
+    )
     monkeypatch.setattr(
         "forven.brain.evaluate_promotion",
         lambda *a, **k: (True, "ok"),

--- a/tests/test_unknown_close_fix.py
+++ b/tests/test_unknown_close_fix.py
@@ -35,7 +35,7 @@ def _insert_paper_trade(
     asset: str = "SOL",
     direction: str = "long",
     size: float = 10.0,
-    entry_price: float = 72.0,
+    entry_price: float | None = 72.0,
     signal_exit_price: float | None = None,
     signal_data: dict | None = None,
     opened_at: str | None = None,
@@ -140,12 +140,42 @@ def test_sweep_closes_local_paper_with_resolved_price(forven_db):
     assert sd["close_incomplete"] is False
 
 
-def test_sweep_marks_incomplete_only_when_no_price_anywhere(forven_db):
-    """With NO recoverable price anywhere, the sweep must still close (so the book
-    doesn't hang) but flag it incomplete — never fabricate a fill."""
+def test_sweep_falls_back_to_entry_price_for_a_local_paper_close(forven_db):
+    """No pending price and no signal_exit_price still yields a COMPLETE close.
+
+    A local paper trade never reached an exchange, so there is no fill to wait
+    for and it can always be priced: live-cache mark, else the recorded entry —
+    a neutral 0-PnL close. Writing exit_price=None here instead produced the
+    E0006-E0016 "closed with no PnL" rows, which drop out of the equity curve AND
+    the promotion gate.
+    """
     _insert_paper_trade(
         "P-SWEEP-NONE",
         asset="SOL",
+        entry_price=72.0,
+        signal_exit_price=None,
+        signal_data={
+            "pending_close_reconcile": True,
+            "pending_close_reconcile_at": _iso(60),
+        },
+    )
+
+    scanner_mod.sweep_pending_close_reconcile()
+    trade = _get_trade("P-SWEEP-NONE")
+    assert trade["status"] == "CLOSED"
+    assert trade["exit_price"] == 72.0          # priced at entry, not fabricated
+    sd = json.loads(trade["signal_data"])
+    assert sd["close_incomplete"] is False
+
+
+def test_sweep_marks_incomplete_only_when_no_price_anywhere(forven_db):
+    """With NO recoverable price anywhere — not even an entry — the sweep must
+    still close (so the book doesn't hang) but flag it incomplete rather than
+    fabricate a fill."""
+    _insert_paper_trade(
+        "P-SWEEP-NONE",
+        asset="SOL",
+        entry_price=None,
         signal_exit_price=None,
         signal_data={
             "pending_close_reconcile": True,

--- a/tests/test_walk_forward.py
+++ b/tests/test_walk_forward.py
@@ -51,7 +51,11 @@ def test_walk_forward_returns_valid_structure(monkeypatch, forven_db):
     def _full_candles(*_args, **_kwargs):
         return _fake_ohlcv(1000)
 
-    monkeypatch.setattr("forven.scanner.fetch_candles", _full_candles)
+    # walk_forward loads through backtest.load_backtest_candles, NOT
+    # scanner.fetch_candles — stubbing the latter is decorative and lets the real
+    # loader run, which falls through the (empty on CI) lake to a live Binance
+    # fetch and dies on HTTP 451 from a geo-blocked runner.
+    monkeypatch.setattr("forven.strategies.backtest.load_backtest_candles", _full_candles)
 
     result = walk_forward(
         strategy_id="wf-valid",
@@ -95,7 +99,11 @@ def test_walk_forward_gap_reduces_effective_oos(monkeypatch, forven_db):
     def _candles(*_args, **_kwargs):
         return _fake_ohlcv(1000)
 
-    monkeypatch.setattr("forven.scanner.fetch_candles", _candles)
+    # walk_forward loads through backtest.load_backtest_candles, NOT
+    # scanner.fetch_candles — stubbing the latter is decorative and lets the real
+    # loader run, which falls through the (empty on CI) lake to a live Binance
+    # fetch and dies on HTTP 451 from a geo-blocked runner.
+    monkeypatch.setattr("forven.strategies.backtest.load_backtest_candles", _candles)
 
     baseline = walk_forward("wf-gap", "BTC", "rsi_momentum", {}, total_bars=1000, n_splits=2)
     gapped = walk_forward(


### PR DESCRIPTION
CI ran **44 of 546 test files** (810 of 5769 tests). The ungated 86% had accumulated **69 failures** against product behaviour that had, in nearly every case, been changed deliberately — nobody was told, because nothing was watching.

Among the rotted tests were the only ones asserting that **the kill switch fires**, that **the paper→live gate enforces its PF/overfitting floors**, and that **funding accrual is correct**. Red tests in a pile of 69 aren't uninformative — they're camouflage.

## Three commits

**`fix:`** two latent defects the tests were already flagging, where the product was wrong and the test was right:
- `forven-live-graduation-scan` was seeded by `seed_forven_jobs()` but missing from `_DEFAULT_JOB_IDS`, so `reconcile_forven_jobs()` deleted it on the very next run. The paper→live recommender has never stayed on its daily schedule. Third instance of the documented SEED-DRIFT-1 class.
- With `FORVEN_FRONTEND_DIR` set (packaged build), `GET /` served API JSON instead of the SPA index. `api.py` tried to strip the `path == "/"` route before mounting StaticFiles, but FastAPI keeps included routers as internal `_IncludedRouter` wrappers, so the filter matched nothing.

**`test:`** 33 files repaired. Root causes were all product-intentional: engine v2→v5 re-baselines (costs are two-legged now — half on entry notional, half on **exit**), HALT-CONFIRM-1's 3-tick halt confirmation, the gate's persisted-artifact precondition, `_PARITY_PNL_FILTER`, GO-LIVE-1, CHAT-ROUNDS-1's soft landing, `filled_size` required to confirm a close, plus newer symbol/duplicate/LIVE-CLAMP-1 guards the fixtures predate.

Also two **test-isolation** bugs: both HyperLiquid SDK fixtures tore down with a bare `sys.modules.pop("forven.exchange.hyperliquid")`, which leaves the fake module bound as the `hyperliquid` *attribute* of the `forven.exchange` package. Every later `from forven.exchange import hyperliquid` — and every monkeypatch aimed at it — then hit the fake while the code under test imported the real one. That alone caused 9 `test_reconcile_sweep` failures, and survived because both files pass in isolation.

**`ci:`** run the whole suite, `-n auto --dist loadfile`. 28m serial → **9m14s** sharded.

## Fixture rot is now structurally harder

Where a fixture pinned a literal the product derives, it reads the source of truth instead — `BACKTEST_ENGINE_VERSION`, `_HALT_CONFIRM_TICKS`, `ek._trade_drag`, `INTERVAL_TO_MS`. The engine has a provenance mechanism that stales artifacts on a version bump; the tests sat outside it, so every re-baseline silently rotted them.

## Coverage that did not exist before

- The kill switch: must **not** latch on one breaching tick, **must** latch on the 3rd, resets on a clean tick.
- Source reconciliation prefers the stored HL venue series over a live fetch.
- Funding regime-filter and exit paths.
- Kelly's bounds at the sizing layer.

## Known defect, deliberately not fixed

**Kelly sizing is inert.** `kelly_fraction()` returns 0 until it has both a win and a loss; the shared kernel skips any entry with `size_fraction <= 0`. No trade opens → no evidence → the fraction never leaves 0. The legacy loop opened the zero-size trade and recorded its gross return, which is how it bootstrapped. Fixing it changes live sizing behaviour, so it's an operator call. `test_kelly_mode_opens_nothing_through_the_kernel` characterises it and will fail loudly when it's fixed.

## Verification

Run in a **clean worktree** (no local gitignored strategy modules — what CI actually sees):

| gate | result |
|---|---|
| `pytest -n auto --dist loadfile` | **5741 passed, 8 skipped, 0 failed** (9m14s) |
| `ruff check forven tests` | passed |
| `pytest --collect-only` | 5746 collected |
| identity-leak grep | clean |

That clean-worktree run caught two tests that only ever passed because the dev checkout carries gitignored modules under `forven/strategies/custom/` — both fixed here, verified in both environments.

## After merge

`forven-live-graduation-scan` will stay scheduled and run daily for the first time. Recommendation-only and dark, so it's safe — but expect new output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)