### PR TITLE
fix(tests): three blank-line E303 offenders that broke the formatting ratchet

### DIFF
--- a/tests/test_paper_no_global_halts.py
+++ b/tests/test_paper_no_global_halts.py
@@ -33,7 +33,6 @@ def _instant_halt_confirms(monkeypatch):
     monkeypatch.setattr(_risk, "_open_live_notional_usd", lambda: float("inf"))
 
 
-
 def _risk_state() -> dict:
     from forven.sim.clock import sim_kv_key
 

--- a/tests/test_risk_drawdown_math.py
+++ b/tests/test_risk_drawdown_math.py
@@ -18,7 +18,6 @@ def _instant_halt_confirms(monkeypatch):
     monkeypatch.setattr(_risk, "_open_live_notional_usd", lambda: float("inf"))
 
 
-
 def test_drawdown_percent_tracks_high_water_mark(forven_db):
     first = update_equity(10000.0)
     assert first["high_water_mark"] == 10000.0

--- a/tests/test_risk_module.py
+++ b/tests/test_risk_module.py
@@ -37,7 +37,6 @@ def _instant_halt_confirms(monkeypatch):
     monkeypatch.setattr(_risk, "_open_live_notional_usd", lambda: float("inf"))
 
 
-
 class TestModeAwareRiskLimits:
     """Risk limits change based on execution mode."""
 


### PR DESCRIPTION
## Summary
`tests/test_finish_formatting.py::test_e303_offender_set_may_only_shrink` fails on main @ 5c5fa676: the three risk test files added in the recent halt-guard work each carry a triple blank line after their `_instant_halt_confirms` fixture, tripping the frozen E303 ratchet.

Mechanical `ruff check --preview --select E303 --fix` on the three files — 3 deleted blank lines, no behavioral change.

## Verification
- `test_finish_formatting.py` + all three touched files: 95 passed.
- Full suite re-run in progress; found during the Bug Fixes channel backend review (thread 4d19d502…).

🤖 Generated with [Claude Code](https://claude.com/claude-code)