### PR TITLE
fix: keep MCP 1.x and decouple route guard tests

### DIFF
--- a/forven/api.py
+++ b/forven/api.py
@@ -836,12 +836,12 @@ async def shutdown(request: Request):
 # a real directory. Mount is registered last so explicit API routes always win,
 # and html=True makes StaticFiles resolve SPA deep links to index.html.
 #
-# The bare "GET /" is NOT handled here. FastAPI keeps included routers as internal
-# `_IncludedRouter` wrappers instead of flattening their APIRoutes into
-# app.router.routes, so the filter that used to live here ("drop any route whose
-# path == '/'") matched nothing and left routers/status.py:root() shadowing the SPA
-# index — the packaged app served API JSON at "/". That route now serves index.html
-# itself when this env var is set; see routers/status.py.
+# The bare "GET /" is NOT handled here. FastAPI's representation of included
+# routers varies by release: some versions flatten their APIRoutes, while others
+# retain internal wrappers. The filter that used to live here assumed a flat list
+# and therefore missed routers/status.py:root() under the wrapped representation,
+# shadowing the SPA index. That route now serves index.html itself when this env
+# var is set; see routers/status.py.
 from fastapi.staticfiles import StaticFiles  # noqa: E402
 
 _frontend_dir = os.environ.get("FORVEN_FRONTEND_DIR")
@@ -857,25 +857,15 @@ if _frontend_dir and os.path.isdir(_frontend_dir):
 def iter_effective_routes(routes, prefix: str = ""):
     """Yield ``(method, path)`` for every route a request can actually reach.
 
-    API-04: on the FastAPI we pin (0.138.0) ``app.routes`` is NOT the flat list it
-    looks like. Since 0.13x, ``include_router`` appends a single internal
-    ``fastapi.routing._IncludedRouter`` wrapper (routing.py:1518) holding
-    ``original_router`` + ``include_context``, instead of flattening the child
-    APIRoutes into ``app.router.routes``; the wrapper's own ``path``/``methods``
-    are None. Measured on this app: ``app.routes`` is 41 ``_IncludedRouter`` + 4
-    built-in docs ``Route`` + the 1 directly-decorated ``APIRoute``, so the old
-    guard's ``getattr(route, "path"/"methods")`` loop saw 9 (method, path) pairs —
-    the docs routes and POST /api/shutdown — and NONE of the 479 real ones. It
-    could not fire. Same root cause as the ``path == "/"`` filter that let
-    routers/status.py:root() shadow the packaged SPA index (fixed in 2711c779);
-    this walks the wrappers instead of assuming the flattening.
+    API-04: FastAPI has used both flat route lists and internal included-router
+    wrappers across supported releases. Under the wrapped representation, a
+    top-level ``path``/``methods`` loop sees only directly registered routes and
+    silently misses the included application routes it is meant to protect.
 
-    (Older FastAPIs — 0.133 and earlier — really did flatten, and there
-    ``_IncludedRouter``/``original_router`` do not exist at all. That is why this
-    is duck-typed on ``original_router`` / ``include_context.prefix`` rather than
-    isinstance-checked: it yields the same set either way, so an upgrade or a
-    downgrade cannot silently disarm the guard. The branch is live, not dead, on
-    the installed version.)
+    The wrapper traversal is deliberately duck-typed on ``original_router`` and
+    ``include_context.prefix`` rather than coupled to a private FastAPI class.
+    Flat routes pass through the normal branch, so both representations yield the
+    same effective ``(method, path)`` set.
 
     Mounts (StaticFiles) are skipped: they own a subtree, not a method+path.
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,8 @@ dependencies = [
     "beautifulsoup4>=4.12",
     "yfinance>=0.2",
     "yt-dlp>=2025.1.0",
-    "mcp>=1.0",
+    # Forven uses mcp.server.fastmcp, which was removed in MCP 2.x.
+    "mcp>=1.0,<2",
     "PyYAML>=6.0",
 ]
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -21,7 +21,8 @@ feedparser>=6.0
 filelock>=3.13
 httpx>=0.25
 hyperliquid-python-sdk>=0.22.0,<1
-mcp>=1.0
+# Forven uses mcp.server.fastmcp, which was removed in MCP 2.x.
+mcp>=1.0,<2
 numpy>=1.26,<3
 pandas>=2.2,<4
 psutil>=5.9

--- a/tests/test_harden_api_ui.py
+++ b/tests/test_harden_api_ui.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import json
 import threading
+from types import SimpleNamespace
 
 import pytest
 from fastapi import APIRouter, FastAPI, HTTPException
@@ -116,21 +117,6 @@ def test_in_range_risk_write_still_lands(forven_db):
 # --------------------------------------------------------------------------- #
 
 
-def _old_guard_pairs(app_) -> list[tuple[str, str]]:
-    """The PRE-FIX guard body, verbatim — what `_assert_no_duplicate_routes` used
-    to iterate. Kept here so the tests below prove the delta rather than assert it.
-    """
-    pairs: list[tuple[str, str]] = []
-    for route in app_.routes:
-        path = getattr(route, "path", None)
-        methods = getattr(route, "methods", None)
-        if not path or not methods:
-            continue
-        for method in methods:
-            pairs.append((method, path))
-    return pairs
-
-
 def _two_router_app(register) -> FastAPI:
     first = APIRouter()
     second = APIRouter()
@@ -151,13 +137,6 @@ def test_duplicate_route_guard_detects_a_duplicate_across_routers():
             return {}
 
     app = _two_router_app(_register)
-
-    # Discrimination check: on the INSTALLED FastAPI (0.138.0) `include_router`
-    # appends an opaque `_IncludedRouter` wrapper (path=None, methods=None), so the
-    # pre-fix guard saw only FastAPI's own /docs routes and could not have caught
-    # this duplicate. If this assertion ever fails, FastAPI started flattening
-    # again and the test below stopped proving anything — fix the test, not this.
-    assert ("GET", "/api/backtesting/run") not in _old_guard_pairs(app)
 
     with pytest.raises(RuntimeError) as excinfo:
         _assert_no_duplicate_routes(app)
@@ -189,10 +168,16 @@ def test_duplicate_route_guard_walks_prefixed_includes():
     def _c():  # pragma: no cover - never called
         return {}
 
-    app = FastAPI()
-    app.include_router(child, prefix="/api/nested")
+    nested_include = SimpleNamespace(
+        original_router=SimpleNamespace(routes=child.routes),
+        include_context=SimpleNamespace(prefix="/nested"),
+    )
+    outer_include = SimpleNamespace(
+        original_router=SimpleNamespace(routes=[nested_include]),
+        include_context=SimpleNamespace(prefix="/api"),
+    )
 
-    assert ("GET", "/api/nested/thing") in set(iter_effective_routes(app.routes))
+    assert ("GET", "/api/nested/thing") in set(iter_effective_routes([outer_include]))
 
 
 def test_real_app_has_no_duplicate_routes():
@@ -201,9 +186,6 @@ def test_real_app_has_no_duplicate_routes():
     # The guard is a no-op unless it can actually see the routers' routes.
     effective = list(iter_effective_routes(app.routes))
     assert len(effective) > 100
-    # ...and the pre-fix loop genuinely could not: it saw only the handful of
-    # routes registered directly on `app` (the /docs family + POST /api/shutdown).
-    assert len(_old_guard_pairs(app)) < 20
     _assert_no_duplicate_routes(app)
 
     # WS routes are inside the walked set — they were invisible to the old loop


### PR DESCRIPTION
## What changed

- Bound the `mcp` dependency to the supported 1.x API in both `pyproject.toml` and `requirements-ci.txt`.
- Made the duplicate-route guard tests independent of FastAPI's private included-router representation.
- Kept the production guard's duck-typed traversal and its duplicate-route invariant intact.

## Why

Fresh source and CI installs could resolve MCP 2.x even though Forven imports `mcp.server.fastmcp`, an API removed in MCP 2.x. The packaged dependency set was already pinned to MCP 1.26.0, so packaged builds and fresh installs had diverged.

The route-guard regressions also asserted FastAPI 0.138.0's private wrapper layout. Releases that flatten included routes failed the tests even though the production invariant still held.

## Impact

Fresh installs and CI now resolve a compatible MCP major. Route guard coverage remains effective across both flattened and wrapped FastAPI route representations.

## Evidence

- PR #107 backend CI resolved `mcp-2.0.0` from the former unbounded requirement.
- `packaging/requirements-frozen.txt` already pins `mcp==1.26.0`.
- The production guard sees more than 100 effective application routes and still rejects duplicate method/path pairs.

## Validation

- `tests/test_harden_api_ui.py`: 28 passed under FastAPI 0.138.0 and 28 passed under FastAPI 0.135.1.
- MCP test group: 36 passed.
- Full backend suite: 6,281 passed, 9 skipped, 0 failed (parallel-safe portion: 6,262 passed / 6 skipped; serial-only portion: 19 passed / 3 skipped).
- `ruff`: clean.