### PR TITLE
fix(propr): split open-permission from close-permission, and stop the paper bypass outliving the trial

### DIFF
--- a/forven/config.py
+++ b/forven/config.py
@@ -230,9 +230,11 @@ def propr_enabled() -> bool:
     FORVEN_ALLOW_MAINNET guard, an operator must already know this exists to
     turn it on: set FORVEN_PROPR_ENABLED=1 in the environment, or hand-write
     "propr_enabled": true into config.json. The flag controls VISIBILITY only
-    (the Propr nav page + /api/propr routes); actually placing a Propr order
+    (the Propr nav page + /api/propr routes); OPENING a Propr position
     additionally requires FORVEN_ALLOW_PROPR_LIVE=1 (see forven.exchange.propr —
-    Propr has no testnet, every order is real challenge-account money).
+    Propr has no testnet, every entry is real challenge-account money). Closes,
+    protective legs and cancels need only this flag: refusing an exit strands a
+    live position rather than protecting it (PROPR-PERM-2).
 
     Beta builds are unconditionally OFF, same reasoning as the paper lock in
     get_execution_mode: a packaged-build tester must not be able to reach a

--- a/forven/exchange/propr.py
+++ b/forven/exchange/propr.py
@@ -1416,13 +1416,26 @@ def get_status(include_remote: bool = True) -> dict:
             if isinstance(attempt, dict) and attempt:
                 status["attempt_status"] = attempt.get("status")
             status["account_type"] = get_account_type()
-            # Orders place when the operator opted in OR the account is a
+            # OPENS place when the operator opted in OR the account is a
             # verifiable paper/trial account — the page renders this truth.
             status["orders_allowed"] = bool(
                 status["allow_live"] or status["account_type"] == "paper"
             )
+            # EXITS are a separate permission (PROPR-PERM-2) and need no opt-in,
+            # reported explicitly so the page never has to infer "can I get out?"
+            # from the open-oriented flag — telling an operator they are locked
+            # in when they are not is the failure this whole change exists to
+            # prevent.
+            status["closes_allowed"] = True
         except ProprApiError as exc:
             status["account_error"] = str(exc)
+            # Account resolution failed, so NEITHER permission can be honoured:
+            # every order path, exits included, calls resolve_account() and will
+            # raise the same error. Say so rather than leaving the flags unset —
+            # an absent orders_allowed reads as False downstream and would let
+            # the page promise exits that cannot actually be placed.
+            status["orders_allowed"] = False
+            status["closes_allowed"] = False
         status["connected"] = True
     except ProprApiError as exc:
         status["connected"] = False

--- a/forven/exchange/propr.py
+++ b/forven/exchange/propr.py
@@ -216,7 +216,11 @@ def get_account_type(force_refresh: bool = False) -> str | None:
     """The exchange-reported Propr account type ('paper' during a trial).
 
     Cached briefly; a stale cache is NEVER trusted for the paper bypass — an
-    expired entry re-reads, and a failed re-read returns None (fail closed).
+    expired entry re-reads, and a failed re-read returns None (fail closed)
+    AND drops any cached verdict. Without the drop, the open guard's forced
+    re-read failing would leave a still-fresh "paper" entry behind for the
+    next NON-forced read, so get_status() would render orders_allowed=true
+    seconds after the guard refused an open for the same unverifiable account.
     """
     now = time.time()
     if (
@@ -233,8 +237,10 @@ def get_account_type(force_refresh: bool = False) -> str | None:
         if raw:
             _account_type_cache.update({"type": raw, "at": now})
             return raw
+        _account_type_cache.update({"type": None, "at": 0.0})
         return None
     except ProprApiError as exc:
+        _account_type_cache.update({"type": None, "at": 0.0})
         log.warning("Could not verify Propr account type (fail closed): %s", exc)
         return None
 

--- a/forven/exchange/propr.py
+++ b/forven/exchange/propr.py
@@ -14,10 +14,16 @@ Safety model — Propr has NO testnet, every order spends real challenge money:
   deliberately absent from the settings manifest/UI; an operator must know to
   set ``FORVEN_PROPR_ENABLED=1`` (or hand-edit config.json). Gates the nav
   page, the /api/propr routes, and venue selection.
-* ``_assert_propr_execution_allowed()`` — every order-placing/cancelling call
-  additionally requires ``FORVEN_ALLOW_PROPR_LIVE=1``, the direct analog of
-  the FORVEN_ALLOW_MAINNET guard. Read-only calls (positions/attempts/status)
-  deliberately do NOT require it.
+* ``_assert_propr_open_allowed()`` — every RISK-INCREASING call (entries,
+  leverage) additionally requires ``FORVEN_ALLOW_PROPR_LIVE=1``, the direct
+  analog of the FORVEN_ALLOW_MAINNET guard, unless the account verifies as a
+  paper/trial account on a FRESH read. Read-only calls (positions/attempts/
+  status) deliberately do NOT require it.
+* ``_assert_propr_reduce_allowed()`` — every RISK-REDUCING call (reduce-only
+  closes, protective stop/TP legs, cancels) requires the integration flag and
+  nothing more. Permission to open and permission to close are separate
+  permissions: refusing an exit does not protect the account, it strands a
+  live position. See PROPR-PERM-2.
 * Sim redirect — an active sim clock routes to the shared mock exchange
   exactly like the Hyperliquid adapter, so paper/sim can never reach Propr.
 
@@ -122,19 +128,12 @@ def allow_live() -> bool:
     return _is_truthy(os.environ.get("FORVEN_ALLOW_PROPR_LIVE"))
 
 
-def _assert_propr_execution_allowed() -> None:
-    """Single chokepoint guarding every Propr order-placing/cancelling call.
+def _assert_propr_integration_enabled() -> None:
+    """The hidden-flag floor under BOTH permission lanes below.
 
-    Two ways through (read-only functions deliberately do NOT call this):
-
-    * FORVEN_ALLOW_PROPR_LIVE=1 — the explicit real-money opt-in, or
-    * the account is VERIFIABLY a paper/trial account right now: Propr reports
-      ``account.type`` on the challenge attempt ("paper" during a free-trial
-      evaluation), re-verified at most _ACCOUNT_TYPE_CACHE_TTL_S old. The
-      moment Propr flips the account to a funded type — the evaluation ending
-      is exactly when it "becomes real" — this bypass dies and every order
-      fails closed until the operator sets the env opt-in. A failed or
-      ambiguous type read also fails closed.
+    Nothing that touches the venue runs with the integration switched off —
+    that much is unconditional, because with the flag unset there is no
+    operator intent to be talking to Propr at all.
     """
     if not propr_enabled():
         raise RuntimeError(
@@ -142,17 +141,71 @@ def _assert_propr_execution_allowed() -> None:
             "(FORVEN_PROPR_ENABLED is unset). This hidden flag is intentional — "
             "see forven/exchange/propr.py."
         )
+
+
+def _assert_propr_open_allowed() -> None:
+    """Chokepoint for RISK-INCREASING Propr calls (entries, leverage).
+
+    Two ways through (read-only functions deliberately do NOT call this):
+
+    * FORVEN_ALLOW_PROPR_LIVE=1 — the explicit real-money opt-in, or
+    * the account is VERIFIABLY a paper/trial account RIGHT NOW: Propr reports
+      ``account.type`` on the challenge attempt ("paper" during a free-trial
+      evaluation). The moment Propr flips the account to a funded type — the
+      evaluation ending is exactly when it "becomes real" — this bypass dies
+      and every new position fails closed until the operator sets the env
+      opt-in. A failed or ambiguous type read also fails closed.
+
+    PROPR-PERM-1: the type read is FORCED FRESH. get_account_type() otherwise
+    serves a cached verdict for up to _ACCOUNT_TYPE_CACHE_TTL_S (300 s), and
+    the single instant this guard exists for — conversion from paper to funded
+    — is precisely when a cached "paper" is WRONG. A stale-but-unexpired entry
+    written seconds before the flip let the bypass outlive the trial by up to a
+    full TTL, admitting real-capital opens the operator never opted into. The
+    bypass now re-verifies on every open; an unreachable venue reads None and
+    refuses, which is the safe direction for an entry (and cannot strand a
+    position, because exits go through _assert_propr_reduce_allowed instead).
+    """
+    _assert_propr_integration_enabled()
     if allow_live():
         return
-    account_type = get_account_type()
+    account_type = get_account_type(force_refresh=True)
     if account_type == "paper":
         return
     raise RuntimeError(
-        "Refusing to place a Propr order: the account is not verifiably a "
+        "Refusing to open a Propr position: the account is not verifiably a "
         f"paper/trial account (exchange-reported type={account_type!r}) and "
         "FORVEN_ALLOW_PROPR_LIVE is not set. Once a challenge account is real, "
-        "orders need that explicit opt-in on top of FORVEN_PROPR_ENABLED."
+        "new positions need that explicit opt-in on top of FORVEN_PROPR_ENABLED."
     )
+
+
+def _assert_propr_reduce_allowed() -> None:
+    """Chokepoint for RISK-REDUCING Propr calls (exits, protective legs, cancels).
+
+    PROPR-PERM-2: permission to OPEN and permission to CLOSE are not the same
+    permission, and conflating them inverts the guard's own purpose. The
+    real-money opt-in exists to stop capital going OUT on risk the operator did
+    not authorize. A reduce-only close, a stop/take-profit leg placed against an
+    ALREADY-OPEN position, and the cancel that lets a stop be re-placed all
+    reduce or hold exposure flat — none of them can spend new risk. Refusing
+    them does not protect the account; it strands a live position with no exit
+    and no way to manage its protective orders, which is strictly the more
+    dangerous failure.
+
+    That was live behaviour, not theory: the paper bypass expires 300 s after
+    Propr flips the attempt to funded, and from that moment the single old
+    chokepoint blocked close_position() and _place_conditional() too. So the
+    same conversion that (pre-PROPR-PERM-1) let unauthorised opens through
+    would then lock the operator out of closing what those opens created.
+    close_position() already states the principle in its own size-fallback
+    branch — "attempting beats refusing (a refusal strands a live position)" —
+    and this restores it at the guard.
+
+    The integration flag still applies: with FORVEN_PROPR_ENABLED unset there
+    is no Propr session to be exiting from in the first place.
+    """
+    _assert_propr_integration_enabled()
 
 
 _account_type_cache: dict = {"type": None, "at": 0.0}
@@ -689,7 +742,7 @@ def market_order(
         from forven.sim.mock_exchange import sim_market_order
         return sim_market_order(asset, side, size, stop_loss_price, take_profit_price)
 
-    _assert_propr_execution_allowed()
+    _assert_propr_open_allowed()
     if vault_address:
         return {"error": "Propr does not support sub-account routing (vault_address)"}
 
@@ -846,7 +899,7 @@ def limit_order(
         from forven.sim.mock_exchange import sim_market_order
         return sim_market_order(asset, side, size, stop_loss_price, take_profit_price)
 
-    _assert_propr_execution_allowed()
+    _assert_propr_open_allowed()
     if vault_address:
         return {"error": "Propr does not support sub-account routing (vault_address)"}
 
@@ -890,7 +943,10 @@ def limit_order(
 
 def cancel_order(asset: str, oid, testnet: bool = True, vault_address: str | None = None) -> dict:
     """Cancel by orderId. A 400 means already filled/cancelled — surfaced, not raised."""
-    _assert_propr_execution_allowed()
+    # Reduce lane: a cancel can never create exposure, and blocking it is how
+    # a protective stop becomes unreplaceable (cancel-then-re-place is the only
+    # way this venue moves a stop).
+    _assert_propr_reduce_allowed()
     account_id, _ = resolve_account()
     try:
         _request(
@@ -1023,7 +1079,9 @@ def _place_conditional(
 ) -> dict:
     """Shared stop_market / take_profit_market placement against an existing
     position (Propr requires the positionId for standalone conditionals)."""
-    _assert_propr_execution_allowed()
+    # Reduce lane: this only ever arms a stop/TP against an ALREADY-OPEN
+    # position (Propr requires the positionId), so it can only cap risk.
+    _assert_propr_reduce_allowed()
     asset_n = normalize_asset(asset)
     is_long = str(position_direction).strip().lower() in ("long", "buy", "b")
     # The caller typically arms a leg moments after the entry filled; the
@@ -1099,7 +1157,9 @@ def close_position(
         from forven.sim.mock_exchange import sim_close_position
         return sim_close_position(asset, size, side)
 
-    _assert_propr_execution_allowed()
+    # Reduce lane: reduceOnly below makes this strictly an exit. Getting out is
+    # never the thing the real-money opt-in is protecting against.
+    _assert_propr_reduce_allowed()
     asset_n = normalize_asset(asset)
     is_buy = str(side).strip().lower() in ("b", "buy")
     # Closing with a BUY reduces a SHORT; closing with a SELL reduces a LONG —
@@ -1250,7 +1310,8 @@ def set_leverage(
     if is_sim_active():
         return {"leverage": leverage, "sim": True}
 
-    _assert_propr_execution_allowed()
+    # Open lane: raising leverage raises risk on every subsequent entry.
+    _assert_propr_open_allowed()
     asset_n = normalize_asset(asset)
     requested = max(1.0, float(leverage))
     cap = _effective_leverage_limit(asset_n)

--- a/forven/propr_mirror.py
+++ b/forven/propr_mirror.py
@@ -7,10 +7,12 @@ always has, paper trading stays local — the mirror is a read-only OBSERVER of
 the trades table that places its own independently-sized orders on Propr.
 
 Runs as the `forven-propr-mirror` interval job (60s, seeded only while the
-hidden PROPR-1 flag is on). Every placement rides the adapter's execution
-guard, so mirroring works unattended on a verifiable paper/trial account and
-fails closed the moment Propr flips the account to real money (then
-FORVEN_ALLOW_PROPR_LIVE is required).
+hidden PROPR-1 flag is on). Every placement rides the adapter's permission
+guards, so mirroring works unattended on a verifiable paper/trial account and
+its ENTRIES fail closed the moment Propr flips the account to real money (then
+FORVEN_ALLOW_PROPR_LIVE is required). Its EXITS do not: closes, protective legs
+and the post-close cancel take the reduce lane (PROPR-PERM-2), so the mirror can
+always unwind what it opened even after that flip.
 
 Semantics:
 * OPEN mirror — a roster strategy's paper/live trade opens => place a Propr

--- a/forven/routers/propr.py
+++ b/forven/routers/propr.py
@@ -4,8 +4,9 @@ Deliberately hidden: every route except GET /api/propr/status returns 404
 while the hidden integration flag (forven.config.propr_enabled) is off, and
 status itself reports only {"enabled": false} in that state — a casual caller
 learns nothing. The flag is env/config-only (FORVEN_PROPR_ENABLED) and is NOT
-in the settings manifest; order placement additionally requires
-FORVEN_ALLOW_PROPR_LIVE (see forven/exchange/propr.py).
+in the settings manifest; OPENING a position additionally requires
+FORVEN_ALLOW_PROPR_LIVE, while closes, protective legs and cancels need only
+the integration flag (PROPR-PERM-2 — see forven/exchange/propr.py).
 """
 
 from fastapi import APIRouter, Depends, HTTPException

--- a/forven/routers/propr.py
+++ b/forven/routers/propr.py
@@ -180,8 +180,10 @@ def propr_mirror_tick_now():
 def propr_close_position(body: ClosePositionRequest):
     """Manual reduce-only close of a Propr position from the page.
 
-    Placement is still gated by the adapter's FORVEN_ALLOW_PROPR_LIVE guard —
-    without it this returns the guard's refusal instead of closing.
+    NOT gated by FORVEN_ALLOW_PROPR_LIVE. A close is risk-REDUCING, so it goes
+    through the adapter's reduce lane (PROPR-PERM-2), which asks only for the
+    integration flag — refusing an exit would strand the position this endpoint
+    exists to unwind. Opens are the ones that need the opt-in.
     """
     _require_enabled()
     if not body.confirm:

--- a/frontend/src/lib/api/propr.ts
+++ b/frontend/src/lib/api/propr.ts
@@ -17,6 +17,7 @@ export interface ProprStatus {
 	attempt_status?: string;
 	account_type?: string | null;
 	orders_allowed?: boolean;
+	closes_allowed?: boolean;
 	account_value?: number | null;
 	account_error?: string;
 }

--- a/frontend/src/routes/propr/+page.svelte
+++ b/frontend/src/routes/propr/+page.svelte
@@ -379,7 +379,7 @@
 						class={`text-xs px-2 py-1 border ${accountIsPaper ? 'text-[#c9a227] border-[#8a6d1a]' : 'text-red-400 border-red-800'}`}
 						title={accountIsPaper
 							? 'Propr reports this account as a paper/trial account — mirrored orders spend no real money.'
-							: 'Propr reports this account as REAL — orders require the backend live opt-in.'}
+							: 'Propr reports this account as REAL — NEW positions require the backend live opt-in. Closes, protective legs and cancels are unaffected.'}
 					>
 						{accountIsPaper ? 'PAPER ACCOUNT' : `REAL (${status.account_type})`}
 					</span>
@@ -420,16 +420,18 @@
 			</div>
 			{#if status?.connected && !status?.orders_allowed}
 				<div class="border border-yellow-900 bg-yellow-500/5 px-3 py-2 text-[11px] text-yellow-500">
-					Order placement is DISARMED: the account is not verifiably a paper/trial account
+					NEW POSITIONS are DISARMED: the account is not verifiably a paper/trial account
 					(type: {status?.account_type ?? 'unknown'}) and the backend live opt-in is not set.
-					Reads work; every open/close is refused. This is the designed behavior for when the
-					evaluation ends and the account becomes real.
+					This is the designed behavior for when the evaluation ends and the account becomes
+					real. You are NOT locked in: closing a position, arming a stop or take-profit, and
+					cancelling an order all still work (PROPR-PERM-2) — only opens need the opt-in.
 				</div>
 			{:else if accountIsPaper && !status?.allow_live}
 				<div class="border border-[#1a2438] bg-[#050a12] px-3 py-2 text-[11px] text-[#9ab]">
 					Orders are allowed WITHOUT the backend live opt-in because Propr reports this account
-					as paper — verified against the exchange every few minutes. The moment the evaluation
-					ends and the account type changes, order placement fails closed automatically.
+					as paper — re-verified against the exchange on every single open, not from a cache
+					(PROPR-PERM-1). The moment the evaluation ends and the account type changes, new
+					positions fail closed automatically; exits keep working.
 				</div>
 			{/if}
 			<div class="grid grid-cols-1 md:grid-cols-3 gap-2 items-end text-[11px]">

--- a/frontend/src/routes/propr/+page.svelte
+++ b/frontend/src/routes/propr/+page.svelte
@@ -418,7 +418,14 @@
 				<h2 class="text-sm font-bold uppercase tracking-wider text-white">Connection</h2>
 				<span class="text-[10px] text-[#666]">{status?.base_url}</span>
 			</div>
-			{#if status?.connected && !status?.orders_allowed}
+			{#if status?.connected && status?.account_error}
+				<div class="border border-red-900 bg-red-500/5 px-3 py-2 text-[11px] text-red-400">
+					Propr answered, but your ACCOUNT could not be resolved ({status.account_error}).
+					Nothing can be placed until that clears — opens, closes, protective legs and cancels
+					all resolve the same account and will fail with this error. This is a venue or
+					connection problem, not the permission gate.
+				</div>
+			{:else if status?.connected && !status?.orders_allowed}
 				<div class="border border-yellow-900 bg-yellow-500/5 px-3 py-2 text-[11px] text-yellow-500">
 					NEW POSITIONS are DISARMED: the account is not verifiably a paper/trial account
 					(type: {status?.account_type ?? 'unknown'}) and the backend live opt-in is not set.

--- a/tests/test_propr_venue.py
+++ b/tests/test_propr_venue.py
@@ -134,6 +134,11 @@ def test_open_ignores_a_fresh_but_stale_paper_verdict(monkeypatch):
     still INSIDE the 300 s TTL, so the pre-fix guard served it and admitted
     real-capital opens the operator never opted into — for up to a full TTL
     after the account stopped being paper.
+
+    Hermetic by construction: everything past the guard is stubbed and
+    _create_orders is a tripwire, so if the cached-paper bug ever comes back
+    the test fails HERE — a safety regression test must never have to reach
+    Hyperliquid or an authenticated Propr endpoint to prove the failure.
     """
     from forven.exchange import propr
 
@@ -148,9 +153,61 @@ def test_open_ignores_a_fresh_but_stale_paper_verdict(monkeypatch):
         propr, "get_challenge_attempt",
         lambda attempt_id: {"account": {"type": "funded"}},
     )
+    # Stub the whole post-guard path (as armed_propr does) …
+    monkeypatch.setattr(propr, "get_all_mids", lambda testnet=True: {"BTC": 50_000.0})
+    monkeypatch.setattr(propr, "_quantize_size", lambda asset, size: float(size))
+    monkeypatch.setattr(propr, "_round_price", lambda price, asset: float(price))
+    import forven.exchange.liquidity as liquidity
+    monkeypatch.setattr(liquidity, "check_order_liquidity", lambda *a, **k: (True, None))
+
+    # … and make order creation the tripwire (AssertionError is not caught by
+    # market_order's ProprApiError handler, so it surfaces as the failure).
+    def _tripwire(account_id, orders, group_id=None):
+        raise AssertionError(
+            "regression: an order reached the venue — the open guard served the "
+            "stale cached 'paper' verdict instead of re-verifying"
+        )
+
+    monkeypatch.setattr(propr, "_create_orders", _tripwire)
 
     with pytest.raises(RuntimeError, match="not verifiably a paper"):
         propr.market_order("BTC", "buy", 0.001)
+
+
+def test_failed_forced_refresh_drops_the_cached_verdict(monkeypatch):
+    """The guard's forced re-read failing must INVALIDATE the cache, not just
+    return None: get_status() renders orders_allowed from the next non-forced
+    read, and a surviving still-fresh "paper" entry would tell the operator
+    opens are allowed seconds after the guard refused one for the very same
+    unverifiable account."""
+    from forven.exchange import propr
+
+    monkeypatch.setitem(propr._account_type_cache, "type", "paper")
+    monkeypatch.setitem(propr._account_type_cache, "at", time.time() - 1.0)
+
+    def _venue_down(force_refresh=False):
+        raise propr.ProprApiError(0, "venue unreachable")
+
+    monkeypatch.setattr(propr, "resolve_account", _venue_down)
+
+    assert propr.get_account_type(force_refresh=True) is None
+    # The pinned sequence: the stale verdict is GONE, not waiting to resurface.
+    assert propr._account_type_cache["type"] is None
+    assert propr.get_account_type() is None
+
+
+def test_unverifiable_type_read_drops_the_cached_verdict(monkeypatch):
+    """Same drop when the venue answers but reports no usable account type."""
+    from forven.exchange import propr
+
+    monkeypatch.setitem(propr._account_type_cache, "type", "paper")
+    monkeypatch.setitem(propr._account_type_cache, "at", time.time() - 1.0)
+    monkeypatch.setattr(propr, "resolve_account", lambda force_refresh=False: ("acct-1", "att-1"))
+    monkeypatch.setattr(propr, "get_challenge_attempt", lambda attempt_id: {"account": {}})
+
+    assert propr.get_account_type(force_refresh=True) is None
+    assert propr._account_type_cache["type"] is None
+    assert propr.get_account_type() is None
 
 
 def test_open_guard_still_honours_a_live_paper_verdict(monkeypatch):

--- a/tests/test_propr_venue.py
+++ b/tests/test_propr_venue.py
@@ -12,6 +12,7 @@ stamped-venue close routing.
 from __future__ import annotations
 
 import json
+import time
 
 import pytest
 
@@ -96,7 +97,7 @@ def test_market_order_refuses_without_opt_in_or_paper_account(monkeypatch):
         propr.market_order("BTC", "buy", 0.001)
 
 
-def test_real_account_type_fails_closed(monkeypatch):
+def test_real_account_type_fails_closed_for_opens(monkeypatch):
     from forven.exchange import propr
 
     monkeypatch.setenv("FORVEN_PROPR_ENABLED", "1")
@@ -104,9 +105,130 @@ def test_real_account_type_fails_closed(monkeypatch):
     # The evaluation ended: Propr now reports a funded/real account type.
     monkeypatch.setattr(propr, "get_account_type", lambda force_refresh=False: "live")
     with pytest.raises(RuntimeError, match="not verifiably a paper"):
-        propr.close_position("BTC", 0.001, "sell")
+        propr.market_order("BTC", "buy", 0.001)
+    with pytest.raises(RuntimeError, match="not verifiably a paper"):
+        propr.limit_order("BTC", "buy", 0.001, 50_000.0)
     with pytest.raises(RuntimeError, match="not verifiably a paper"):
         propr.set_leverage("BTC", 2.0)
+
+
+# ---------------------------------------------------------------------------
+# PROPR-PERM: opening and closing are separate permissions
+# ---------------------------------------------------------------------------
+
+def _converted_to_funded(monkeypatch):
+    """The account Propr just flipped from trial to funded, no operator opt-in."""
+    from forven.exchange import propr
+
+    monkeypatch.setenv("FORVEN_PROPR_ENABLED", "1")
+    monkeypatch.delenv("FORVEN_ALLOW_PROPR_LIVE", raising=False)
+    monkeypatch.setattr(propr, "get_account_type", lambda force_refresh=False: "funded")
+    monkeypatch.setattr(propr, "resolve_account", lambda force_refresh=False: ("acct-1", "att-1"))
+    return propr
+
+
+def test_open_ignores_a_fresh_but_stale_paper_verdict(monkeypatch):
+    """PROPR-PERM-1: the paper bypass must re-verify, not read its own cache.
+
+    A "paper" entry written seconds before Propr flips the attempt to funded is
+    still INSIDE the 300 s TTL, so the pre-fix guard served it and admitted
+    real-capital opens the operator never opted into — for up to a full TTL
+    after the account stopped being paper.
+    """
+    from forven.exchange import propr
+
+    monkeypatch.setenv("FORVEN_PROPR_ENABLED", "1")
+    monkeypatch.delenv("FORVEN_ALLOW_PROPR_LIVE", raising=False)
+    # Cached one second ago, i.e. 299 s of TTL left.
+    monkeypatch.setitem(propr._account_type_cache, "type", "paper")
+    monkeypatch.setitem(propr._account_type_cache, "at", time.time() - 1.0)
+    # The venue's current truth: the evaluation converted.
+    monkeypatch.setattr(propr, "resolve_account", lambda force_refresh=False: ("acct-1", "att-1"))
+    monkeypatch.setattr(
+        propr, "get_challenge_attempt",
+        lambda attempt_id: {"account": {"type": "funded"}},
+    )
+
+    with pytest.raises(RuntimeError, match="not verifiably a paper"):
+        propr.market_order("BTC", "buy", 0.001)
+
+
+def test_open_guard_still_honours_a_live_paper_verdict(monkeypatch):
+    """Counterpart: forcing the refresh must not break the legitimate bypass."""
+    from forven.exchange import propr
+
+    monkeypatch.setenv("FORVEN_PROPR_ENABLED", "1")
+    monkeypatch.delenv("FORVEN_ALLOW_PROPR_LIVE", raising=False)
+    monkeypatch.setattr(propr, "resolve_account", lambda force_refresh=False: ("acct-1", "att-1"))
+    monkeypatch.setattr(
+        propr, "get_challenge_attempt",
+        lambda attempt_id: {"account": {"type": "paper"}},
+    )
+    propr._assert_propr_open_allowed()  # must not raise
+
+
+def test_reduce_guard_survives_conversion_to_funded(monkeypatch):
+    """PROPR-PERM-2: an exit is not an open. Once the bypass dies, the operator
+    must still be able to get OUT of whatever is already on the book."""
+    propr = _converted_to_funded(monkeypatch)
+
+    propr._assert_propr_reduce_allowed()  # must not raise
+    with pytest.raises(RuntimeError, match="not verifiably a paper"):
+        propr._assert_propr_open_allowed()
+
+
+def test_reduce_guard_still_requires_the_integration_flag(monkeypatch):
+    """The hidden flag is the floor under BOTH lanes — with Propr switched off
+    there is no session to be exiting from."""
+    from forven.exchange import propr
+
+    monkeypatch.delenv("FORVEN_PROPR_ENABLED", raising=False)
+    monkeypatch.delenv("FORVEN_ALLOW_PROPR_LIVE", raising=False)
+    with pytest.raises(RuntimeError, match="not enabled"):
+        propr._assert_propr_reduce_allowed()
+
+
+def test_close_position_reaches_the_venue_after_conversion(monkeypatch):
+    """End-to-end on the path that matters: a reduce-only close on a converted
+    account must get all the way to the venue call, not die at the guard."""
+    propr = _converted_to_funded(monkeypatch)
+    monkeypatch.setattr(propr, "get_all_mids", lambda testnet=True: {"BTC": 50_000.0})
+    monkeypatch.setattr(propr, "_quantize_size", lambda asset, size: float(size))
+    monkeypatch.setattr(propr, "_round_price", lambda price, asset: float(price))
+
+    def _boom(account_id, orders, group_id=None):
+        assert orders[0]["reduceOnly"] is True
+        raise propr.ProprApiError(0, "reached the venue")
+
+    monkeypatch.setattr(propr, "_create_orders", _boom)
+
+    result = propr.close_position("BTC", 0.001, "sell")
+    assert "reached the venue" in result["error"]
+
+
+def test_protective_leg_reaches_the_venue_after_conversion(monkeypatch):
+    """A stop can only ever be armed against an ALREADY-OPEN position, so it
+    caps risk — losing the ability to place one is the opposite of safe."""
+    propr = _converted_to_funded(monkeypatch)
+    monkeypatch.setattr(propr, "_find_position", lambda asset, direction: None)
+
+    result = propr._place_conditional(
+        "BTC", "long", 0.001, 49_000.0, "stop_market", "stop",
+    )
+    assert "no open Propr BTC long position to protect" in result["error"]
+
+
+def test_cancel_reaches_the_venue_after_conversion(monkeypatch):
+    """Cancel is how a stop gets re-placed; blocking it freezes stop management."""
+    propr = _converted_to_funded(monkeypatch)
+
+    def _boom(method, path, **kwargs):
+        raise propr.ProprApiError(0, "reached the venue")
+
+    monkeypatch.setattr(propr, "_request", _boom)
+
+    result = propr.cancel_order("BTC", "order-1")
+    assert "reached the venue" in result["error"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_propr_venue.py
+++ b/tests/test_propr_venue.py
@@ -127,6 +127,52 @@ def _converted_to_funded(monkeypatch):
     return propr
 
 
+def _status_stubs(monkeypatch):
+    from forven.exchange import propr
+
+    monkeypatch.setenv("FORVEN_PROPR_ENABLED", "1")
+    monkeypatch.delenv("FORVEN_ALLOW_PROPR_LIVE", raising=False)
+    monkeypatch.setattr(propr, "get_api_key", lambda: "k")
+    monkeypatch.setattr(propr, "get_user", lambda: {"userId": "u-1"})
+    monkeypatch.setattr(propr, "get_account_value",
+                        lambda *a, **k: {"accountValue": 5000.0})
+    return propr
+
+
+def test_status_reports_exits_as_their_own_permission(monkeypatch):
+    """PROPR-PERM-2 in the operator status. After conversion, opens are refused
+    but exits are not — the page must be able to say so from the status rather
+    than infer "can I get out?" from the open-oriented flag."""
+    propr = _status_stubs(monkeypatch)
+    monkeypatch.setattr(propr, "resolve_account",
+                        lambda force_refresh=False: ("acct-1", "att-1"))
+    monkeypatch.setattr(propr, "get_account_type", lambda force_refresh=False: "funded")
+
+    status = propr.get_status()
+    assert status["orders_allowed"] is False
+    assert status["closes_allowed"] is True
+
+
+def test_status_fails_both_permissions_when_the_account_cannot_resolve(monkeypatch):
+    """Codex review finding on 06018b18: get_status() left orders_allowed UNSET
+    when resolve_account() raised, which reads as False downstream — so the
+    disarmed banner fired and promised that closes, protective legs and cancels
+    "all still work". They do not: every one of them calls resolve_account() and
+    raises the same error. Neither permission is honourable in that state."""
+    propr = _status_stubs(monkeypatch)
+
+    def _boom(force_refresh=False):
+        raise propr.ProprApiError(0, "challenge-attempt lookup failed")
+
+    monkeypatch.setattr(propr, "resolve_account", _boom)
+
+    status = propr.get_status()
+    assert status["connected"] is True
+    assert "challenge-attempt lookup failed" in status["account_error"]
+    assert status["orders_allowed"] is False
+    assert status["closes_allowed"] is False
+
+
 def test_open_ignores_a_fresh_but_stale_paper_verdict(monkeypatch):
     """PROPR-PERM-1: the paper bypass must re-verify, not read its own cache.
 


### PR DESCRIPTION
PR-2 in the agreed money-path sequence (PR-1 is #108). Two halves of the same
failure, both timed to the instant a Propr challenge attempt converts from
paper to funded.

Originating thread: Buzz channel `Daily Brief` (#063ba03e-59d8-4a95-996e-652d4eba8890).

## PROPR-PERM-1 — the paper bypass read its own cache

`_assert_propr_execution_allowed()` let orders through when the account
verified as a paper/trial account. It got that verdict from
`get_account_type()`, which caches for `_ACCOUNT_TYPE_CACHE_TTL_S` (300 s).

So a `"paper"` entry written seconds before Propr flips the attempt to funded
is still unexpired, and was served straight to the guard. **For up to a full
TTL after the account stopped being paper, entries placed on real capital with
no `FORVEN_ALLOW_PROPR_LIVE` opt-in** — the guard failing open at the one
moment it exists for. The docstring claimed "a stale cache is NEVER trusted for
the paper bypass"; it was, whenever the flip landed mid-TTL.

The bypass now forces a fresh read. An unreachable venue reads `None` and
refuses, which is the safe direction for an entry — and, given PROPR-PERM-2
below, can no longer strand a position. Cost is one extra `GET
/challenge-attempts/{id}` per open; `get_status()` still reads cached.

## PROPR-PERM-2 — opening and closing are not the same permission

The single chokepoint guarded "every order-placing/cancelling call", which put
reduce-only exits, protective stop/TP legs and cancels behind the same
real-money opt-in as entries. So 300 s after that same conversion, the operator
was locked **out** of closing whatever the (then unauthorised) opens created:
`close_position()`, `_place_conditional()` and `cancel_order()` all raised.

Refusing an exit protects nothing. It strands a live position with no way out
and no way to manage its protective orders — strictly worse than the open it
was modelled on. `close_position()` already argues this in its own size-fallback
branch ("attempting beats refusing (a refusal strands a live position)"); the
guard now agrees with it.

The chokepoint is therefore two:

| lane | calls | requires |
|---|---|---|
| `_assert_propr_open_allowed()` | `market_order`, `limit_order`, `set_leverage` | integration flag **+** opt-in or a freshly-verified paper account |
| `_assert_propr_reduce_allowed()` | `close_position`, `_place_conditional` (`place_stop` / `place_take_profit`), `cancel_order` | integration flag only |

None of the reduce-lane calls can spend new risk. `cancel_order` is in it
deliberately: it is the only way this venue re-places a stop, and
`propr_mirror.py:825` uses it to clear orphaned protective legs after a close.
`FORVEN_PROPR_ENABLED` remains the unconditional floor under both lanes.

## Review notes

- **`test_real_account_type_fails_closed` asserted the old close-path refusal.**
  It is now scoped to opens (and widened to cover `limit_order`). That flipped
  assertion *is* the behaviour change above — please read it as the change, not
  as an incidental test edit.
- Seven new tests pin both halves. All seven fail against the pre-fix module;
  the stale-cache one fails by actually building and submitting a
  `reduceOnly: false` BUY body to the venue, which is the bug reproduced.
- Live Propr state at time of writing: `account_type=paper`, `allow_live=false`,
  attempt active at ~$4,987. Both safeties are in the safe position, so neither
  defect is currently firing — this is a fix-before-the-window-opens change.
  The window opens when the challenge converts, not after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
