### PR TITLE
Harden run_shell context permissions

### DIFF
--- a/forven/agents/tools_core.py
+++ b/forven/agents/tools_core.py
@@ -185,6 +185,7 @@ async def _kill_shell_process_tree(proc: asyncio.subprocess.Process) -> None:
         "required": ["command"],
     },
     is_async=True,
+    category="catastrophic",
 )
 async def _tool_run_shell(command: str) -> str:
     """Execute a shell command with timeout."""

--- a/tests/test_run_shell_safety.py
+++ b/tests/test_run_shell_safety.py
@@ -6,7 +6,9 @@ import asyncio
 
 import pytest
 
+from forven.agents import tool_registry
 from forven.agents import tools_core
+from forven.agents.context import reset_tool_context, set_tool_context
 
 
 @pytest.fixture(autouse=True)
@@ -26,6 +28,30 @@ def test_run_shell_disabled_by_default(monkeypatch):
     out = asyncio.run(tools_core._tool_run_shell("echo hello"))
     assert "Blocked" in out
     assert "disabled by default" in out
+
+
+def test_run_shell_is_denied_in_research_context(monkeypatch):
+    """Untrusted research content cannot reach the opt-in shell primitive."""
+    monkeypatch.setattr(tool_registry, "_load_toolset_overrides", lambda *_args: {})
+
+    registered = tool_registry._REGISTRY["run_shell"]
+    assert registered.category == "catastrophic"
+
+    available = {
+        tool["name"] for tool in tool_registry.get_tools_for_agent(None, context="research")
+    }
+    assert "run_shell" not in available
+
+    tokens = set_tool_context(None, "T0001", tools_context="research")
+    try:
+        out = asyncio.run(tool_registry.execute_tool("run_shell", {"command": "echo hello"}))
+    finally:
+        reset_tool_context(tokens)
+
+    assert out == (
+        "Tool 'run_shell' (category 'catastrophic') is disabled "
+        "in the 'research' context."
+    )
 
 
 def test_program_basename_strips_path_and_ext():


### PR DESCRIPTION
## Summary

- classify `run_shell` as a catastrophic tool so the existing research-context deny policy removes it from both discovery and dispatch
- keep the existing `FORVEN_ENABLE_SHELL_TOOL=1` operator opt-in unchanged
- add a regression covering category registration, research-context listing, and direct dispatch refusal

This closes batch item 1 from the agent-safety review: the research tool context denied catastrophic tools, but `run_shell` had no category and therefore bypassed that boundary.

## Related issues

Authorized safety-hardening batch item; no public issue.

## Testing

- [x] Full backend parallel lane: 6,287 passed, 6 skipped
- [x] Serial sandbox lane: 19 passed, 3 skipped
- [x] `python -m ruff check forven tests` is clean
- [x] Verification ran at unchanged exact head `7f0827d7fc332f6d4b098dcb90f44a849b1a87ae`
- [ ] `cd frontend && npm run check` (frontend not touched)

## Checklist

- [x] No secrets, credentials, or personal info added
- [x] Defaults remain safe; shell execution remains disabled unless the operator explicitly opts in
- [x] No new outbound calls
- [x] No documentation or configuration changes required
