### PR TITLE
fix(propr): the venue nets one position per asset — gate opens, retire vanished legs, stop retrying no-position closes

### DIFF
--- a/forven/exchange/propr.py
+++ b/forven/exchange/propr.py
@@ -981,7 +981,11 @@ def _position_quantity(position: dict) -> float:
     return 0.0
 
 
-def _position_side(position: dict) -> str:
+def position_side(position: dict) -> str:
+    """The side of a venue position payload — public because every consumer of
+    ``raw_positions()`` rows must interpret them the SAME way. Falls back to
+    the sign of the quantity when ``positionSide``/``side`` is missing or
+    unrecognized (the venue's own convention: negative = short)."""
     side = str(position.get("positionSide") or position.get("side") or "").strip().lower()
     if side in ("long", "short"):
         return side
@@ -1074,7 +1078,7 @@ def _find_position(asset: str, position_direction: str) -> dict | None:
     for p in raw_positions():
         if normalize_asset(str(p.get("asset") or p.get("coin") or "")) != asset_n:
             continue
-        if _position_side(p) == want:
+        if position_side(p) == want:
             return p
     return None
 

--- a/forven/exchange/propr.py
+++ b/forven/exchange/propr.py
@@ -1206,7 +1206,12 @@ def close_position(
     try:
         created = _create_orders(account_id, [order])
     except ProprApiError as exc:
-        return {"error": f"Propr close rejected: {exc}"}
+        # Surface the venue's numeric error code structurally — callers that
+        # must branch on a specific reject (e.g. the mirror treating 13065
+        # position_not_found_or_not_open as already-flat) get the code, not a
+        # string to parse.
+        code = exc.payload.get("code") if isinstance(exc.payload, dict) else None
+        return {"error": f"Propr close rejected: {exc}", "error_code": code}
     row = created[0] if created else {}
     order_id = _order_id(row)
     if order_id is None:

--- a/forven/propr_mirror.py
+++ b/forven/propr_mirror.py
@@ -640,13 +640,18 @@ def _position_key(propr, asset, direction) -> tuple[str, str]:
 
 
 def _venue_position_keys(propr, positions) -> set[tuple[str, str]]:
+    """(asset, side) for every venue position row, sided by the ADAPTER's
+    quantity-aware ``position_side`` — a payload with a missing or
+    unrecognized side field must never misclassify a real long as short
+    (Codex P1 on #113: that would retire the tracked leg and cancel its
+    live brackets)."""
     keys: set[tuple[str, str]] = set()
     for pos in positions or []:
         if not isinstance(pos, dict):
             continue
         asset = propr.normalize_asset(str(pos.get("asset") or pos.get("coin") or ""))
         if asset:
-            keys.add(_position_key(propr, asset, pos.get("positionSide") or pos.get("side")))
+            keys.add((asset, propr.position_side(pos)))
     return keys
 
 
@@ -1076,8 +1081,7 @@ def _reconcile_unmanaged_positions(propr, state: dict, now: datetime, summary: d
         if not isinstance(pos, dict):
             continue
         asset = propr.normalize_asset(str(pos.get("asset") or pos.get("coin") or ""))
-        side = str(pos.get("positionSide") or pos.get("side") or "").strip().lower()
-        side = "long" if side not in ("long", "short") else side
+        side = propr.position_side(pos)
         if not asset or (asset, side) in tracked:
             continue
         unmanaged[f"{asset}:{side}"] = {

--- a/forven/propr_mirror.py
+++ b/forven/propr_mirror.py
@@ -34,9 +34,16 @@ Semantics:
 * Idempotency — entry intentIds derive deterministically from the source
   trade id, so a re-tick after a lost state write cannot double-open; closes
   are reduceOnly, so a duplicate close is harmless by construction.
-* Propr merges same-asset/same-side positions into one; two roster strategies
-  long the same coin share a merged position, and each mirrored close reduces
-  it by that trade's own quantity.
+* Propr NETS one position per asset (verified 2026-07-31 against the live
+  order history — an earlier revision claimed same-side-only merging, which is
+  wrong): same-side entries merge into the netted position, and an
+  opposite-side entry REDUCES or FLIPS it — and the venue cancels every
+  resting protective stop when the position flips, leaving the book
+  unprotected. PROPR-NET-1: an open that would net against an opposite-side
+  leg (tracked here or live on the venue) is DEFERRED, not placed; it mirrors
+  normally if the opposite leg closes inside the freshness window and expires
+  to a stale skip past it. Same-side merging is unaffected: each mirrored
+  close still reduces the netted position by that trade's own quantity.
 
 Halts (two independent layers, both OPEN-only — closes are never blocked):
 * The GLOBAL trading halt (`risk.is_trading_allowed`: kill-switch / daily-loss
@@ -61,7 +68,10 @@ depend on it: mirrored opens are idempotent by intentId and closes are
 reduce-only, but a LOST state entry means nothing here will close that leg. The
 per-tick reconcile against `propr.raw_positions()` exists for exactly that gap
 — it reports venue positions with no open state entry (kv
-`forven:propr-mirror:unmanaged`) so an orphan is visible instead of silent.
+`forven:propr-mirror:unmanaged`) so an orphan is visible instead of silent, and
+it retires tracked legs whose venue position is GONE (PROPR-LEDGER-2, status
+``venue_missing``) so state cannot keep reporting exposure the venue no longer
+holds.
 Roster: kv `forven:settings` key `propr_mirror_strategies` {sid: added_iso},
 toggle `propr_mirror_enabled`. Managed ONLY via /api/propr/mirror (the generic
 settings PUT preserves unknown keys; nothing here is in the settings manifest).
@@ -136,6 +146,17 @@ MAX_OPENS_PER_TICK = 3
 MAX_OPEN_ATTEMPTS = 3
 MAX_CLOSE_ATTEMPTS = 10
 _STATE_RETENTION_DAYS = 7
+
+# The venue's "position_not_found_or_not_open" reject. On a reduce-only close
+# it means there is nothing left to reduce — the leg is already flat (its stop
+# filled first, or per-asset netting consumed it) — so retrying can never
+# succeed and the FIRST such reject is terminal.
+_PROPR_CODE_NO_POSITION = 13065
+
+# PROPR-LEDGER-2: consecutive venue reads a tracked-open leg must be absent
+# from before it is retired as ``venue_missing``. Hysteresis, not a delay knob:
+# one partial positions response must not retire a real leg.
+_VENUE_MISSING_TICKS = 3
 
 # RETRY-1: how fresh the scanner's signal snapshot must be to prove the entry
 # signal is still active (fail closed on a stale snapshot), and how long a
@@ -609,6 +630,59 @@ def _notify_mirror_failure(trade_id: str, entry: dict, kind: str) -> None:
         log.debug("Could not emit propr mirror failure notification: %s", exc)
 
 
+def _position_key(propr, asset, direction) -> tuple[str, str]:
+    """(normalized asset, long|short) — the identity Propr nets positions by."""
+    side = str(direction or "").strip().lower()
+    return (
+        propr.normalize_asset(str(asset or "")),
+        "long" if side == "long" else "short",
+    )
+
+
+def _venue_position_keys(propr, positions) -> set[tuple[str, str]]:
+    keys: set[tuple[str, str]] = set()
+    for pos in positions or []:
+        if not isinstance(pos, dict):
+            continue
+        asset = propr.normalize_asset(str(pos.get("asset") or pos.get("coin") or ""))
+        if asset:
+            keys.add(_position_key(propr, asset, pos.get("positionSide") or pos.get("side")))
+    return keys
+
+
+def _netting_conflict(propr, state: dict, trade_id: str, asset: str, direction: str) -> str | None:
+    """PROPR-NET-1: the reason this open must not be placed, else None.
+
+    Propr keeps ONE netted position per asset, so an opposite-side open is a
+    reduce/flip of an existing leg, not a new hedged position — and the venue
+    cancels every resting protective stop when the position flips (observed
+    2026-07-31: one entry flipped the ETH book long->short and Propr cancelled
+    all three resting ETH stops, leaving the exposure unprotected). Check both
+    this mirror's open legs and the venue book; an unreadable venue fails
+    CLOSED — an order that cannot be verified safe is not placed."""
+    opposite = ("short" if direction == "long" else "long")
+    for other_id, other in state.items():
+        if other_id == trade_id or not isinstance(other, dict):
+            continue
+        if other.get("status") != "open":
+            continue
+        if _position_key(propr, other.get("asset"), other.get("direction")) == (asset, opposite):
+            return (
+                f"netting conflict: mirrored trade {other_id} holds the opposite side of "
+                f"{asset} and Propr nets one position per asset"
+            )
+    try:
+        positions = propr.raw_positions() or []
+    except Exception as exc:
+        return f"venue positions unreadable ({exc}) — failing closed on the netting check"
+    if (asset, opposite) in _venue_position_keys(propr, positions):
+        return (
+            f"netting conflict: the venue already holds an opposite-side {asset} position "
+            "and Propr nets one position per asset"
+        )
+    return None
+
+
 def _record_open_error(trade_id: str, entry: dict, reason: str) -> None:
     """Bounded-retry bookkeeping for a failed open attempt; notifies once the
     failure turns terminal."""
@@ -650,6 +724,15 @@ def _mirror_open(
     # Price already through the stop => the trade is over before we arrived.
     if (direction == "long" and mid <= stop_price) or (direction == "short" and mid >= stop_price):
         entry.update({"status": "skipped", "reason": "price already beyond the stop at mirror time"})
+        return
+
+    # PROPR-NET-1: never place an open that would net against an opposite-side
+    # leg. Deferred (status pending), not skipped — it mirrors normally if the
+    # opposite leg closes inside the freshness window, and past the window the
+    # tick loop expires it to a stale skip like any other aged entry.
+    conflict = _netting_conflict(propr, state, trade_id, asset, direction)
+    if conflict:
+        entry.update({"status": "pending", "reason": f"deferred: {conflict}"})
         return
 
     # SLICE-1: size against this member's share of the challenge, not the whole
@@ -775,6 +858,20 @@ def _rearm_or_close_unprotected(
         entry["reason"] = f"unprotected and emergency close raised: {exc}"
 
 
+def _cancel_bracket_legs(propr, asset: str, entry: dict) -> None:
+    """Best-effort cancel of a retired leg's resting stop/TP orders.
+
+    The bracket legs are reduce-only so they can never re-open a position,
+    but cancel them anyway to keep the order book tidy."""
+    for leg_key in ("stop_order_id", "take_profit_order_id"):
+        leg_id = entry.get(leg_key)
+        if leg_id:
+            try:
+                propr.cancel_order(asset, leg_id)
+            except Exception as exc:
+                log.debug("Propr mirror: bracket cancel %s failed: %s", leg_id, exc)
+
+
 def _mirror_close(propr, trade_id: str, entry: dict, now: datetime) -> None:
     asset = propr.normalize_asset(str(entry.get("asset") or ""))
     direction = str(entry.get("direction") or "").strip().lower()
@@ -783,6 +880,31 @@ def _mirror_close(propr, trade_id: str, entry: dict, now: datetime) -> None:
         entry.update({"status": "closed", "reason": "nothing to close (zero mirrored quantity)"})
         return
     result = propr.close_position(asset, quantity, "sell" if direction == "long" else "buy")
+
+    # A no-position reject is terminal on the FIRST attempt: the venue has
+    # nothing this reduce-only close could reduce — the leg is already flat
+    # (its stop filled first, or per-asset netting consumed it) — and no
+    # number of retries changes that. Recorded as closed-at-venue, not
+    # alarmed as a failure: before this branch existed each such close burned
+    # MAX_CLOSE_ATTEMPTS rejects and a close_failed notification for a
+    # position that no longer existed.
+    if (
+        isinstance(result, dict)
+        and result.get("error")
+        and result.get("error_code") == _PROPR_CODE_NO_POSITION
+    ):
+        entry.update({
+            "status": "closed",
+            "reason": "venue reported no open position to reduce (13065) — already flat",
+            "venue_position_missing": True,
+            "closed_at": now.isoformat(),
+        })
+        _cancel_bracket_legs(propr, asset, entry)
+        log.warning(
+            "Propr mirror: close for trade %s found no venue position (13065) — "
+            "recording the leg as already closed", trade_id,
+        )
+        return
     # PROPR-CLOSE-1: gate the "closed" transition AND the bracket-leg cancels on
     # a fill that CONFIRMS THE WHOLE MIRRORED QUANTITY. Marking a close "closed"
     # retires the position from this ledger AND cancels its stop/TP — leaving a
@@ -818,15 +940,7 @@ def _mirror_close(propr, trade_id: str, entry: dict, now: datetime) -> None:
             "closed_quantity": filled,
             "closed_at": now.isoformat(),
         })
-        # The bracket legs are reduce-only so they can never re-open a
-        # position, but cancel them anyway to keep the order book tidy.
-        for leg_key in ("stop_order_id", "take_profit_order_id"):
-            leg_id = entry.get(leg_key)
-            if leg_id:
-                try:
-                    propr.cancel_order(asset, leg_id)
-                except Exception as exc:
-                    log.debug("Propr mirror: bracket cancel %s failed: %s", leg_id, exc)
+        _cancel_bracket_legs(propr, asset, entry)
         log.info("Propr mirror CLOSE %s %s for trade %s", asset, direction, trade_id)
     else:
         attempts = int(entry.get("close_attempts") or 0) + 1
@@ -863,6 +977,64 @@ def _mirror_close(propr, trade_id: str, entry: dict, now: datetime) -> None:
             _notify_mirror_failure(trade_id, entry, "close")
 
 
+def _retire_venue_missing_legs(propr, state: dict, venue_keys: set, now: datetime, summary: dict) -> None:
+    """PROPR-LEDGER-2: retire tracked-open legs whose venue position is GONE.
+
+    The reverse of the unmanaged report. Propr nets one position per asset, so
+    a leg this mirror tracks as open can be consumed venue-side (its stop
+    fills, or an opposite-side fill nets it away — observed 2026-07-31, where
+    a netted-away leg kept reporting "open" for days). Leaving it "open" keeps
+    phantom exposure on the page and burns MAX_CLOSE_ATTEMPTS rejected closes
+    when the source finally exits. A leg absent for _VENUE_MISSING_TICKS
+    consecutive successful reads is retired as ``venue_missing`` and notified
+    once; the hysteresis exists so one partial positions response cannot
+    retire a real leg, and a wrongly retired leg still surfaces through the
+    unmanaged report, so either failure mode stays visible."""
+    for trade_id, entry in state.items():
+        if not isinstance(entry, dict) or entry.get("status") != "open":
+            continue
+        key = _position_key(propr, entry.get("asset"), entry.get("direction"))
+        if not key[0] or key in venue_keys:
+            entry.pop("venue_missing_ticks", None)
+            continue
+        misses = int(entry.get("venue_missing_ticks") or 0) + 1
+        entry["venue_missing_ticks"] = misses
+        if misses < _VENUE_MISSING_TICKS:
+            continue
+        entry.update({
+            "status": "venue_missing",
+            "reason": (
+                f"no {key[1]} {key[0]} position on the venue for {misses} consecutive "
+                "reads — the leg was closed venue-side (stop fill or netted away); "
+                "nothing is left for this mirror to manage"
+            ),
+            "recorded_at": now.isoformat(),
+        })
+        summary["venue_missing"] = summary.get("venue_missing", 0) + 1
+        log.warning(
+            "Propr mirror: tracked leg for trade %s (%s %s) has no venue position — "
+            "retiring it as venue_missing", trade_id, key[0], key[1],
+        )
+        _cancel_bracket_legs(propr, key[0], entry)
+        try:
+            from forven.notifications import emit_notification
+            emit_notification(
+                "propr_mirror_venue_missing",
+                severity="warning",
+                source="propr_mirror",
+                title=f"Propr mirrored leg vanished venue-side ({key[0]})",
+                summary=(
+                    f"{entry.get('strategy')} {key[0]} {key[1]} (trade {trade_id}): the venue "
+                    "no longer holds this position — retired from the mirror ledger as "
+                    "venue_missing (stop fill or netted away)."
+                ),
+                body=str(entry.get("reason") or ""),
+                dedupe_key=f"propr_mirror_venue_missing:{trade_id}",
+            )
+        except Exception as exc:
+            log.debug("Could not emit propr mirror venue-missing notification: %s", exc)
+
+
 def _reconcile_unmanaged_positions(propr, state: dict, now: datetime, summary: dict) -> None:
     """PROPR-LEDGER-1: report venue positions this mirror is not tracking.
 
@@ -877,21 +1049,27 @@ def _reconcile_unmanaged_positions(propr, state: dict, now: datetime, summary: d
     understand (a hand-placed hedge, a leftover from a previous roster). The
     orphan is surfaced in kv ``forven:propr-mirror:unmanaged`` and notified
     once, so the operator can adopt or flatten it deliberately. A read failure
-    is never fatal — the mirror keeps working."""
+    is never fatal — the mirror keeps working.
+
+    The same read feeds the reverse check, PROPR-LEDGER-2 (see
+    ``_retire_venue_missing_legs``): tracked legs with no venue position left
+    are retired instead of tracked forever."""
     try:
         positions = propr.raw_positions() or []
     except Exception as exc:
         log.debug("Propr mirror: venue position read failed: %s", exc)
         return
 
+    venue_keys = _venue_position_keys(propr, positions)
+    _retire_venue_missing_legs(propr, state, venue_keys, now, summary)
+
     tracked: set[tuple[str, str]] = set()
     for entry in state.values():
         if entry.get("status") != "open":
             continue
-        asset = propr.normalize_asset(str(entry.get("asset") or ""))
-        side = str(entry.get("direction") or "").strip().lower()
-        if asset and side:
-            tracked.add((asset, "long" if side == "long" else "short"))
+        key = _position_key(propr, entry.get("asset"), entry.get("direction"))
+        if key[0]:
+            tracked.add(key)
 
     unmanaged: dict = {}
     for pos in positions:
@@ -1126,7 +1304,7 @@ def mirror_tick() -> dict:
     # --- prune aged terminal entries ----------------------------------------
     cutoff = now - timedelta(days=_STATE_RETENTION_DAYS)
     for trade_id, entry in list(state.items()):
-        if entry.get("status") in ("closed", "skipped", "failed", "close_failed"):
+        if entry.get("status") in ("closed", "skipped", "failed", "close_failed", "venue_missing"):
             # Terminal records without their own timestamp (skips/failures) are
             # stamped now so they show on the page for the retention window
             # instead of being pruned in the same tick that wrote them.

--- a/tests/test_propr_mirror_netting.py
+++ b/tests/test_propr_mirror_netting.py
@@ -1,0 +1,250 @@
+"""PROPR-NET-1 / PROPR-LEDGER-2: Propr NETS one position per asset.
+
+Pins the three behaviours that came out of the 2026-07-31 incident (an
+opposite-side mirror entry flipped the netted ETH position, the venue
+cancelled every resting stop at the flip, and the mirror kept tracking a leg
+the venue no longer held):
+
+* an open that would net against an opposite-side leg — tracked or live on
+  the venue — is DEFERRED, never placed;
+* a tracked-open leg absent from the venue for consecutive reads is retired
+  as ``venue_missing`` instead of reporting phantom exposure forever;
+* a 13065 position_not_found_or_not_open close reject is terminal on the
+  FIRST attempt (already flat), not MAX_CLOSE_ATTEMPTS retries + an alarm.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import forven.propr_mirror as pm
+
+NOW = datetime(2026, 8, 1, 12, 0, tzinfo=timezone.utc)
+
+
+class FakePropr:
+    """The slice of the adapter surface the mirror touches, order-recording."""
+
+    def __init__(self, positions=None, close_result=None):
+        self.positions = [] if positions is None else positions
+        self.close_result = close_result
+        self.orders = []
+        self.cancelled = []
+
+    def normalize_asset(self, asset):
+        return str(asset or "").upper()
+
+    def raw_positions(self):
+        if isinstance(self.positions, Exception):
+            raise self.positions
+        return self.positions
+
+    def get_all_mids(self, testnet=True):
+        return {"ETH": 2000.0, "BTC": 60_000.0}
+
+    def set_leverage(self, asset, leverage):
+        return {}
+
+    def market_order(self, asset, side, size, **kwargs):
+        self.orders.append((asset, side, size))
+        return {
+            "filled_size": size,
+            "entry_price": 2000.0,
+            "entry_order_id": "o-entry",
+            "stop_order_id": "o-stop",
+            "take_profit_order_id": None,
+        }
+
+    def close_position(self, asset, size, side):
+        return self.close_result
+
+    def cancel_order(self, asset, oid):
+        self.cancelled.append(oid)
+        return {}
+
+
+def _row(trade_id="T1", asset="ETH", direction="long", stop=1900.0):
+    return {
+        "id": trade_id,
+        "strategy_id": "S1",
+        "strategy": "S1",
+        "asset": asset,
+        "direction": direction,
+        "execution_type": "paper",
+        "leverage": 2.0,
+        "signal_data": {"stop_loss_price": stop},
+    }
+
+
+# ---------------------------------------------------------------------------
+# PROPR-NET-1: the opposite-side open gate
+# ---------------------------------------------------------------------------
+
+def test_open_defers_on_an_opposite_side_tracked_leg(forven_db, monkeypatch):
+    monkeypatch.setattr(pm, "mirror_roster", lambda: {"S1": "t"})
+    propr = FakePropr()
+    state = {"E1": {"status": "open", "asset": "ETH", "direction": "short"}}
+
+    pm._mirror_open(propr, _row(direction="long"), state, 5000.0, NOW)
+
+    assert state["T1"]["status"] == "pending"
+    assert "netting conflict" in state["T1"]["reason"]
+    assert propr.orders == []
+
+
+def test_open_defers_on_an_opposite_side_venue_position(forven_db, monkeypatch):
+    """The venue book is checked too — a hand-placed or unmanaged opposite leg
+    must block the open exactly like a tracked one."""
+    monkeypatch.setattr(pm, "mirror_roster", lambda: {"S1": "t"})
+    propr = FakePropr(positions=[{"asset": "ETH", "positionSide": "short", "quantity": "0.5"}])
+
+    state: dict = {}
+    pm._mirror_open(propr, _row(direction="long"), state, 5000.0, NOW)
+
+    assert state["T1"]["status"] == "pending"
+    assert "netting conflict" in state["T1"]["reason"]
+    assert propr.orders == []
+
+
+def test_open_fails_closed_when_the_venue_is_unreadable(forven_db, monkeypatch):
+    """An order that cannot be verified safe is not placed."""
+    monkeypatch.setattr(pm, "mirror_roster", lambda: {"S1": "t"})
+    propr = FakePropr(positions=RuntimeError("api down"))
+
+    state: dict = {}
+    pm._mirror_open(propr, _row(direction="long"), state, 5000.0, NOW)
+
+    assert state["T1"]["status"] == "pending"
+    assert "failing closed" in state["T1"]["reason"]
+    assert propr.orders == []
+
+
+def test_open_proceeds_alongside_a_same_side_leg(forven_db, monkeypatch):
+    """Same-side merging is the venue's normal behaviour — never blocked."""
+    monkeypatch.setattr(pm, "mirror_roster", lambda: {"S1": "t"})
+    propr = FakePropr(positions=[{"asset": "ETH", "positionSide": "long", "quantity": "0.5"}])
+    state = {"E1": {"status": "open", "asset": "ETH", "direction": "long"}}
+
+    pm._mirror_open(propr, _row(direction="long"), state, 5000.0, NOW)
+
+    assert state["T1"]["status"] == "open"
+    assert len(propr.orders) == 1
+
+
+def test_open_ignores_retired_opposite_side_entries(forven_db, monkeypatch):
+    """Only OPEN legs can conflict — a closed/venue_missing record is history."""
+    monkeypatch.setattr(pm, "mirror_roster", lambda: {"S1": "t"})
+    propr = FakePropr()
+    state = {
+        "E1": {"status": "closed", "asset": "ETH", "direction": "short"},
+        "E2": {"status": "venue_missing", "asset": "ETH", "direction": "short"},
+    }
+
+    pm._mirror_open(propr, _row(direction="long"), state, 5000.0, NOW)
+
+    assert state["T1"]["status"] == "open"
+    assert len(propr.orders) == 1
+
+
+# ---------------------------------------------------------------------------
+# 13065: a no-position close reject is terminal, not retried
+# ---------------------------------------------------------------------------
+
+def test_no_position_close_reject_is_terminal_and_not_alarmed(forven_db, monkeypatch):
+    alarms = []
+    monkeypatch.setattr(pm, "_notify_mirror_failure", lambda *a, **k: alarms.append(a))
+    propr = FakePropr(close_result={
+        "error": "Propr close rejected: position_not_found_or_not_open",
+        "error_code": 13065,
+    })
+    entry = {"status": "open", "asset": "ETH", "direction": "short",
+             "quantity": 0.5, "stop_order_id": "o-stop"}
+
+    pm._mirror_close(propr, "T1", entry, NOW)
+
+    assert entry["status"] == "closed"
+    assert entry["venue_position_missing"] is True
+    assert not entry.get("close_attempts")
+    assert propr.cancelled == ["o-stop"]
+    assert alarms == []
+
+
+def test_other_close_rejects_still_retry(forven_db):
+    propr = FakePropr(close_result={
+        "error": "Propr close rejected: rate limited", "error_code": 42,
+    })
+    entry = {"status": "open", "asset": "ETH", "direction": "short", "quantity": 0.5}
+
+    pm._mirror_close(propr, "T1", entry, NOW)
+
+    assert entry["status"] == "open"
+    assert entry["close_attempts"] == 1
+
+
+# ---------------------------------------------------------------------------
+# PROPR-LEDGER-2: tracked legs the venue no longer holds
+# ---------------------------------------------------------------------------
+
+def test_tracked_leg_missing_from_the_venue_is_retired_after_hysteresis(forven_db, monkeypatch):
+    import forven.notifications as notifications
+    emitted = []
+    monkeypatch.setattr(notifications, "emit_notification",
+                        lambda *a, **k: emitted.append((a, k)))
+    propr = FakePropr(positions=[])
+    state = {"E1": {"status": "open", "asset": "ETH", "direction": "short",
+                    "strategy": "S1", "stop_order_id": "o-stop"}}
+    summary: dict = {}
+
+    for i in range(pm._VENUE_MISSING_TICKS - 1):
+        pm._reconcile_unmanaged_positions(propr, state, NOW, summary)
+        assert state["E1"]["status"] == "open"
+        assert state["E1"]["venue_missing_ticks"] == i + 1
+
+    pm._reconcile_unmanaged_positions(propr, state, NOW, summary)
+
+    assert state["E1"]["status"] == "venue_missing"
+    assert summary["venue_missing"] == 1
+    assert propr.cancelled == ["o-stop"]
+    assert len(emitted) == 1
+
+
+def test_reappearing_leg_resets_the_missing_counter(forven_db):
+    propr = FakePropr(positions=[])
+    state = {"E1": {"status": "open", "asset": "ETH", "direction": "short"}}
+
+    pm._reconcile_unmanaged_positions(propr, state, NOW, {})
+    assert state["E1"]["venue_missing_ticks"] == 1
+
+    propr.positions = [{"asset": "ETH", "positionSide": "short", "quantity": "0.5"}]
+    pm._reconcile_unmanaged_positions(propr, state, NOW, {})
+
+    assert state["E1"]["status"] == "open"
+    assert "venue_missing_ticks" not in state["E1"]
+
+
+def test_venue_read_failure_never_counts_as_missing(forven_db):
+    propr = FakePropr(positions=RuntimeError("api down"))
+    state = {"E1": {"status": "open", "asset": "ETH", "direction": "short"}}
+
+    pm._reconcile_unmanaged_positions(propr, state, NOW, {})
+
+    assert state["E1"]["status"] == "open"
+    assert "venue_missing_ticks" not in state["E1"]
+
+
+def test_retired_leg_is_pruned_like_other_terminal_records(forven_db, monkeypatch):
+    """venue_missing joins the terminal statuses the tick loop ages out."""
+    import forven.sim.clock as sim_clock
+
+    monkeypatch.setattr(pm, "propr_enabled", lambda: True)
+    monkeypatch.setattr(pm, "mirror_enabled", lambda *a, **k: True)
+    monkeypatch.setattr(pm, "mirror_roster", lambda *a, **k: {"S1": "t"})
+    monkeypatch.setattr(sim_clock, "is_sim_active", lambda: False)
+
+    stale = (NOW - timedelta(days=pm._STATE_RETENTION_DAYS + 1)).isoformat()
+    pm._save_state({"E1": {"status": "venue_missing", "asset": "ETH",
+                           "direction": "short", "recorded_at": stale}})
+
+    pm.mirror_tick()
+
+    assert "E1" not in pm.get_state()

--- a/tests/test_propr_mirror_netting.py
+++ b/tests/test_propr_mirror_netting.py
@@ -34,6 +34,18 @@ class FakePropr:
     def normalize_asset(self, asset):
         return str(asset or "").upper()
 
+    def position_side(self, position):
+        # Mirrors forven.exchange.propr.position_side: explicit side wins,
+        # else the sign of the quantity decides.
+        side = str(position.get("positionSide") or position.get("side") or "").strip().lower()
+        if side in ("long", "short"):
+            return side
+        try:
+            qty = float(position.get("quantity") or 0)
+        except (TypeError, ValueError):
+            qty = 0.0
+        return "long" if qty >= 0 else "short"
+
     def raw_positions(self):
         if isinstance(self.positions, Exception):
             raise self.positions
@@ -220,6 +232,36 @@ def test_reappearing_leg_resets_the_missing_counter(forven_db):
 
     assert state["E1"]["status"] == "open"
     assert "venue_missing_ticks" not in state["E1"]
+
+
+def test_sideless_venue_long_backs_a_tracked_long(forven_db):
+    """Codex P1 on #113: a venue row with no side field must be sided by its
+    quantity sign, not defaulted — misreading a real long as short would
+    retire the tracked leg and cancel its live brackets."""
+    propr = FakePropr(positions=[{"asset": "ETH", "quantity": "0.29"}])
+    state = {"E1": {"status": "open", "asset": "ETH", "direction": "long",
+                    "stop_order_id": "o-stop"}}
+
+    for _ in range(pm._VENUE_MISSING_TICKS + 1):
+        pm._reconcile_unmanaged_positions(propr, state, NOW, {})
+
+    assert state["E1"]["status"] == "open"
+    assert "venue_missing_ticks" not in state["E1"]
+    assert propr.cancelled == []
+
+
+def test_sideless_venue_short_blocks_an_opposite_open(forven_db, monkeypatch):
+    """Same inference on the netting gate: negative quantity = short, so a
+    long open against it is deferred."""
+    monkeypatch.setattr(pm, "mirror_roster", lambda: {"S1": "t"})
+    propr = FakePropr(positions=[{"asset": "ETH", "quantity": "-0.5"}])
+
+    state: dict = {}
+    pm._mirror_open(propr, _row(direction="long"), state, 5000.0, NOW)
+
+    assert state["T1"]["status"] == "pending"
+    assert "netting conflict" in state["T1"]["reason"]
+    assert propr.orders == []
 
 
 def test_venue_read_failure_never_counts_as_missing(forven_db):

--- a/tests/test_propr_venue.py
+++ b/tests/test_propr_venue.py
@@ -309,6 +309,28 @@ def test_close_position_reaches_the_venue_after_conversion(monkeypatch):
     assert "reached the venue" in result["error"]
 
 
+def test_close_reject_surfaces_the_venue_error_code(monkeypatch):
+    """The mirror branches on 13065 position_not_found_or_not_open (already
+    flat — terminal on the first attempt), so the venue's numeric code must
+    arrive structurally, not embedded in an error string."""
+    propr = _converted_to_funded(monkeypatch)
+    monkeypatch.setattr(propr, "get_all_mids", lambda testnet=True: {"BTC": 50_000.0})
+    monkeypatch.setattr(propr, "_quantize_size", lambda asset, size: float(size))
+    monkeypatch.setattr(propr, "_round_price", lambda price, asset: float(price))
+
+    def _reject(account_id, orders, group_id=None):
+        raise propr.ProprApiError(
+            400, "POST /accounts/acct-1/orders: position_not_found_or_not_open",
+            {"message": "position_not_found_or_not_open", "code": 13065},
+        )
+
+    monkeypatch.setattr(propr, "_create_orders", _reject)
+
+    result = propr.close_position("BTC", 0.001, "sell")
+    assert result["error_code"] == 13065
+    assert "position_not_found_or_not_open" in result["error"]
+
+
 def test_protective_leg_reaches_the_venue_after_conversion(monkeypatch):
     """A stop can only ever be armed against an ALREADY-OPEN position, so it
     caps risk — losing the ability to place one is the opposite of safe."""
@@ -617,6 +639,24 @@ def mirror_env(forven_db, monkeypatch):
     monkeypatch.setattr(propr, "market_order", fake_market_order)
     monkeypatch.setattr(propr, "close_position", fake_close)
     monkeypatch.setattr(propr, "cancel_order", lambda *a, **k: {"cancelled": True})
+
+    # The venue book, derived from the fake fills above, so the PROPR-NET-1
+    # open gate and the PROPR-LEDGER-2 tracked-vs-venue reconcile see a venue
+    # consistent with what the mirror has placed (the real adapter would).
+    def fake_raw_positions():
+        open_qty: dict[tuple[str, str], float] = {}
+        for o in calls["orders"]:
+            key = (o["asset"], "long" if o["side"] == "buy" else "short")
+            open_qty[key] = open_qty.get(key, 0.0) + float(o["size"])
+        for c in calls["closes"]:
+            key = (c["asset"], "short" if c["side"] == "buy" else "long")
+            open_qty[key] = open_qty.get(key, 0.0) - float(c["size"])
+        return [
+            {"asset": asset, "positionSide": side, "quantity": qty}
+            for (asset, side), qty in open_qty.items() if abs(qty) > 1e-12
+        ]
+
+    monkeypatch.setattr(propr, "raw_positions", fake_raw_positions)
     return pm, calls
 
 


### PR DESCRIPTION
## What

Fixes the three Propr-mirror defects found in the 2026-08-01 Trading Checkups review. The mirror assumed Propr is a hedge-mode venue; the live order history (position `FC3bbDTFieUv`, 2026-07-31) shows it **nets one position per asset**:

- E0313's mirror "short" never existed — its sell netted E0309's long 0.2901 → 0.02.
- E0352's entry flipped the netted position long→short, and the venue cancelled **every** resting ETH stop at that instant (E0309's, E0313's, E0352's own bracket; none `user_cancelled`) — unprotected exposure.
- The mirror tracked E0313 as "open" for days with no venue position behind it, and E0309/E0352 each burned 10 rejected closes + a `close_failed` alarm on `13065 position_not_found_or_not_open` for legs that were already flat.

## Changes

1. **PROPR-NET-1 — netting-aware open gate.** `_mirror_open` never places an open that would net against an opposite-side leg on the same asset, checked against both mirror state and the venue book; an unreadable venue fails closed. Deferred (pending, retried each tick), not skipped — mirrors normally if the opposite leg closes inside the freshness window, expires to a stale skip past it. Same-side merging untouched.
2. **PROPR-LEDGER-2 — reverse reconcile.** A tracked-open leg with no same-side venue position for 3 consecutive successful reads is retired as `venue_missing` (brackets cancelled best-effort, notified once, pruned with the other terminal statuses). Hysteresis so one partial read can't retire a real leg. Self-heals the current phantom E0313 entry within ~3 ticks of deploy.
3. **13065 close rejects are terminal on the first attempt.** Recorded as already-flat (`venue_position_missing` stamp) instead of `MAX_CLOSE_ATTEMPTS` retries + alarm. `close_position` now returns the venue's numeric `error_code` so the mirror branches structurally, not on string matching.
4. **Docs corrected** — module docstring now states the netting reality and flags the old same-side-merge claim as wrong.

## Verification

- New `tests/test_propr_mirror_netting.py` pins all three behaviours (11 tests); adapter `error_code` test added to `test_propr_venue.py`; `mirror_env` fixture now derives `raw_positions` from its own fake fills so the gate/reconcile see a venue consistent with what the fake mirror placed.
- Full suite at e87811e3: **6318 passed, 9 skipped**. ruff clean.
- No money was lost in the incident (account $4,987.46/$5,000); the remaining BTC leg was verified correct and stop-protected.

Note for deploy: the backend needs a restart to pick this up; until then the flip risk remains live on the mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
