### PR TITLE
fix(portfolio): cross-strategy signal dedup + symbol-variant duplicate matching

### DIFF
--- a/forven/api_core.py
+++ b/forven/api_core.py
@@ -1749,6 +1749,19 @@ def _apply_settings_section(section: str, payload: dict, actor: str = "ui") -> d
                 payload.get("paper_test_local_execution_only"),
                 bool(updates.get("paper_test_local_execution_only", True)),
             )
+        # PORT-DEDUP-1: cross-strategy paper clone-signal guard (read by
+        # forven.scanner._open_trade_db via _scanner_bool/float_setting).
+        if "paper_cross_strategy_dedup_enabled" in payload:
+            updates["paper_cross_strategy_dedup_enabled"] = _coerce_bool(
+                payload.get("paper_cross_strategy_dedup_enabled"),
+                bool(updates.get("paper_cross_strategy_dedup_enabled", True)),
+            )
+        if "paper_cross_strategy_dedup_window_seconds" in payload:
+            updates["paper_cross_strategy_dedup_window_seconds"] = max(
+                0.0, min(86400.0, _coerce_float(
+                    payload.get("paper_cross_strategy_dedup_window_seconds"), 900.0
+                ))
+            )
 
     elif section == "strategy":
         # The legacy single-strategy fields (strategy_name / strategy_symbol /

--- a/forven/api_domains/paper_control.py
+++ b/forven/api_domains/paper_control.py
@@ -1036,10 +1036,16 @@ def _open_trade_db_safe(
     from forven.scanner import _open_trade_db
 
     try:
+        # cross_strategy_dedup=False: every caller here is a MANUAL operator
+        # entry (paper control / recovery). A human deliberately duplicating a
+        # strategy's bet is intent, not the clone-signal race PORT-DEDUP-1
+        # exists to stop — and a recovery re-entry must never be refused
+        # because some strategy traded the same asset minutes earlier.
         return _open_trade_db(
             strat_id=strategy_id, asset=asset, direction=direction, entry=entry,
             size=size, risk_pct=risk_pct, leverage=leverage,
             signal_data=signal_data, execution_type=execution_type, book=book,
+            cross_strategy_dedup=False,
         )
     except Exception as exc:  # noqa: BLE001
         if "idx_trades_unique_open" in str(exc):

--- a/forven/db.py
+++ b/forven/db.py
@@ -4801,6 +4801,30 @@ def log_tool_call(
 _TRADING_STAGES = frozenset({"paper", "live", "live_graduated", "deployed"})
 
 
+def _duplicate_symbol_variants(symbol: str, params: dict | None = None) -> list[str]:
+    """SYMBOL-DUP-2: every stored spelling that names the same market as
+    ``symbol``, for the duplicate check's comparison.
+
+    Mint-time normalisation only landed 2026-07-02, so legacy rows still hold
+    bare ('ETH'), dashed ('ETH-USDT') or glued ('ETHUSDT') forms — and exact
+    string equality let 'ETH' and 'ETH/USDT' register AND promote as two
+    strategies trading the identical signal (S06298/S06299, S06538/S06539:
+    fills fractions of a second apart, P&L identical to the cent). The bare
+    base is a variant only for the default USDT quote: a bare legacy row is
+    ambiguous, and colliding it with the default-quote market is the safe
+    reading — refusing a possible duplicate beats doubling exposure."""
+    raw = str(symbol or "").strip().upper()
+    variants = {raw} if raw else set()
+    canonical = normalize_strategy_symbol_strict(raw, params)
+    if canonical:
+        base, _, quote = canonical.partition("/")
+        variants.update({canonical, f"{base}-{quote}", f"{base}{quote}"})
+        if quote == "USDT":
+            variants.add(base)
+    variants.discard("")
+    return sorted(variants) if variants else [raw]
+
+
 def find_duplicate_trading_strategy(
     conn: sqlite3.Connection,
     *,
@@ -4812,13 +4836,18 @@ def find_duplicate_trading_strategy(
 ) -> str | None:
     """The id of an existing TRADING-stage strategy with the identical
     type + symbol + timeframe + params, or None. Canonical (sorted-key) JSON
-    comparison so key order can't defeat the check."""
+    comparison so key order can't defeat the check; canonical symbol-variant
+    matching (SYMBOL-DUP-2) so a spelling difference ('ETH' vs 'ETH/USDT')
+    can't either."""
     params_canon = json.dumps(params or {}, sort_keys=True)
     stage_ph = ",".join("?" for _ in _TRADING_STAGES)
+    sym_variants = _duplicate_symbol_variants(symbol, params)
+    sym_ph = ",".join("?" for _ in sym_variants)
     for row in conn.execute(
-        f"SELECT id, params FROM strategies WHERE type = ? AND symbol = ? AND timeframe = ? "
+        f"SELECT id, params FROM strategies WHERE type = ? "
+        f"AND UPPER(TRIM(COALESCE(symbol, ''))) IN ({sym_ph}) AND timeframe = ? "
         f"AND LOWER(COALESCE(stage, '')) IN ({stage_ph})",
-        (str(type_ or ""), str(symbol or ""), str(timeframe or "1h"), *sorted(_TRADING_STAGES)),
+        (str(type_ or ""), *sym_variants, str(timeframe or "1h"), *sorted(_TRADING_STAGES)),
     ).fetchall():
         if exclude_id and str(row["id"]) == str(exclude_id):
             continue
@@ -6953,6 +6982,11 @@ def auto_assign_best_symbol_timeframe(strategy_id: str) -> tuple[str, str] | Non
     best_symbol, best_timeframe, fitness, _ = resolve_best_symbol_timeframe(strategy_id)
     if not best_symbol or not best_timeframe or fitness <= 0:
         return None
+    # SYMBOL-DUP-2: this write-back bypasses the mint-time normaliser, so a
+    # bare/dashed backtest-context symbol would reintroduce exactly the spelling
+    # split the duplicate check guards against. Repair when repairable; an
+    # unrepairable value stays as-is (strict, never the BTC/USDT fallback).
+    best_symbol = normalize_strategy_symbol_strict(best_symbol) or best_symbol
 
     with get_db() as conn:
         row = conn.execute(

--- a/forven/db.py
+++ b/forven/db.py
@@ -4821,6 +4821,23 @@ def _duplicate_symbol_variants(symbol: str, params: dict | None = None) -> list[
         variants.update({canonical, f"{base}-{quote}", f"{base}{quote}"})
         if quote == "USDT":
             variants.add(base)
+    # SYMBOL-DUP-3: a glued legacy spelling ('SOLUSDT') has no separator, so
+    # the strict normaliser reads it as a bare base and canonicalises it to
+    # 'SOLUSDT/USDT' — the variant set above then never contains 'SOL/USDT',
+    # and a glued CANDIDATE sails past a canonical INCUMBENT (the reverse of
+    # the orientation the canonical branch covers). Split a trailing known
+    # quote (longest first, so 'FDUSD' wins over 'USD') and add that reading's
+    # variants too. A false split (e.g. 'PYUSD' → 'PY/USD') only widens the
+    # duplicate net, which is the safe direction.
+    if raw and "/" not in raw and "-" not in raw and re.fullmatch(r"[A-Z0-9]+", raw):
+        for quote in sorted(_KNOWN_QUOTE_CURRENCIES, key=len, reverse=True):
+            if raw.endswith(quote):
+                glued_base = raw[: -len(quote)]
+                if re.fullmatch(r"[A-Z0-9]{2,8}", glued_base):
+                    variants.update({f"{glued_base}/{quote}", f"{glued_base}-{quote}"})
+                    if quote == "USDT":
+                        variants.add(glued_base)
+                    break
     variants.discard("")
     return sorted(variants) if variants else [raw]
 

--- a/forven/evolution.py
+++ b/forven/evolution.py
@@ -31,6 +31,7 @@ from forven.db import (
     kv_get,
     kv_set,
     log_activity,
+    normalize_strategy_symbol_strict,
 )
 from forven.util import normalize_stage
 from forven.policy import evaluate_promotion, score_strategy, compute_live_metrics, check_promotion_readiness
@@ -2122,6 +2123,10 @@ def _run_testing_step_impl(code_first: bool = True) -> dict:
                     raise RuntimeError(str(first_failure))
 
                 selected_symbol = str(best_validation.get("symbol") or symbol).strip().upper() or symbol
+                # SYMBOL-DUP-2: write-back bypasses the mint normaliser — repair
+                # a bare/dashed context symbol so a spelling split cannot
+                # re-enter the registry here (strict: unrepairable stays as-is).
+                selected_symbol = normalize_strategy_symbol_strict(selected_symbol) or selected_symbol
                 selected_timeframe = _normalize_timeframe(str(best_validation.get("timeframe") or timeframe).strip(), timeframe)
                 metrics = best_validation.get("metrics") if isinstance(best_validation.get("metrics"), dict) else {}
                 context_fitness = _to_float(best_validation.get("fitness"), 0.0)

--- a/forven/lab_intent_dispatch.py
+++ b/forven/lab_intent_dispatch.py
@@ -17,7 +17,7 @@ from forven.lab_models import (
     DispatchPaperIntentRequest,
     DispatchPaperIntentResponse,
 )
-from forven.scanner import _open_trade_db
+from forven.scanner import CrossStrategyDuplicateSignal, _open_trade_db
 from forven.trade_state import close_trade_record
 
 _ACTION_ALIASES: dict[str, str] = {
@@ -303,39 +303,50 @@ def dispatch_paper_intent(request: DispatchPaperIntentRequest) -> DispatchPaperI
                 fill_price = signal_price
                 feedback_details["existing_trade_id"] = str(existing_trade.get("id") or "")
             else:
-                trade_id = _open_trade_db(
-                    strat_id=champion_strategy_id,
-                    asset=asset,
-                    direction=direction,
-                    entry=signal_price,
-                    size=intent_payload["size"],
-                    risk_pct=intent_payload["risk_pct"],
-                    leverage=intent_payload["leverage"],
-                    signal_data={
-                        "source": "lab_regime_dispatch",
-                        "selection_event_id": selected_event_id,
-                        "intent_id": intent.id,
-                        "regime": regime,
-                        "confidence": confidence,
-                        "strategy_candidate_key": candidate_key,
-                        "champion_strategy_key": champion_strategy_key,
-                        "trade_mode": trade_mode,
-                        "position_model": position_model,
-                        **intent_payload["meta_json"],
-                    },
-                    execution_type="paper",
-                )
-                register(
-                    trade_id=trade_id,
-                    asset=asset,
-                    direction=direction,
-                    strategy=champion_strategy_id,
-                    risk_pct=float(intent_payload["risk_pct"]),
-                    entry_price=signal_price,
-                    execution_type="paper",
-                )
-                fill_price = signal_price
-                execution_status = "filled"
+                try:
+                    trade_id = _open_trade_db(
+                        strat_id=champion_strategy_id,
+                        asset=asset,
+                        direction=direction,
+                        entry=signal_price,
+                        size=intent_payload["size"],
+                        risk_pct=intent_payload["risk_pct"],
+                        leverage=intent_payload["leverage"],
+                        signal_data={
+                            "source": "lab_regime_dispatch",
+                            "selection_event_id": selected_event_id,
+                            "intent_id": intent.id,
+                            "regime": regime,
+                            "confidence": confidence,
+                            "strategy_candidate_key": candidate_key,
+                            "champion_strategy_key": champion_strategy_key,
+                            "trade_mode": trade_mode,
+                            "position_model": position_model,
+                            **intent_payload["meta_json"],
+                        },
+                        execution_type="paper",
+                    )
+                except CrossStrategyDuplicateSignal as dup_exc:
+                    # PORT-DEDUP-1: another strategy already recorded this bet
+                    # inside the dedup window. A clean rejection, not a failure
+                    # — the generic except below would mislabel it "failed".
+                    execution_status = "rejected"
+                    reason = "cross_strategy_duplicate_signal"
+                    fill_price = signal_price
+                    feedback_details["blocking_trade_id"] = dup_exc.blocking_trade_id
+                    feedback_details["blocking_strategy"] = dup_exc.blocking_strategy
+                else:
+                    register(
+                        trade_id=trade_id,
+                        asset=asset,
+                        direction=direction,
+                        strategy=champion_strategy_id,
+                        risk_pct=float(intent_payload["risk_pct"]),
+                        entry_price=signal_price,
+                        execution_type="paper",
+                    )
+                    fill_price = signal_price
+                    execution_status = "filled"
         else:
             close_direction = "long" if action == "long_exit" else "short"
             open_trade = _find_open_trade(champion_strategy_id, asset, close_direction)

--- a/forven/scanner.py
+++ b/forven/scanner.py
@@ -4344,12 +4344,41 @@ def _clean_signal_data(d: dict) -> dict:
             cleaned[k] = v
     return cleaned
 
+class CrossStrategyDuplicateSignal(Exception):
+    """PORT-DEDUP-1: a DIFFERENT strategy already recorded the same paper
+    (asset, direction) bet inside the dedup window, so this open would add a
+    clone leg, not an independent position.
+
+    The per-strategy unique-open index cannot catch this: it is keyed on the
+    strategy, so N strategies emitting one signal all pass it and the book
+    piles N copies of the same trade (2026-07-26..08-07 streak: 55 of 160
+    paper trades were 2nd-or-later copies of an identical entry, 39% of the
+    loss). Callers treat this like the IntegrityError duplicate guard — skip
+    the open, keep the scan loop alive."""
+
+    def __init__(
+        self, asset: str, direction: str,
+        blocking_trade_id: str, blocking_strategy: str, window_seconds: float,
+    ):
+        self.asset = asset
+        self.direction = direction
+        self.blocking_trade_id = blocking_trade_id
+        self.blocking_strategy = blocking_strategy
+        self.window_seconds = window_seconds
+        super().__init__(
+            f"cross-strategy duplicate signal: {blocking_strategy} already recorded "
+            f"{blocking_trade_id} ({asset} {direction}) within the last "
+            f"{int(window_seconds)}s — one signal, one position"
+        )
+
+
 def _open_trade_db(
     strat_id: str, asset: str, direction: str, entry: float,
     size: float, risk_pct: float, leverage: float, signal_data: dict,
     execution_type: str = "live",
     book: str | None = None,
     opened_at: str | None = None,
+    cross_strategy_dedup: bool = True,
 ) -> str:
     """Record a new trade in SQLite. Returns trade ID.
 
@@ -4375,6 +4404,44 @@ def _open_trade_db(
             if isinstance(signal_data, dict) and "regime_confidence" not in signal_data:
                 signal_data["regime_confidence"] = round(float(cached_state.confidence), 3)
     with get_db() as conn:
+        # PORT-DEDUP-1: collapse cross-strategy clone signals at the choke point
+        # every open path funnels through. Scoped to execution_type 'paper'
+        # exactly: live pools already enforce one-net-position-per-asset in
+        # can_open, and simulation/soak lanes are isolated sandboxes. Window is
+        # measured against created_at (recording time) rather than opened_at —
+        # kernel late hop-ins backdate opened_at to the historical entry bar,
+        # which would defeat a "fired together" comparison. ANY status counts:
+        # a clone that already stopped out inside the window is the same doomed
+        # signal, not new information. Manual operator entries pass
+        # cross_strategy_dedup=False — a human duplicating a bet on purpose is
+        # not a race. Check-then-insert (not an index) because a time window
+        # cannot be expressed as a UNIQUE constraint; the scanner's open paths
+        # run sequentially in-process, which is the race the streak evidence
+        # shows (clones landed seconds apart from one scan cycle).
+        if (
+            cross_strategy_dedup
+            and execution_type == "paper"
+            and _scanner_bool_setting("paper_cross_strategy_dedup_enabled", True)
+        ):
+            _dedup_window_s = _scanner_float_setting(
+                "paper_cross_strategy_dedup_window_seconds", 900.0
+            )
+            if _dedup_window_s > 0:
+                _dup_row = conn.execute(
+                    """SELECT id, COALESCE(NULLIF(strategy_id, ''), strategy) AS sid
+                    FROM trades
+                    WHERE execution_type = 'paper' AND asset = ? AND direction = ?
+                      AND COALESCE(NULLIF(strategy_id, ''), strategy) <> ?
+                      AND (julianday('now') - julianday(COALESCE(NULLIF(created_at, ''), opened_at)))
+                          * 86400.0 <= ?
+                    ORDER BY id DESC LIMIT 1""",
+                    (asset, direction, strat_id, float(_dedup_window_s)),
+                ).fetchone()
+                if _dup_row is not None:
+                    raise CrossStrategyDuplicateSignal(
+                        asset, direction, str(_dup_row["id"]), str(_dup_row["sid"]),
+                        float(_dedup_window_s),
+                    )
         # The "E" counter can fall behind the real trade ids when a row is inserted
         # out-of-band (e.g. exchange-recovery) without bumping container_counters.
         # When that happens next_container_id() hands back an ALREADY-USED id, the
@@ -5281,6 +5348,31 @@ def manage_positions(
                     execution_type=execution_type,
                     **_open_extra,
                 )
+            except CrossStrategyDuplicateSignal as dup_exc:
+                # PORT-DEDUP-1: a different strategy already recorded this same
+                # (asset, direction) bet inside the dedup window — this open
+                # would be a clone leg. Skip it exactly like the unique-open
+                # duplicate below; log_activity so "why didn't S0xxxx trade?"
+                # is answerable from the activity log (the armed
+                # min_paper_trades gate makes censored opens promotion-relevant).
+                strategy_diag["execution_decision"] = "blocked"
+                strategy_diag["blocked_reason"] = (
+                    f"cross-strategy duplicate signal (clone of {dup_exc.blocking_trade_id} "
+                    f"by {dup_exc.blocking_strategy})"
+                )
+                actions.append(
+                    f"BLOCKED {strat['asset']} - cross-strategy duplicate signal"
+                )
+                log_activity(
+                    "warning", "scanner",
+                    f"Cross-strategy duplicate signal blocked for {strat_id} "
+                    f"{strat['asset']} {direction}: {dup_exc.blocking_strategy} already "
+                    f"recorded {dup_exc.blocking_trade_id} within "
+                    f"{int(dup_exc.window_seconds)}s (PORT-DEDUP-1).",
+                )
+                if diagnostics is not None:
+                    diagnostics[strat_id] = strategy_diag
+                return actions
             except sqlite3.IntegrityError:
                 # M1: the partial UNIQUE index on OPEN trades rejected a second
                 # identical (strategy, asset, direction) open. Either a concurrent
@@ -6069,6 +6161,20 @@ def _kernel_open_paper_trade(strat_id: str, strat: dict, action, *, sizing_equit
             float(alloc_risk), float(leverage), signal_data, execution_type="paper",
             opened_at=opened_at_val,  # late hop-in: current bar time; else the kernel entry-BAR time
         )
+    except CrossStrategyDuplicateSignal as dup_exc:
+        # PORT-DEDUP-1: another strategy already recorded this identical bet
+        # inside the dedup window — skip the clone leg, keep the kernel loop
+        # alive. log_activity (not just log): with min_paper_trades armed,
+        # censored opens are promotion evidence someone will ask about.
+        log.warning("[%s] kernel paper: %s", strat_id, dup_exc)
+        log_activity(
+            "warning", "scanner",
+            f"Cross-strategy duplicate signal blocked for {strat_id} {asset} "
+            f"{direction}: {dup_exc.blocking_strategy} already recorded "
+            f"{dup_exc.blocking_trade_id} within {int(dup_exc.window_seconds)}s "
+            "(PORT-DEDUP-1).",
+        )
+        return None
     except sqlite3.IntegrityError:
         # A position for this strategy/asset/direction is already OPEN (the unique-open
         # partial index). Don't crash the scan loop and drop the cycle — the existing

--- a/forven/settings_apply.py
+++ b/forven/settings_apply.py
@@ -709,6 +709,8 @@ _SETTINGS_SECTION_KNOWN_KEYS: dict[str, frozenset[str]] = {
         "relaxed_trade_filters_enabled", "paper_test_mode_enabled",
         "paper_test_high_activity_enabled", "paper_test_bypass_gates_enabled",
         "paper_test_local_execution_only",
+        # PORT-DEDUP-1: cross-strategy paper clone-signal guard
+        "paper_cross_strategy_dedup_enabled", "paper_cross_strategy_dedup_window_seconds",
     }),
 }
 
@@ -767,6 +769,9 @@ _SETTINGS_SECTION_NUMERIC_BOUNDS: dict[str, dict[str, tuple[float, float]]] = {
         # Whole percent of the member's challenge slice; the mirror caps its
         # own read at 10% (mirror_risk_fraction), the rail matches.
         "propr_mirror_risk_pct": (0.0001, 10.0),
+        # PORT-DEDUP-1: 0 disables the window outright; a day is the sane ceiling
+        # (beyond that it is a concurrency cap, which lives in risk.py, not here).
+        "paper_cross_strategy_dedup_window_seconds": (0.0, 86400.0),
     },
 }
 

--- a/tests/test_cross_strategy_dedup.py
+++ b/tests/test_cross_strategy_dedup.py
@@ -1,0 +1,111 @@
+"""PORT-DEDUP-1: cross-strategy clone signals must not stack paper positions.
+
+The per-strategy unique-open index cannot catch N different strategy ids
+emitting one signal — in the 2026-07-26..08-07 losing streak, 55 of 160 paper
+trades were 2nd-or-later copies of an identical (asset, direction, entry)
+opened seconds apart by different strategies (one BTC short was opened by
+seven). The guard collapses them at the ``_open_trade_db`` choke point.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from forven.db import get_db, kv_set
+
+
+def _open(sid, asset="BTC", direction="long", execution_type="paper", **kw):
+    from forven.scanner import _open_trade_db
+
+    return _open_trade_db(
+        sid, asset, direction, 100.0, 1.0, 0.01, 1.0, {},
+        execution_type=execution_type, **kw,
+    )
+
+
+def test_second_strategy_same_bet_blocked(forven_db):
+    from forven.scanner import CrossStrategyDuplicateSignal
+
+    first = _open("S-A")
+    with pytest.raises(CrossStrategyDuplicateSignal) as excinfo:
+        _open("S-B")
+    assert excinfo.value.blocking_trade_id == first
+    assert excinfo.value.blocking_strategy == "S-A"
+    assert excinfo.value.asset == "BTC"
+
+
+def test_same_strategy_still_hits_unique_open_index(forven_db):
+    """The per-strategy duplicate stays an IntegrityError — the dedup guard
+    must not shadow the existing M1 contract callers rely on."""
+    _open("S-A")
+    with pytest.raises(sqlite3.IntegrityError):
+        _open("S-A")
+
+
+def test_different_direction_and_asset_allowed(forven_db):
+    _open("S-A")
+    assert _open("S-B", direction="short")
+    assert _open("S-C", asset="ETH")
+
+
+def test_closed_clone_inside_window_still_blocks(forven_db):
+    """A clone that already stopped out inside the window is the same doomed
+    signal — ANY status counts, only recency matters."""
+    from forven.scanner import CrossStrategyDuplicateSignal
+
+    tid = _open("S-A")
+    with get_db() as conn:
+        conn.execute("UPDATE trades SET status = 'CLOSED' WHERE id = ?", (tid,))
+    with pytest.raises(CrossStrategyDuplicateSignal):
+        _open("S-B")
+
+
+def test_outside_window_allowed(forven_db):
+    tid = _open("S-A")
+    with get_db() as conn:
+        conn.execute(
+            "UPDATE trades SET created_at = datetime('now', '-2 hours'), "
+            "opened_at = datetime('now', '-2 hours') WHERE id = ?",
+            (tid,),
+        )
+    assert _open("S-B")
+
+
+def test_live_scope_unaffected(forven_db):
+    """Live pools have their own one-net-position-per-asset semantics in
+    can_open — the guard is scoped to 'paper' exactly."""
+    _open("S-A", execution_type="live")
+    assert _open("S-B", execution_type="live")
+
+
+def test_simulation_scope_unaffected(forven_db):
+    _open("S-A", execution_type="simulation")
+    assert _open("S-B", execution_type="simulation")
+
+
+def test_paper_clone_of_live_position_allowed(forven_db):
+    """A live position must not censor paper research on the same asset —
+    the guard compares within the paper book only."""
+    _open("S-A", execution_type="live")
+    assert _open("S-B", execution_type="paper")
+
+
+def test_disabled_via_settings(forven_db):
+    kv_set("forven:settings", {"paper_cross_strategy_dedup_enabled": False})
+    _open("S-A")
+    assert _open("S-B")
+
+
+def test_zero_window_disables(forven_db):
+    kv_set("forven:settings", {"paper_cross_strategy_dedup_window_seconds": 0})
+    _open("S-A")
+    assert _open("S-B")
+
+
+def test_manual_entry_bypass(forven_db):
+    """cross_strategy_dedup=False (the manual paper-control path) skips the
+    guard — a human deliberately duplicating a bet is intent, not a race."""
+    _open("S-A")
+    assert _open("S-B", cross_strategy_dedup=False)

--- a/tests/test_duplicate_registration_guard.py
+++ b/tests/test_duplicate_registration_guard.py
@@ -82,3 +82,37 @@ def test_promotion_gate_blocks_duplicate_into_trading_stage(forven_db, monkeypat
     result = brain.transition_stage(sid2, "paper", reason="test", actor="system")
     assert result.get("to") != "paper"
     assert result.get("reason_code") == "duplicate_trading_strategy"
+
+
+def test_symbol_spelling_variant_refused(forven_db):
+    """SYMBOL-DUP-2: a legacy bare-symbol row ('ETH') and a canonical
+    'ETH/USDT' registration name the same market — exact-string comparison let
+    S06298/S06299 register twice and book identical fills seconds apart."""
+    with get_db() as conn:
+        sid, _, _ = _create(conn, symbol="ETH/USDT", stage="paper")
+        # Simulate a pre-2026-07-02 row minted before symbol normalisation.
+        conn.execute("UPDATE strategies SET symbol = 'ETH' WHERE id = ?", (sid,))
+        with pytest.raises(ValueError, match="duplicate strategy"):
+            _create(conn, symbol="ETH/USDT", stage="paper")
+
+
+def test_symbol_variant_matching_covers_legacy_spellings(forven_db):
+    from forven.db import find_duplicate_trading_strategy
+
+    with get_db() as conn:
+        sid, _, _ = _create(conn, symbol="SOL/USDT", stage="paper")
+        for legacy in ("SOL", "SOL-USDT", "SOLUSDT", "sol"):
+            conn.execute("UPDATE strategies SET symbol = ? WHERE id = ?", (legacy, sid))
+            assert find_duplicate_trading_strategy(
+                conn, type_="donchian_breakout", symbol="SOL/USDT",
+                timeframe="1h", params=PARAMS,
+            ) == sid, f"legacy spelling {legacy!r} escaped the duplicate check"
+
+
+def test_different_quote_is_not_a_duplicate(forven_db):
+    """'ETH/USDC' and 'ETH/USDT' are different markets; only the bare legacy
+    form collapses onto the default USDT quote."""
+    with get_db() as conn:
+        _create(conn, symbol="ETH/USDC", stage="paper")
+        sid2, _, _ = _create(conn, symbol="ETH/USDT", stage="paper")
+        assert sid2

--- a/tests/test_duplicate_registration_guard.py
+++ b/tests/test_duplicate_registration_guard.py
@@ -109,6 +109,43 @@ def test_symbol_variant_matching_covers_legacy_spellings(forven_db):
             ) == sid, f"legacy spelling {legacy!r} escaped the duplicate check"
 
 
+def test_glued_legacy_candidate_matches_canonical_incumbent(forven_db):
+    """SYMBOL-DUP-3, the reverse orientation: the CANDIDATE carries the legacy
+    glued spelling while the incumbent is canonical. The strict normaliser
+    reads 'SOLUSDT' as a bare base ('SOLUSDT/USDT'), so without the glued-quote
+    split the candidate's variant set misses 'SOL/USDT' and transition_stage —
+    which passes the stored symbol through untouched — would promote a legacy
+    glued twin alongside its canonical double."""
+    from forven.db import find_duplicate_trading_strategy
+
+    with get_db() as conn:
+        sid, _, _ = _create(conn, symbol="SOL/USDT", stage="paper")
+        for glued in ("SOLUSDT", "solusdt"):
+            assert find_duplicate_trading_strategy(
+                conn, type_="donchian_breakout", symbol=glued,
+                timeframe="1h", params=PARAMS,
+            ) == sid, f"glued candidate {glued!r} escaped the duplicate check"
+
+
+def test_glued_non_default_quote_candidate_matches_canonical(forven_db):
+    """The glued split must key on the actual trailing quote, not assume USDT:
+    'ETHUSDC' names the USDC market, and 'FDUSD' must out-match its 'USD'
+    suffix."""
+    from forven.db import find_duplicate_trading_strategy
+
+    with get_db() as conn:
+        sid, _, _ = _create(conn, symbol="ETH/USDC", stage="paper")
+        assert find_duplicate_trading_strategy(
+            conn, type_="donchian_breakout", symbol="ETHUSDC",
+            timeframe="1h", params=PARAMS,
+        ) == sid
+        sid2, _, _ = _create(conn, symbol="SOL/FDUSD", stage="paper")
+        assert find_duplicate_trading_strategy(
+            conn, type_="donchian_breakout", symbol="SOLFDUSD",
+            timeframe="1h", params=PARAMS,
+        ) == sid2
+
+
 def test_different_quote_is_not_a_duplicate(forven_db):
     """'ETH/USDC' and 'ETH/USDT' are different markets; only the bare legacy
     form collapses onto the default USDT quote."""

--- a/tests/test_mark_watcher_exit_timing.py
+++ b/tests/test_mark_watcher_exit_timing.py
@@ -179,6 +179,11 @@ def test_watcher_closes_manual_paper_position(forven_db):
 
 
 def test_watcher_skips_paused_live_and_untouched(forven_db):
+    # This test needs two paper SOL positions from different strategies at
+    # once; PORT-DEDUP-1 would collapse the second as a clone signal, which is
+    # not what is under test here — disable the guard for this scenario.
+    from forven.db import kv_set
+    kv_set("forven:settings", {"paper_cross_strategy_dedup_enabled": False})
     mw.invalidate_armed_cache()
     paused = _open_paper_trade(strat_id="S-W5", sd_extra={"manual_pause": True})
     live = _open_paper_trade(strat_id="S-W6", execution_type="live")


### PR DESCRIPTION
## What

Two fixes for the clone-leg problem diagnosed in the 2026-08-07 propr/live deep dive (Forven Development thread): **34% of the losing streak's paper trades were 2nd-or-later copies of an identical (asset, direction, entry) opened seconds apart by different strategy ids — 39% of the loss.**

**Commit 1 — PORT-DEDUP-1 (cross-strategy paper dedup).** `_open_trade_db` (the choke point every open path funnels through) now refuses a paper open when a *different* strategy recorded the same (asset, direction) bet inside a configurable window (default 900s; `paper_cross_strategy_dedup_enabled` / `paper_cross_strategy_dedup_window_seconds`, risk settings section, operator-editable). Scoped to `execution_type == "paper"` exactly: live pools already enforce one-net-position-per-asset in `can_open`; simulation/soak lanes are isolated sandboxes. Window measured on `created_at` (recording time — kernel late hop-ins backdate `opened_at`). Any status inside the window counts. Manual paper-control entries bypass via `cross_strategy_dedup=False` (operator intent is not a race). Blocked opens are recorded via `log_activity` — with `min_paper_trades` armed, censored opens are promotion evidence.

**Commit 2 — SYMBOL-DUP-2 (spelling variants are the same market).** `find_duplicate_trading_strategy` compared symbols by exact string, so a legacy bare-symbol row ('ETH') and canonical 'ETH/USDT' registered AND promoted as twins (S06298/S06299, S06538/S06539 — identical fills to the cent). The check now matches canonical/bare/dashed/glued spellings (bare collapses onto the default USDT quote only; different quotes stay distinct). The two write-back paths that bypass the mint normaliser (`auto_assign_best_symbol_timeframe`, evolution context select) now repair symbols strictly before writing.

## Evidence

- 14 new tests (11 dedup + 3 symbol-variant); each behavior-bearing test verified to FAIL on the unfixed tree.
- Full parallel lane at `9bfc48e1`: **6,332 passed, 6 skipped, 0 failed** (serial sandbox lane running, will confirm in thread).
- Streak evidence: 29 clone groups, one signal fired by 7 strategies at once, redundant legs −$4,119.

## Notes for review

- The dedup guard is check-then-insert (a time window cannot be a UNIQUE constraint); the documented pathology is same-scan-cycle sequential clones, which this fully covers. Cross-process race residue is accepted and documented in the code comment.
- `test_watcher_skips_paused_live_and_untouched` now disables the guard explicitly — it legitimately constructs two same-asset paper positions.
- Not in scope (follow-ups filed): archival of existing registered twins (the gate sweep already archived them), force-close paper-lane bug, propr leg-quantity matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)