### PR TITLE
fix(api): a paper-row force-close must never place an exchange order

### DIFF
--- a/forven/api_domains/trading.py
+++ b/forven/api_domains/trading.py
@@ -22,7 +22,6 @@ from forven.trade_state import (
     is_local_only_paper_trade,
     mark_trade_pending_close_reconcile,
     parse_trade_signal_data,
-    trade_reached_exchange,
 )
 
 log = logging.getLogger("forven.api")

--- a/forven/api_domains/trading.py
+++ b/forven/api_domains/trading.py
@@ -1157,23 +1157,36 @@ def _force_close_exchange_backed_trade(trade_id: str, body) -> dict[str, object]
 
 
 def _force_close_local_paper_trade(trade_id: str, trade: dict, body) -> dict:
-    """Close a local-only paper-lane row at the current mid, entirely
-    off-exchange (PAPER-CLOSE-1). Refuses (no state change) when no mid is
-    available: closing at entry or a stale price would fabricate P&L, and the
-    operator can simply retry."""
+    """Close a local-only paper-lane row at the current mark, entirely
+    off-exchange (PAPER-CLOSE-1). Mirrors close_open_paper_trades_for_strategy,
+    the lifecycle paper-close path: the mark comes from the CONFIGURED
+    market-data source via _fresh_mark_price (which refuses stale or
+    unavailable prices — a Binance-priced paper book must not book exits
+    against Hyperliquid mids), and kernel-managed rows book P&L through the
+    kernel's net cost convention so a gross-P&L close cannot inflate the paper
+    sandbox equity that sizes subsequent trades. No fresh mark → refuse with
+    no state change; the operator can simply retry."""
+    from forven.trade_state import _fresh_mark_price
+
     asset = str(trade.get("asset") or "").strip().upper()
     direction = str(trade.get("direction") or "long").strip().lower()
-    try:
-        from forven.exchange.hyperliquid import get_all_mids  # read-only price fetch
-
-        mark = _coerce_optional_float((get_all_mids(_resolve_exchange_testnet()) or {}).get(asset))
-    except Exception as exc:
-        return {"ok": False, "error": f"no current price for {asset}: {exc}"}
-    if mark is None or mark <= 0:
+    mark = _fresh_mark_price(asset)
+    if mark is None:
         return {
             "ok": False,
-            "error": f"no current price for {asset}; a paper force-close needs a mark to close at",
+            "error": (
+                f"no fresh mark for {asset} from the configured market-data source — "
+                "a paper force-close needs a trustworthy price; retry shortly"
+            ),
         }
+
+    pnl_override, cost_signal_data = None, None
+    try:
+        from forven.api_domains.paper_control import _manual_paper_close_pnl_override
+
+        pnl_override, cost_signal_data = _manual_paper_close_pnl_override(trade, mark)
+    except Exception:
+        pnl_override, cost_signal_data = None, None
 
     close_note = str(body.reason or "").strip() or None
     closed = close_trade_record(
@@ -1183,7 +1196,11 @@ def _force_close_local_paper_trade(trade_id: str, trade: dict, body) -> dict:
         close_reason="manual_force_close",
         close_price_source="paper_mark",
         closed_at=_now(),
-        extra_signal_data={"manual_close_note": close_note},
+        extra_signal_data={
+            "manual_close_note": close_note,
+            **(cost_signal_data or {}),
+        },
+        pnl_override=pnl_override,
     )
     if not closed or not closed.get("updated"):
         return {"ok": False, "error": "Failed to persist force-close"}

--- a/forven/api_domains/trading.py
+++ b/forven/api_domains/trading.py
@@ -22,6 +22,7 @@ from forven.trade_state import (
     is_local_only_paper_trade,
     mark_trade_pending_close_reconcile,
     parse_trade_signal_data,
+    trade_reached_exchange,
 )
 
 log = logging.getLogger("forven.api")
@@ -1156,6 +1157,66 @@ def _force_close_exchange_backed_trade(trade_id: str, body) -> dict[str, object]
     }
 
 
+def _force_close_local_paper_trade(trade_id: str, trade: dict, body) -> dict:
+    """Close a local-only paper-lane row at the current mid, entirely
+    off-exchange (PAPER-CLOSE-1). Refuses (no state change) when no mid is
+    available: closing at entry or a stale price would fabricate P&L, and the
+    operator can simply retry."""
+    asset = str(trade.get("asset") or "").strip().upper()
+    direction = str(trade.get("direction") or "long").strip().lower()
+    try:
+        from forven.exchange.hyperliquid import get_all_mids  # read-only price fetch
+
+        mark = _coerce_optional_float((get_all_mids(_resolve_exchange_testnet()) or {}).get(asset))
+    except Exception as exc:
+        return {"ok": False, "error": f"no current price for {asset}: {exc}"}
+    if mark is None or mark <= 0:
+        return {
+            "ok": False,
+            "error": f"no current price for {asset}; a paper force-close needs a mark to close at",
+        }
+
+    close_note = str(body.reason or "").strip() or None
+    closed = close_trade_record(
+        trade_id,
+        signal_exit_price=mark,
+        exit_price=mark,
+        close_reason="manual_force_close",
+        close_price_source="paper_mark",
+        closed_at=_now(),
+        extra_signal_data={"manual_close_note": close_note},
+    )
+    if not closed or not closed.get("updated"):
+        return {"ok": False, "error": "Failed to persist force-close"}
+    release(trade_id)
+    log_activity(
+        "warning",
+        "api",
+        f"Manual force-close executed for paper trade {trade_id} (local close, no exchange order)",
+        {
+            "trade_id": trade_id,
+            "asset": asset,
+            "direction": direction,
+            "size": float(trade.get("size") or 0.0),
+            "exit_price": closed.get("exit_price"),
+            "reason": close_note or "manual_force_close",
+            "execution_type": str(trade.get("execution_type") or ""),
+        },
+    )
+    return {
+        "ok": True,
+        "trade_id": trade_id,
+        "asset": asset,
+        "direction": direction,
+        "close_side": "sell" if direction == "long" else "buy",
+        "exit_price": round(float(closed["exit_price"]), 8) if closed.get("exit_price") is not None else None,
+        "pnl_pct": round(float(closed["pnl_pct"]), 6) if closed.get("pnl_pct") is not None else None,
+        "pnl_usd": round(float(closed["pnl_usd"]), 4) if closed.get("pnl_usd") is not None else None,
+        "closed_at": closed.get("closed_at"),
+        "source": "paper_local",
+    }
+
+
 def force_close_trade(trade_id: str, body):
     trade_id = trade_id.strip()
     if not trade_id:
@@ -1178,6 +1239,17 @@ def force_close_trade(trade_id: str, body):
         return {"ok": False, "error": "Trade asset is missing"}
     if size <= 0:
         return {"ok": False, "error": "Trade size must be > 0"}
+
+    # PAPER-CLOSE-1: a local-only paper row is a DB record, not a venue
+    # position — its force-close must never reach the exchange. 2026-08-07:
+    # this path sent nine reduce-only close orders to Hyperliquid MAINNET for
+    # paper-lane rows during an operator sweep; every one was rejected only
+    # because the master wallet happened to hold no reducible position. Trades
+    # carrying an exchange correlation id (including paper bot-test fills)
+    # stay on the exchange path below — those DID place venue orders and must
+    # be closed and reconciled there.
+    if is_local_only_paper_trade(trade):
+        return _force_close_local_paper_trade(trade_id, trade, body)
 
     close_side = "sell" if direction == "long" else "buy"
     testnet = _resolve_exchange_testnet()

--- a/tests/test_force_close_paper_lane.py
+++ b/tests/test_force_close_paper_lane.py
@@ -10,6 +10,7 @@ import json
 from types import SimpleNamespace
 
 import forven.exchange.hyperliquid as hl
+import forven.trade_state as ts
 from forven.api_domains.trading import force_close_trade
 from forven.db import get_db
 
@@ -39,7 +40,7 @@ def test_paper_force_close_never_touches_the_exchange(forven_db, monkeypatch):
     with get_db() as conn:
         _insert_open_trade(conn, "t-paper")
     _forbid_exchange_orders(monkeypatch)
-    monkeypatch.setattr(hl, "get_all_mids", lambda testnet=False: {"ETH": 2500.0})
+    monkeypatch.setattr(ts, "_fresh_mark_price", lambda asset: 2500.0)
 
     result = force_close_trade("t-paper", SimpleNamespace(reason="sweep"))
     assert result["ok"] is True
@@ -58,7 +59,7 @@ def test_paper_challenger_force_close_never_touches_the_exchange(forven_db, monk
     with get_db() as conn:
         _insert_open_trade(conn, "t-chal", execution_type="paper_challenger")
     _forbid_exchange_orders(monkeypatch)
-    monkeypatch.setattr(hl, "get_all_mids", lambda testnet=False: {"ETH": 2400.0})
+    monkeypatch.setattr(ts, "_fresh_mark_price", lambda asset: 2400.0)
 
     result = force_close_trade("t-chal", SimpleNamespace(reason=None))
     assert result["ok"] is True
@@ -66,12 +67,12 @@ def test_paper_challenger_force_close_never_touches_the_exchange(forven_db, monk
 
 
 def test_paper_force_close_without_a_mark_refuses_and_stays_open(forven_db, monkeypatch):
-    """No mid available: refuse rather than fabricate an exit price — and still
-    never touch the exchange."""
+    """No fresh mark from the configured market-data source: refuse rather
+    than fabricate an exit price — and still never touch the exchange."""
     with get_db() as conn:
         _insert_open_trade(conn, "t-nomark")
     _forbid_exchange_orders(monkeypatch)
-    monkeypatch.setattr(hl, "get_all_mids", lambda testnet=False: {})
+    monkeypatch.setattr(ts, "_fresh_mark_price", lambda asset: None)
 
     result = force_close_trade("t-nomark", SimpleNamespace(reason="sweep"))
     assert result["ok"] is False
@@ -79,6 +80,33 @@ def test_paper_force_close_without_a_mark_refuses_and_stays_open(forven_db, monk
     with get_db() as conn:
         row = conn.execute("SELECT status FROM trades WHERE id = 't-nomark'").fetchone()
     assert row["status"] == "OPEN"
+
+
+def test_paper_force_close_applies_the_kernel_cost_override(forven_db, monkeypatch):
+    """Kernel-managed rows must book P&L through the kernel's net cost
+    convention (Codex P1 on #115): a gross-P&L close would inflate the paper
+    sandbox equity that sizes subsequent trades. Pin that the hook is wired by
+    asserting its cost metadata reaches the persisted row."""
+    import forven.api_domains.paper_control as pc
+
+    with get_db() as conn:
+        _insert_open_trade(conn, "t-kernel")
+    _forbid_exchange_orders(monkeypatch)
+    monkeypatch.setattr(ts, "_fresh_mark_price", lambda asset: 2500.0)
+    monkeypatch.setattr(
+        pc,
+        "_manual_paper_close_pnl_override",
+        lambda trade, mark: (None, {"kernel_cost_marker": f"wired@{mark}"}),
+    )
+
+    result = force_close_trade("t-kernel", SimpleNamespace(reason="sweep"))
+    assert result["ok"] is True
+
+    with get_db() as conn:
+        row = conn.execute("SELECT signal_data FROM trades WHERE id = 't-kernel'").fetchone()
+    assert "wired@2500.0" in str(row["signal_data"]), (
+        "the kernel P&L override hook must run on the paper force-close path"
+    )
 
 
 def test_paper_row_with_exchange_correlation_keeps_the_exchange_path(forven_db, monkeypatch):

--- a/tests/test_force_close_paper_lane.py
+++ b/tests/test_force_close_paper_lane.py
@@ -1,0 +1,115 @@
+"""PAPER-CLOSE-1 regression: an operator force-close of a local-only paper row
+must close at the current mid WITHOUT touching the exchange. 2026-08-07: the
+shared close path sent nine reduce-only orders to Hyperliquid mainnet for
+paper-lane rows during an operator sweep; only the venue's reduce-only
+rejection (no reducible position on the master wallet) stood between a paper
+cleanup and real exposure."""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import forven.exchange.hyperliquid as hl
+from forven.api_domains.trading import force_close_trade
+from forven.db import get_db
+
+
+def _insert_open_trade(conn, trade_id, execution_type="paper", signal_data="{}"):
+    conn.execute(
+        """
+        INSERT INTO trades
+        (id, strategy, strategy_id, asset, direction, entry_price, signal_entry_price,
+         fill_entry_price, size, risk_pct, leverage, status, execution_type, source,
+         signal_data, opened_at)
+        VALUES (?, 'S-PC1', 'S-PC1', 'ETH', 'long', 2000, 2000,
+                2000, 0.5, 0.01, 1, 'OPEN', ?, 'manual', ?, datetime('now'))
+        """,
+        (trade_id, execution_type, signal_data),
+    )
+
+
+def _forbid_exchange_orders(monkeypatch):
+    def _boom(*a, **k):
+        raise AssertionError("a paper force-close must never place an exchange order")
+
+    monkeypatch.setattr(hl, "close_position", _boom)
+
+
+def test_paper_force_close_never_touches_the_exchange(forven_db, monkeypatch):
+    with get_db() as conn:
+        _insert_open_trade(conn, "t-paper")
+    _forbid_exchange_orders(monkeypatch)
+    monkeypatch.setattr(hl, "get_all_mids", lambda testnet=False: {"ETH": 2500.0})
+
+    result = force_close_trade("t-paper", SimpleNamespace(reason="sweep"))
+    assert result["ok"] is True
+    assert result["source"] == "paper_local"
+    assert result["exit_price"] == 2500.0
+
+    with get_db() as conn:
+        row = conn.execute(
+            "SELECT status, exit_price FROM trades WHERE id = 't-paper'"
+        ).fetchone()
+    assert row["status"] != "OPEN"
+    assert float(row["exit_price"]) == 2500.0
+
+
+def test_paper_challenger_force_close_never_touches_the_exchange(forven_db, monkeypatch):
+    with get_db() as conn:
+        _insert_open_trade(conn, "t-chal", execution_type="paper_challenger")
+    _forbid_exchange_orders(monkeypatch)
+    monkeypatch.setattr(hl, "get_all_mids", lambda testnet=False: {"ETH": 2400.0})
+
+    result = force_close_trade("t-chal", SimpleNamespace(reason=None))
+    assert result["ok"] is True
+    assert result["source"] == "paper_local"
+
+
+def test_paper_force_close_without_a_mark_refuses_and_stays_open(forven_db, monkeypatch):
+    """No mid available: refuse rather than fabricate an exit price — and still
+    never touch the exchange."""
+    with get_db() as conn:
+        _insert_open_trade(conn, "t-nomark")
+    _forbid_exchange_orders(monkeypatch)
+    monkeypatch.setattr(hl, "get_all_mids", lambda testnet=False: {})
+
+    result = force_close_trade("t-nomark", SimpleNamespace(reason="sweep"))
+    assert result["ok"] is False
+
+    with get_db() as conn:
+        row = conn.execute("SELECT status FROM trades WHERE id = 't-nomark'").fetchone()
+    assert row["status"] == "OPEN"
+
+
+def test_paper_row_with_exchange_correlation_keeps_the_exchange_path(forven_db, monkeypatch):
+    """A paper row that DID place a venue order (bot-test fill) still closes via
+    the exchange — its venue position is real and must be reduced there."""
+    calls = []
+    with get_db() as conn:
+        _insert_open_trade(
+            conn, "t-corr", signal_data=json.dumps({"entry_exchange_order_id": "123"})
+        )
+    monkeypatch.setattr(
+        hl,
+        "close_position",
+        lambda *a, **k: calls.append(a)
+        or {"exit_price": 2500.0, "filled_size": 0.5, "close_price": 2500.0},
+    )
+
+    force_close_trade("t-corr", SimpleNamespace(reason="test"))
+    assert calls, "exchange-correlated paper rows must still close via the exchange"
+
+
+def test_live_force_close_still_uses_the_exchange(forven_db, monkeypatch):
+    calls = []
+    with get_db() as conn:
+        _insert_open_trade(conn, "t-live", execution_type="live")
+    monkeypatch.setattr(
+        hl,
+        "close_position",
+        lambda *a, **k: calls.append(a)
+        or {"exit_price": 2500.0, "filled_size": 0.5, "close_price": 2500.0},
+    )
+
+    force_close_trade("t-live", SimpleNamespace(reason="test"))
+    assert calls, "live rows must close via the exchange"


### PR DESCRIPTION
## What

The operator force-close endpoint (`POST /api/trades/{id}/force-close`) routed every OPEN trade through the shared exchange close path regardless of execution lane. On 2026-08-07 a paper-book sweep sent **nine reduce-only close orders to Hyperliquid mainnet for local-only paper rows**; every one was rejected solely because the master wallet held no reducible position. The reduce-only flag was the only guard between a paper cleanup and real exposure.

## Fix

- Local-only paper rows (Lead-1's `is_local_only_paper_trade`: `paper`/`paper_challenger` with no exchange correlation id) now close at the current mid entirely off-exchange (`get_all_mids` is a read-only data call).
- No mid available → refuse with no state change, rather than fabricating an exit price; the operator retries.
- Paper rows that genuinely placed a venue order (bot-test fills carrying `entry_exchange_order_id`) and live rows keep the exchange path — their venue positions are real and must be reduced and reconciled there.

## Evidence

Five new tests in `tests/test_force_close_paper_lane.py`. The two exchange-isolation tests monkeypatch `close_position` to raise `AssertionError` (assert-never-called), and both are proven to fail on the unfixed tree — reproducing the incident — and pass with the fix. The correlation-id and live-row tests pin the exchange path where it is still correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)